### PR TITLE
Macでライブ変換の遅延を有効にする

### DIFF
--- a/src/mac/mozc_imk_input_controller.h
+++ b/src/mac/mozc_imk_input_controller.h
@@ -130,7 +130,6 @@
 @property(readwrite, retain) id imkClientForTest;
 @property(readwrite, assign) bool useLiveConversionForTest;
 @property(readwrite, assign) bool allowCandidateWindowForLiveConversionForTest;
-@property(readonly, assign) bool hasDelayedSessionCommandForTest;
 
 /** Sets the RendererReceiver used by all instances of the controller.
  * the RendererReceiver is a singleton object used as a proxy to receive messages from

--- a/src/mac/mozc_imk_input_controller.h
+++ b/src/mac/mozc_imk_input_controller.h
@@ -104,6 +104,11 @@
   /** True after explicit conversion request so candidate UI may be shown. */
   bool allowCandidateWindowForLiveConversion_;
 
+  /** Latest delayed callback requested by Output::Callback. */
+  std::unique_ptr<mozc::commands::SessionCommand> delayedSessionCommand_;
+  __weak id delayedSessionCommandClient_;
+  NSTimer *delayedSessionCommandTimer_;
+
   /** |mozcClient_| manages connection to the mozc server. */
   std::unique_ptr<mozc::client::ClientInterface> mozcClient_;
 
@@ -125,6 +130,7 @@
 @property(readwrite, retain) id imkClientForTest;
 @property(readwrite, assign) bool useLiveConversionForTest;
 @property(readwrite, assign) bool allowCandidateWindowForLiveConversionForTest;
+@property(readonly, assign) bool hasDelayedSessionCommandForTest;
 
 /** Sets the RendererReceiver used by all instances of the controller.
  * the RendererReceiver is a singleton object used as a proxy to receive messages from

--- a/src/mac/mozc_imk_input_controller.mm
+++ b/src/mac/mozc_imk_input_controller.mm
@@ -79,7 +79,6 @@ using SetOfString = std::set<std::string, std::less<>>;
 @interface MozcImkInputController ()
 - (void)cancelDelayedSessionCommand;
 - (void)delayedInvokeSessionCommandFromTimer:(NSTimer *)timer;
-- (void)delayedInvokeSessionCommand;
 - (void)dispatchSessionCommand:(const SessionCommand *)command client:(id)sender;
 @end
 
@@ -245,10 +244,6 @@ int32_t GetRendererAnchorPosition(const Output &output) {
 @synthesize useLiveConversionForTest = useLiveConversion_;
 @synthesize allowCandidateWindowForLiveConversionForTest =
     allowCandidateWindowForLiveConversion_;
-- (bool)hasDelayedSessionCommandForTest {
-  return delayedSessionCommand_ != nullptr;
-}
-
 - (mozc::client::ClientInterface *)mozcClient {
   return mozcClient_.get();
 }
@@ -290,9 +285,6 @@ int32_t GetRendererAnchorPosition(const Output &output) {
   hasLiveConversionAnchorLeft_ = false;
   useLiveConversion_ = false;
   allowCandidateWindowForLiveConversion_ = false;
-  delayedSessionCommand_ = nullptr;
-  delayedSessionCommandClient_ = nil;
-  delayedSessionCommandTimer_ = nil;
   mozcRenderer_ = mozc::renderer::RendererClient::Create();
   mozcClient_ = mozc::client::ClientFactory::NewClient();
   lastKeyDownTime_ = 0;
@@ -725,10 +717,6 @@ int32_t GetRendererAnchorPosition(const Output &output) {
   if (timer != delayedSessionCommandTimer_) {
     return;
   }
-  [self delayedInvokeSessionCommand];
-}
-
-- (void)delayedInvokeSessionCommand {
   if (!delayedSessionCommand_) {
     return;
   }

--- a/src/mac/mozc_imk_input_controller.mm
+++ b/src/mac/mozc_imk_input_controller.mm
@@ -76,6 +76,13 @@ using mozc::config::Config;
 // less<> is necessary to compare between std::string and absl::string_view.
 using SetOfString = std::set<std::string, std::less<>>;
 
+@interface MozcImkInputController ()
+- (void)cancelDelayedSessionCommand;
+- (void)delayedInvokeSessionCommandFromTimer:(NSTimer *)timer;
+- (void)delayedInvokeSessionCommand;
+- (void)dispatchSessionCommand:(const SessionCommand *)command client:(id)sender;
+@end
+
 namespace {
 // Global object used as a singleton used as a proxy to receive messages from
 // the renderer process.
@@ -238,6 +245,10 @@ int32_t GetRendererAnchorPosition(const Output &output) {
 @synthesize useLiveConversionForTest = useLiveConversion_;
 @synthesize allowCandidateWindowForLiveConversionForTest =
     allowCandidateWindowForLiveConversion_;
+- (bool)hasDelayedSessionCommandForTest {
+  return delayedSessionCommand_ != nullptr;
+}
+
 - (mozc::client::ClientInterface *)mozcClient {
   return mozcClient_.get();
 }
@@ -279,6 +290,9 @@ int32_t GetRendererAnchorPosition(const Output &output) {
   hasLiveConversionAnchorLeft_ = false;
   useLiveConversion_ = false;
   allowCandidateWindowForLiveConversion_ = false;
+  delayedSessionCommand_ = nullptr;
+  delayedSessionCommandClient_ = nil;
+  delayedSessionCommandTimer_ = nil;
   mozcRenderer_ = mozc::renderer::RendererClient::Create();
   mozcClient_ = mozc::client::ClientFactory::NewClient();
   lastKeyDownTime_ = 0;
@@ -309,6 +323,7 @@ int32_t GetRendererAnchorPosition(const Output &output) {
 }
 
 - (void)dealloc {
+  [self cancelDelayedSessionCommand];
   keyCodeMap_ = nil;
   originalString_ = nil;
   composedString_ = nil;
@@ -364,6 +379,8 @@ int32_t GetRendererAnchorPosition(const Output &output) {
   if (imkClientForTest_) {
     return;
   }
+
+  [self cancelDelayedSessionCommand];
 
   RendererCommand clearCommand;
   clearCommand.set_type(RendererCommand::UPDATE);
@@ -677,16 +694,60 @@ int32_t GetRendererAnchorPosition(const Output &output) {
 
   // Handle callbacks.
   if (output->has_callback() && output->callback().has_session_command()) {
-    const SessionCommand &callback_command = output->callback().session_command();
-    if (callback_command.type() == SessionCommand::CONVERT_REVERSE) {
-      [self invokeReconvert:&callback_command client:sender];
-    } else if (callback_command.type() == SessionCommand::UNDO) {
-      [self invokeUndo:sender];
+    const Output::Callback &callback = output->callback();
+    const SessionCommand &callback_command = callback.session_command();
+    if (callback.has_delay_millisec() && callback.delay_millisec() > 0) {
+      [self cancelDelayedSessionCommand];
+      delayedSessionCommand_ = std::make_unique<SessionCommand>(callback_command);
+      delayedSessionCommandClient_ = sender;
+      const NSTimeInterval delay =
+          static_cast<NSTimeInterval>(callback.delay_millisec()) / 1000.0;
+      delayedSessionCommandTimer_ =
+          [NSTimer scheduledTimerWithTimeInterval:delay
+                                           target:self
+                                         selector:@selector(delayedInvokeSessionCommandFromTimer:)
+                                         userInfo:nil
+                                          repeats:NO];
     } else {
-      Output output_for_callback;
-      if (mozcClient_->SendCommand(callback_command, &output_for_callback)) {
-        [self processOutput:&output_for_callback client:sender];
-      }
+      [self dispatchSessionCommand:&callback_command client:sender];
+    }
+  }
+}
+
+- (void)cancelDelayedSessionCommand {
+  [delayedSessionCommandTimer_ invalidate];
+  delayedSessionCommandTimer_ = nil;
+  delayedSessionCommand_.reset();
+  delayedSessionCommandClient_ = nil;
+}
+
+- (void)delayedInvokeSessionCommandFromTimer:(NSTimer *)timer {
+  if (timer != delayedSessionCommandTimer_) {
+    return;
+  }
+  [self delayedInvokeSessionCommand];
+}
+
+- (void)delayedInvokeSessionCommand {
+  if (!delayedSessionCommand_) {
+    return;
+  }
+
+  SessionCommand command = *delayedSessionCommand_;
+  id sender = delayedSessionCommandClient_;
+  [self cancelDelayedSessionCommand];
+  [self dispatchSessionCommand:&command client:sender];
+}
+
+- (void)dispatchSessionCommand:(const SessionCommand *)command client:(id)sender {
+  if (command->type() == SessionCommand::CONVERT_REVERSE) {
+    [self invokeReconvert:command client:sender];
+  } else if (command->type() == SessionCommand::UNDO) {
+    [self invokeUndo:sender];
+  } else {
+    Output output_for_callback;
+    if (mozcClient_->SendCommand(*command, &output_for_callback)) {
+      [self processOutput:&output_for_callback client:sender];
     }
   }
 }


### PR DESCRIPTION
## Summary
macOS で live conversion の開始を遅延させる変更です。

## What
- IMK input controller に delayed session command を追加
- live conversion 中の状態を保持し、候補表示タイミングを制御

## Why
- Macでは「ライブ変換の遅延」が有効ではなかった。

## Test
- macOS 26.3.1 で live conversion の開始タイミングを確認
- 候補ウィンドウが必要なタイミングでのみ表示されることを確認