### PR TITLE
Fix Zenz feedback priority against user history

### DIFF
--- a/src/rewriter/rewriter.cc
+++ b/src/rewriter/rewriter.cc
@@ -168,9 +168,9 @@ Rewriter::Rewriter(const engine::Modules& modules) {
 
   if (absl::GetFlag(FLAGS_use_history_rewriter)) {
     AddRewriter(std::make_unique<UserBoundaryHistoryRewriter>());
+    AddRewriter(std::make_unique<ZenzFeedbackCandidateRewriter>());
     AddRewriter(
         std::make_unique<UserSegmentHistoryRewriter>(pos_matcher, pos_group));
-    AddRewriter(std::make_unique<ZenzFeedbackCandidateRewriter>());
   }
 
 #ifdef MOZC_DATE_REWRITER

--- a/src/rewriter/user_segment_history_rewriter.cc
+++ b/src/rewriter/user_segment_history_rewriter.cc
@@ -420,6 +420,32 @@ size_t LongestCommittedPrefixSuffixSize(absl::string_view committed_value,
 std::optional<UserSegmentHistoryRewriter::PendingRevert>
     UserSegmentHistoryRewriter::pending_revert_;
 
+void UpdateBestCandidateAfterUserSegmentHistoryRewrite(Segment* segment) {
+  DCHECK(segment);
+  if (segment->candidates_size() == 0) {
+    return;
+  }
+
+  // UserSegmentHistoryRewriter physically moves the learned candidate to
+  // candidate(0).  The previous default candidate may still have
+  // BEST_CANDIDATE because Rewrite() marks the old candidate(0) before
+  // reranking.
+  //
+  // Some output paths consult BEST_CANDIDATE rather than blindly using
+  // candidate(0), so keeping the stale marker makes the UI/commit path show
+  // the old default value even after SortCandidates() has promoted the learned
+  // value.
+  for (size_t i = 0; i < segment->candidates_size(); ++i) {
+    segment->mutable_candidate(i)->attributes &=
+        ~converter::Attribute::BEST_CANDIDATE;
+  }
+
+  segment->mutable_candidate(0)->attributes |=
+      converter::Attribute::BEST_CANDIDATE;
+  segment->mutable_candidate(0)->attributes |=
+      converter::Attribute::USER_SEGMENT_HISTORY_REWRITER;
+}
+
 bool UserSegmentHistoryRewriter::SortCandidates(
     absl::Span<const ScoreCandidate> sorted_scores, Segment* segment) const {
   const uint32_t top_score = sorted_scores[0].score;
@@ -1061,9 +1087,16 @@ bool UserSegmentHistoryRewriter::Rewrite(const ConversionRequest& request,
 
     std::stable_sort(scores.begin(), scores.end(),
                      std::greater<ScoreCandidate>());
-    modified |= SortCandidates(scores, segment);
-    if (!(segment->candidate(0).attributes &
-          converter::Attribute::BEST_CANDIDATE)) {
+
+    const std::string old_top_value = segment->candidate(0).value;
+    const bool sorted = SortCandidates(scores, segment);
+    modified |= sorted;
+
+    if (sorted && segment->candidate(0).value != old_top_value) {
+      UpdateBestCandidateAfterUserSegmentHistoryRewrite(segment);
+    } else if (sorted &&
+               !(segment->candidate(0).attributes &
+                 converter::Attribute::BEST_CANDIDATE)) {
       segment->mutable_candidate(0)->attributes |=
           converter::Attribute::USER_SEGMENT_HISTORY_REWRITER;
     }

--- a/src/session/session.cc
+++ b/src/session/session.cc
@@ -3344,156 +3344,30 @@ void Session::ClearZenzLiveCorrectionState() {
 
 bool Session::MaybeApplyZenzFeedbackLiveCorrection(
     commands::Command* command) {
-  const config::Config& config = context_->GetConfig();
+  (void)command;
 
-  if (!UseZenzFeedbackLearning(config)) {
-    return false;
-  }
-
-  if (!config.use_zenz_live_correction()) {
-    return false;
-  }
-
-  if (!config.use_live_conversion()) {
-    return false;
-  }
-
-  if (!live_conversion_active_) {
-    return false;
-  }
-
-  if (context_->state() != ImeContext::CONVERSION) {
-    return false;
-  }
-
-  if (context_->composer().GetInputFieldType() == commands::Context::PASSWORD) {
-    return false;
-  }
-
-  if (live_conversion_key_.empty() || live_conversion_value_.empty()) {
-    return false;
-  }
-
-  const ZenzTextPrivacyDecision key_privacy =
-      EvaluateZenzLiveKeyPrivacy(live_conversion_key_);
-  if (!key_privacy.allow) {
-    ZenzDebugOutput(absl::StrCat(
-        "[zenz-feedback] fast path skip key_privacy reason=",
-        key_privacy.reason,
-        " ",
-        ZenzRedactedTextStats("key", live_conversion_key_)));
-    return false;
-  }
-
-  const ZenzTextPrivacyDecision mozc_value_privacy =
-      EvaluateZenzLiveValuePrivacy(live_conversion_value_);
-  if (!mozc_value_privacy.allow) {
-    ZenzDebugOutput(absl::StrCat(
-        "[zenz-feedback] fast path skip mozc_value_privacy reason=",
-        mozc_value_privacy.reason,
-        " ",
-        ZenzRedactedTextStats("value", live_conversion_value_)));
-    return false;
-  }
-
-  const uint32_t min_key_len = GetZenzLiveCorrectionMinKeyLength(config);
-  if (Util::CharsLen(live_conversion_key_) < min_key_len) {
-    return false;
-  }
-
-  const uint32_t left_context_len =
-      GetZenzLiveCorrectionLeftContextLength(config);
-
-  const std::string raw_left_context =
-      ExtractZenzLeftContext(left_context_len);
-  const ZenzContextSanitizationResult context_result =
-      zenz_context_sanitizer_.SanitizeForZenz(
-          raw_left_context, left_context_len);
-
-  const std::string left_context_for_validation =
-      context_result.allowed_for_prompt
-          ? context_result.sanitized_context
-          : std::string();
-
-  const std::string context_class =
-      context_result.context_class.empty()
-          ? std::string("empty")
-          : context_result.context_class;
-
-  const std::vector<ZenzFeedbackCandidate> feedback_candidates =
-      zenz_feedback_store_.GetAcceptedCandidates(
-          live_conversion_key_, context_class);
-
-  if (feedback_candidates.empty()) {
-    return false;
-  }
-
-  for (const ZenzFeedbackCandidate& feedback_candidate :
-       feedback_candidates) {
-    const std::string& feedback_value = feedback_candidate.value;
-
-    const ZenzTextPrivacyDecision feedback_value_privacy =
-        EvaluateZenzLiveValuePrivacy(feedback_value);
-    if (!feedback_value_privacy.allow) {
-      ZenzDebugOutput(absl::StrCat(
-          "[zenz-feedback] fast path candidate rejected reason=value_privacy_",
-          feedback_value_privacy.reason,
-          " ",
-          ZenzRedactedTextStats("key", live_conversion_key_),
-          " ",
-          ZenzRedactedTextStats("value", feedback_value),
-          " context_class=", context_class,
-          " accepted_count=", feedback_candidate.accepted_count,
-          " rejected_count=", feedback_candidate.rejected_count));
-      continue;
-    }
-
-    ZenzValidationInput validation_input;
-    validation_input.key = live_conversion_key_;
-    validation_input.mozc_value = live_conversion_value_;
-    validation_input.zenz_value = feedback_value;
-    validation_input.left_context = left_context_for_validation;
-    validation_input.min_key_length = min_key_len;
-    validation_input.allow_synthetic_candidate =
-        config.use_zenz_synthetic_candidate();
-
-    const ZenzValidationResult validation =
-        zenz_output_validator_.Validate(validation_input);
-
-    if (!validation.accept) {
-      ZenzDebugOutput(absl::StrCat(
-          "[zenz-feedback] fast path candidate rejected reason=",
-          validation.reason,
-          " ", ZenzRedactedTextStats("key", live_conversion_key_),
-          " ", ZenzRedactedTextStats("value", feedback_value),
-          " context_class=", context_class,
-          " accepted_count=", feedback_candidate.accepted_count,
-          " rejected_count=", feedback_candidate.rejected_count));
-      continue;
-    }
-
-    ++zenz_live_generation_;
-    pending_zenz_live_ = PendingZenzLiveCorrection();
-
-    zenz_live_visible_generation_ = zenz_live_generation_;
-    zenz_live_key_ = live_conversion_key_;
-    zenz_live_value_ = feedback_value;
-    zenz_live_mozc_value_ = live_conversion_value_;
-    zenz_live_context_class_ = context_class;
-    zenz_live_left_context_ = left_context_for_validation;
-
-    ZenzDebugOutput(absl::StrCat(
-        "[zenz-feedback] fast path applied ",
-        ZenzRedactedTextStats("key", zenz_live_key_),
-        " ", ZenzRedactedTextStats("value", zenz_live_value_),
-        " ", ZenzRedactedTextStats("mozc_value", zenz_live_mozc_value_),
-        " context_class=", zenz_live_context_class_,
-        " accepted_count=", feedback_candidate.accepted_count,
-        " rejected_count=", feedback_candidate.rejected_count));
-
-    return OutputZenzLiveCorrection(feedback_value, command);
-  }
-
+  // Do not replay accepted Zenz feedback as a session-level live correction.
+  //
+  // Zenz feedback is already applied in the converter rewriter chain by
+  // ZenzFeedbackCandidateRewriter.  The rewriter order is:
+  //
+  //   ZenzFeedbackCandidateRewriter
+  //   UserSegmentHistoryRewriter
+  //
+  // This lets accepted Zenz feedback participate in candidate ranking while
+  // still allowing explicit user segment history to decide the final order.
+  //
+  // Keeping this session-level fast path would make Zenz feedback always win
+  // after the visible Mozc live-conversion result has already been generated.
+  // That breaks the "last learned result wins" rule.
+  //
+  // Example:
+  //   Existing Zenz feedback: たなべ -> 田辺
+  //   Later user selection:   たなべ -> 田邊
+  //
+  // UserSegmentHistoryRewriter correctly promotes 田邊, but this fast path
+  // would replay the stale Zenz feedback 田辺 afterwards and record it as
+  // accepted again.
   return false;
 }
 

--- a/src/session/session_test.cc
+++ b/src/session/session_test.cc
@@ -989,7 +989,7 @@ TEST_F(SessionTest, PendingZenzFeedbackStoresContextClassOnly) {
 #if defined(_WIN32)
 
 TEST_F(SessionTest,
-       ZenzFeedbackFastPathAppliesAcceptedCandidateAsLiveCorrection) {
+       ZenzFeedbackFastPathDoesNotOverrideLiveConversionResult) {
   MockEngine engine;
   std::shared_ptr<MockConverter> converter = CreateEngineConverterMock(&engine);
 
@@ -1013,21 +1013,16 @@ TEST_F(SessionTest,
   session_peer.live_conversion_value_() = "彼は点滴です";
 
   commands::Command command;
-  EXPECT_TRUE(session_peer.MaybeApplyZenzFeedbackLiveCorrection(&command));
+  EXPECT_FALSE(session_peer.MaybeApplyZenzFeedbackLiveCorrection(&command));
 
-  EXPECT_TRUE(command.output().live_conversion());
-  EXPECT_FALSE(command.output().live_conversion_pending());
-  EXPECT_FALSE(command.output().zenz_live_correction_pending());
-  EXPECT_TRUE(command.output().zenz_live_correction_applied());
+  EXPECT_FALSE(command.output().zenz_live_correction_applied());
   EXPECT_FALSE(command.output().has_callback());
-  EXPECT_SINGLE_SEGMENT_AND_KEY("彼は天敵です",
-                                "かれはてんてきです",
-                                command);
+  EXPECT_FALSE(command.output().has_preedit());
 
-  EXPECT_EQ(session_peer.zenz_live_key_(), "かれはてんてきです");
-  EXPECT_EQ(session_peer.zenz_live_value_(), "彼は天敵です");
-  EXPECT_EQ(session_peer.zenz_live_mozc_value_(), "彼は点滴です");
-  EXPECT_EQ(session_peer.zenz_live_context_class_(), "empty");
+  EXPECT_TRUE(session_peer.zenz_live_key_().empty());
+  EXPECT_TRUE(session_peer.zenz_live_value_().empty());
+  EXPECT_TRUE(session_peer.zenz_live_mozc_value_().empty());
+  EXPECT_TRUE(session_peer.zenz_live_context_class_().empty());
 }
 
 TEST_F(SessionTest,


### PR DESCRIPTION
## Summary

Fix priority handling between Zenz feedback learning and Mozc user segment history.

Previously, accepted Zenz feedback could be replayed as a session-level live correction after the normal live-conversion result had already been produced. This allowed stale Zenz feedback to override a newer explicit user selection.

This change:
- Applies `ZenzFeedbackCandidateRewriter` before `UserSegmentHistoryRewriter`
- Lets `UserSegmentHistoryRewriter` make the final candidate ranking decision
- Keeps `BEST_CANDIDATE` in sync when `UserSegmentHistoryRewriter` promotes a candidate to the top
- Disables the session-level Zenz feedback fast path that could override the ranked Mozc result after output generation

## Validation

- Build passed
- Verified that if Zenz feedback has `たなべ -> 田辺`, selecting `田邊` later makes `田邊` win on subsequent conversion
- Verified that explicitly accepting a visible Zenz correction still learns that result
- Verified that selecting another candidate later can override the previous learned result