### PR TITLE
Fix/zenz localhost transport hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ Windows 向けリリースバイナリについては、Mozc core runtime execut
 
 Zenz helper process は、同梱された `llama-server.exe` と localhost endpoint のみで通信します。この local HTTP endpoint は推論処理を分離するための内部的なプロセス境界であり、外部ネットワークアクセスを目的としたものではありません。
 
+Zenz の localhost 通信は、固定 endpoint に依存しないようにし、内部 request も誤接続を避けるための保護を加えています。
+
 Zenz feedback learning は、読み、候補、粗い文脈クラス、採用/却下回数、理由 marker などのローカル学習情報だけを保存します。生の左文脈は保存しません。feedback に使う文脈は、`empty`、`japanese_only`、`japanese_with_punctuation`、`mixed_japanese_ascii`、`sensitive_like` などの非可逆な context class に落とします。
 
 さらに、リリース時には Mozc core runtime binaries にテレメトリ、アップデータ、クラッシュアップロード、使用統計関連の危険な marker が含まれないことを確認します。
@@ -173,7 +175,7 @@ Windows 版では、追加のオフライン防御層として、インストー
 
 ライブ変換と Zenz ライブ補正の両方を有効にすると、まず通常の Mozc ライブ変換結果を表示し、その後でローカルの Zenz runtime に非同期で補正を依頼します。
 
-Zenz request は `mozc_server` から Windows named pipe 経由で `mozc_zenz_scorer.exe` に送られます。scorer は同梱された `llama-server.exe` の localhost endpoint を呼び出し、ローカル推論を行います。
+Zenz request は `mozc_server` から Windows named pipe 経由で `mozc_zenz_scorer.exe` に送られます。scorer は同梱された `llama-server.exe` の localhost endpoint を呼び出し、ローカル推論を行います。この localhost 通信は固定 endpoint に依存しないようにし、内部 request も誤接続を避けるための保護を加えています。
 
 Zenz 補正は設定可能なデバウンス時間の後に実行されます。デフォルトは 1000 ms です。Zenz 結果が返る前に入力内容が変わった場合、古い結果は generation / key の検査により破棄されます。
 
@@ -365,6 +367,10 @@ The Zenz helper process communicates with the bundled `llama-server.exe` only
 through a localhost endpoint. This local HTTP endpoint is used as an internal
 process boundary for inference and is not intended for external network access.
 
+The Zenz localhost transport is hardened so that it does not rely on a fixed
+endpoint, and internal requests include protection against accidental or stale
+local endpoint mismatches.
+
 Zenz feedback learning stores only local learning records such as reading,
 candidate, coarse context class, accepted/rejected counts, and reason markers.
 Raw left context is not stored. Context used for feedback is reduced to a
@@ -512,7 +518,9 @@ Zenz runtime to refine the visible preedit.
 
 The Zenz request is sent from `mozc_server` to `mozc_zenz_scorer.exe` through a
 Windows named pipe. The scorer then calls the bundled `llama-server.exe` on a
-localhost endpoint for local inference.
+localhost endpoint for local inference. The localhost transport is hardened so
+that it does not rely on a fixed endpoint, and internal requests include
+protection against accidental or stale local endpoint mismatches.
 
 Zenz correction is delayed by a configurable debounce interval. The default
 delay is 1000 ms. If the current composition changes before the Zenz result

--- a/docs/security/offline_guarantee.md
+++ b/docs/security/offline_guarantee.md
@@ -31,8 +31,26 @@ This fork uses local resources for normal IME operation:
 - local user dictionary
 - local user history
 - local settings
+- bundled local Zenz scorer, runtime, and model when Zenz support is included
 
 Input text is processed locally.
+
+For Zenz-bundled builds, local Zenz correction is performed through
+`mozc_zenz_scorer.exe`, the bundled `llama-server.exe`, and the bundled local
+GGUF model. The scorer-to-runtime transport is localhost-only and must be bound
+to `127.0.0.1`.
+
+The Zenz localhost transport must not rely on a fixed public-facing endpoint.
+The scorer chooses a random high port for `llama-server.exe` and protects
+completion requests with a random API key. Generated port and API key values
+must not be written to DebugView logs.
+
+The API key is a defense-in-depth measure for stale, accidental, or mismatched
+localhost endpoints. It is passed to `llama-server.exe` through the command line
+because that is the interface exposed by llama.cpp server. Therefore it should
+not be treated as a strong secret against same-user local malware. The primary
+boundary is that the server is bound to `127.0.0.1`, uses a random high port, and
+is launched and managed by `mozc_zenz_scorer.exe`.
 
 ## Usage statistics and crash reports
 
@@ -53,8 +71,8 @@ python tools\check_no_network_symbols.py
 
 ## Binary import checks
 
-Windows release binaries should be checked so that Mozc runtime executables do
-not import common networking DLLs such as:
+Windows release binaries should be checked so that Mozc core runtime executables
+do not import common networking DLLs such as:
 
 - ws2_32.dll
 - winhttp.dll
@@ -62,6 +80,12 @@ not import common networking DLLs such as:
 - urlmon.dll
 - webio.dll
 - dnsapi.dll
+
+`mozc_zenz_scorer.exe` is a narrow local-only exception. It may import
+`winhttp.dll` only to call the bundled `llama-server.exe` through a
+`127.0.0.1` localhost endpoint. It must not use WinHTTP for external network
+access, must not use a release-build environment override for the runtime or
+model path, and must not expose the local inference endpoint externally.
 
 The check is implemented by:
 
@@ -115,8 +139,27 @@ source, import, and string audits.
 ## Runtime checks
 
 Before publishing a release, install the MSI in a clean Windows VM and confirm
-that no Mozc runtime process initiates outbound communication during normal IME
-operation.
+that no Mozc core runtime process initiates outbound communication during normal
+IME operation.
+
+For Zenz-bundled builds, also confirm that `llama-server.exe` listens only on
+`127.0.0.1`, uses a non-fixed random high port, and does not expose an external
+interface.
+
+```powershell
+Get-Process llama-server -ErrorAction SilentlyContinue |
+  ForEach-Object {
+    Get-NetTCPConnection -OwningProcess $_.Id -State Listen |
+      Select-Object LocalAddress, LocalPort, OwningProcess
+  }
+```
+
+Expected result:
+
+```text
+LocalAddress: 127.0.0.1
+LocalPort: not 18080
+```
 
 Recommended tools:
 

--- a/docs/security/release_checklist.md
+++ b/docs/security/release_checklist.md
@@ -49,7 +49,7 @@ bazelisk --output_user_root=C:/bzl test `
 
 ## Build artifact checks
 
-- [ ] Bazel output binaries do not import prohibited networking DLLs
+- [ ] Bazel output Mozc core runtime binaries do not import prohibited networking DLLs
 
 ```powershell
 cd C:\Users\Makoto\dev\mozc
@@ -78,13 +78,13 @@ New-Item -ItemType Directory -Force $extractDir | Out-Null
 msiexec.exe /a "src\bazel-bin\win32\installer\Mozc64.msi" /qn TARGETDIR="$PWD\$extractDir"
 ```
 
-- [ ] MSI-extracted runtime binaries do not import prohibited networking DLLs
+- [ ] MSI-extracted Mozc core runtime binaries do not import prohibited networking DLLs
 
 ```powershell
 python tools\check_no_network_imports.py --root msi_extract
 ```
 
-- [ ] MSI-extracted runtime binaries do not contain hard-deny telemetry / updater / crash-upload / usage-statistics markers
+- [ ] MSI-extracted Mozc core runtime binaries do not contain hard-deny telemetry / updater / crash-upload / usage-statistics markers
 - [ ] Report-only URL-like markers are reviewed
 
 ```powershell
@@ -96,7 +96,7 @@ python tools\check_no_network_strings.py --root msi_extract
 Use the actual install directory. On many Windows systems, Mozc is installed
 under `C:\Program Files (x86)\Mozc`.
 
-- [ ] Installed runtime binaries do not import prohibited networking DLLs
+- [ ] Installed Mozc core runtime binaries do not import prohibited networking DLLs
 
 ```powershell
 cd C:\Users\Makoto\dev\mozc
@@ -110,7 +110,7 @@ python tools\check_no_network_imports.py `
   "C:\Program Files (x86)\Mozc\mozc_tip64.dll"
 ```
 
-- [ ] Installed runtime binaries do not contain hard-deny telemetry / updater / crash-upload / usage-statistics markers
+- [ ] Installed Mozc core runtime binaries do not contain hard-deny telemetry / updater / crash-upload / usage-statistics markers
 - [ ] Report-only URL-like markers are reviewed
 
 ```powershell
@@ -123,6 +123,98 @@ python tools\check_no_network_strings.py `
   "C:\Program Files (x86)\Mozc\mozc_broker.exe" `
   "C:\Program Files (x86)\Mozc\mozc_cache_service.exe" `
   "C:\Program Files (x86)\Mozc\mozc_tip64.dll"
+```
+
+## Zenz localhost transport checks
+
+For Zenz-bundled Windows builds:
+
+- [ ] `mozc_zenz_scorer.exe` release build does not contain release-disabled runtime/model/port override markers
+
+```powershell
+$Scorer = "C:\Users\Makoto\dev\mozc\src\bazel-bin\zenz_scorer\mozc_zenz_scorer.exe"
+
+function Test-BinaryString2 {
+  param(
+    [string]$Path,
+    [string]$Needle
+  )
+
+  $bytes = [System.IO.File]::ReadAllBytes($Path)
+  $utf8 = [System.Text.Encoding]::UTF8.GetString($bytes)
+  $utf16 = [System.Text.Encoding]::Unicode.GetString($bytes)
+
+  [pscustomobject]@{
+    Needle = $Needle
+    FoundUtf8 = $utf8.Contains($Needle)
+    FoundUtf16 = $utf16.Contains($Needle)
+    FoundAny = ($utf8.Contains($Needle) -or $utf16.Contains($Needle))
+  }
+}
+
+Test-BinaryString2 $Scorer "MOZC_ZENZ_LLAMA_SERVER"
+Test-BinaryString2 $Scorer "MOZC_ZENZ_MODEL"
+Test-BinaryString2 $Scorer "MOZC_ZENZ_PORT"
+Test-BinaryString2 $Scorer "MOZC_ZENZ_CTX"
+Test-BinaryString2 $Scorer "MOZC_ZENZ_THREADS"
+Test-BinaryString2 $Scorer "MOZC_ZENZ_N_PREDICT"
+```
+
+Expected result:
+
+```text
+MOZC_ZENZ_LLAMA_SERVER  FoundAny = False
+MOZC_ZENZ_MODEL         FoundAny = False
+MOZC_ZENZ_PORT          FoundAny = False
+MOZC_ZENZ_CTX           FoundAny = True
+MOZC_ZENZ_THREADS       FoundAny = True
+MOZC_ZENZ_N_PREDICT     FoundAny = True
+```
+
+- [ ] DebugView confirms local transport hardening without exposing generated secrets
+
+Expected DebugView markers:
+
+```text
+[mozc-zenz-scorer] http_port_mode=random
+[mozc-zenz-scorer] api_key_bytes=64
+[mozc-zenz-scorer] launch llama-server port=random api_key_bytes=64
+[mozc-zenz-scorer] ready probe succeeded
+```
+
+The following values must not appear in DebugView logs:
+
+```text
+port=18080
+api_key=<actual value>
+Authorization: Bearer <actual value>
+```
+
+- [ ] `llama-server.exe` listens only on `127.0.0.1`
+- [ ] `llama-server.exe` does not listen on fixed port `18080`
+
+```powershell
+Get-Process llama-server -ErrorAction SilentlyContinue |
+  ForEach-Object {
+    Get-NetTCPConnection -OwningProcess $_.Id -State Listen |
+      Select-Object LocalAddress, LocalPort, OwningProcess
+  }
+```
+
+Expected result:
+
+```text
+LocalAddress: 127.0.0.1
+LocalPort: not 18080
+```
+
+- [ ] Zenz correction request succeeds through the scorer
+
+Expected DebugView markers:
+
+```text
+[zenz-pipe] Convert response status=0
+[zenz] async response ok=true timeout=false
 ```
 
 ## Windows Firewall checks
@@ -187,7 +279,9 @@ Use a clean Windows VM.
 - [ ] Open dictionary tool
 - [ ] Open administration dialog
 - [ ] Confirm IME works with network disabled
-- [ ] Confirm no outbound connection from Mozc processes
+- [ ] Confirm no outbound connection from Mozc core runtime processes
+- [ ] For Zenz-bundled builds, confirm local Zenz correction works
+- [ ] For Zenz-bundled builds, confirm no external listener is exposed by `llama-server.exe`
 
 Recommended tools:
 
@@ -210,5 +304,7 @@ Recommended tools:
 - [ ] README links to `docs/security/offline_guarantee.md`
 - [ ] README links to `docs/security/release_checklist.md`
 - [ ] README states that Windows installer adds outbound firewall block rules for Mozc runtime executables
+- [ ] README describes Zenz localhost transport at a high level without exposing low-level implementation details
+- [ ] Security docs document the `mozc_zenz_scorer.exe` local-only WinHTTP exception
 - [ ] Release notes state that offline behavior means runtime behavior, not build-time dependency fetching
 - [ ] Release notes state that local data protection requires OS-level disk encryption for stronger protection

--- a/src/zenz_scorer/BUILD.bazel
+++ b/src/zenz_scorer/BUILD.bazel
@@ -7,6 +7,7 @@ mozc_cc_binary(
     srcs = ["main.cc"],
     linkopts = [
         "Advapi32.lib",
+        "Bcrypt.lib",
         "Winhttp.lib",
     ],
     tags = MOZC_TAGS.WIN_ONLY,

--- a/src/zenz_scorer/main.cc
+++ b/src/zenz_scorer/main.cc
@@ -1,6 +1,7 @@
 #define WIN32_LEAN_AND_MEAN
 
 #include <windows.h>
+#include <bcrypt.h>
 #include <sddl.h>
 #include <winhttp.h>
 
@@ -11,6 +12,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <iostream>
+#include <limits>
 #include <mutex>
 #include <optional>
 #include <string>
@@ -18,6 +20,7 @@
 #include <vector>
 
 #pragma comment(lib, "Advapi32.lib")
+#pragma comment(lib, "Bcrypt.lib")
 #pragma comment(lib, "Winhttp.lib")
 
 namespace {
@@ -36,7 +39,9 @@ constexpr wchar_t kSingleInstanceMutexName[] =
     L"Local\\MozcZenzScorerSingleInstance";
 
 constexpr wchar_t kDefaultHost[] = L"127.0.0.1";
-constexpr int kDefaultPort = 18080;
+constexpr int kRandomPortMin = 49152;
+constexpr int kRandomPortMax = 65535;
+constexpr int kApiKeyBytes = 32;
 constexpr int kDefaultCtx = 256;
 constexpr int kDefaultThreads = 4;
 constexpr int kDefaultNPredict = 64;
@@ -92,7 +97,10 @@ struct ZenzWireResponseHeader {
 struct Options {
   std::wstring pipe_name = kDefaultPipeName;
   std::wstring host = kDefaultHost;
-  int port = kDefaultPort;
+  int port = 0;
+  std::string api_key;
+  bool random_ok = false;
+
   int ctx = kDefaultCtx;
   int threads = kDefaultThreads;
   int n_predict = kDefaultNPredict;
@@ -198,6 +206,58 @@ int GetEnvInt(const wchar_t* name, int default_value) {
   return static_cast<int>(parsed);
 }
 
+bool FillRandomBytes(void* buffer, size_t size) {
+  if (buffer == nullptr) {
+    return false;
+  }
+  if (size == 0) {
+    return true;
+  }
+  if (size > static_cast<size_t>(std::numeric_limits<ULONG>::max())) {
+    return false;
+  }
+
+  return ::BCryptGenRandom(
+             nullptr,
+             static_cast<PUCHAR>(buffer),
+             static_cast<ULONG>(size),
+             BCRYPT_USE_SYSTEM_PREFERRED_RNG) == 0;
+}
+
+std::string HexEncode(const uint8_t* data, size_t size) {
+  constexpr char kHex[] = "0123456789abcdef";
+
+  std::string output;
+  output.reserve(size * 2);
+
+  for (size_t i = 0; i < size; ++i) {
+    const uint8_t b = data[i];
+    output.push_back(kHex[(b >> 4) & 0x0f]);
+    output.push_back(kHex[b & 0x0f]);
+  }
+
+  return output;
+}
+
+int GenerateRandomPort() {
+  uint32_t value = 0;
+  if (!FillRandomBytes(&value, sizeof(value))) {
+    return 0;
+  }
+
+  constexpr int kRange = kRandomPortMax - kRandomPortMin + 1;
+  return kRandomPortMin + static_cast<int>(value % kRange);
+}
+
+std::string GenerateApiKey() {
+  std::vector<uint8_t> bytes(kApiKeyBytes);
+  if (!FillRandomBytes(bytes.data(), bytes.size())) {
+    return "";
+  }
+
+  return HexEncode(bytes.data(), bytes.size());
+}
+
 std::wstring GetExeDirectory() {
   wchar_t path[MAX_PATH] = {};
   DWORD size = GetModuleFileNameW(nullptr, path, MAX_PATH);
@@ -237,21 +297,29 @@ Options LoadOptions() {
 
   const std::wstring exe_dir = GetExeDirectory();
 
+#if !defined(NDEBUG)
   options.llama_server_path = GetEnvWide(L"MOZC_ZENZ_LLAMA_SERVER");
+#endif  // !defined(NDEBUG)
+
   if (options.llama_server_path.empty()) {
     options.llama_server_path = JoinPath(exe_dir, L"llama-server.exe");
   }
 
+#if !defined(NDEBUG)
   options.model_path = GetEnvWide(L"MOZC_ZENZ_MODEL");
+#endif  // !defined(NDEBUG)
+
   if (options.model_path.empty()) {
     options.model_path =
         JoinPath(JoinPath(exe_dir, L"models"), L"zenz-v3.2-small-Q5_K_M.gguf");
   }
 
-  options.port = std::clamp(
-      GetEnvInt(L"MOZC_ZENZ_PORT", kDefaultPort),
-      1,
-      65535);
+  options.port = GenerateRandomPort();
+  options.api_key = GenerateApiKey();
+  options.random_ok = options.port >= kRandomPortMin &&
+                      options.port <= kRandomPortMax &&
+                      !options.api_key.empty();
+
   options.ctx = std::clamp(
       GetEnvInt(L"MOZC_ZENZ_CTX", kDefaultCtx),
       64,
@@ -759,8 +827,14 @@ bool LaunchLlamaServer(const Options& options, std::wstring* error) {
   cmd += std::to_wstring(options.threads);
   cmd += L" --host 127.0.0.1 --port ";
   cmd += std::to_wstring(options.port);
+  // The API key is defense-in-depth for accidental or stale localhost servers.
+  // It is passed to llama-server via command line because llama-server exposes
+  // --api-key.  Do not treat it as a strong same-user secret.
+  cmd += L" --api-key ";
+  cmd += Utf8ToWide(options.api_key);
 
-  Debug(L"launch llama-server");
+  Debug(L"launch llama-server port=random api_key_bytes=" +
+        std::to_wstring(options.api_key.size()));
 
   std::vector<wchar_t> cmd_buffer(cmd.begin(), cmd.end());
   cmd_buffer.push_back(L'\0');
@@ -775,7 +849,7 @@ bool LaunchLlamaServer(const Options& options, std::wstring* error) {
   const std::wstring work_dir = GetExeDirectory();
 
   if (!CreateProcessW(
-          nullptr,
+          options.llama_server_path.c_str(),
           cmd_buffer.data(),
           nullptr,
           nullptr,
@@ -894,11 +968,14 @@ bool HttpPostCompletion(
           "]";
   body += "}";
 
-  const wchar_t headers[] = L"Content-Type: application/json; charset=utf-8\r\n";
+  std::wstring headers = L"Content-Type: application/json; charset=utf-8\r\n";
+  headers += L"Authorization: Bearer ";
+  headers += Utf8ToWide(options.api_key);
+  headers += L"\r\n";
 
   BOOL ok = WinHttpSendRequest(
       request,
-      headers,
+      headers.c_str(),
       static_cast<DWORD>(-1L),
       body.data(),
       static_cast<DWORD>(body.size()),
@@ -1046,8 +1123,7 @@ void StartLlamaReadyProbeInBackground(const Options& options) {
     }
 
     Debug(L"ready probe timeout");
-    g_llama_ready_probe_started = false;
-    g_llama_server_ready = false;
+    StopLlamaServer();
   }).detach();
 }
 
@@ -1230,7 +1306,14 @@ int RunServer(const Options& options) {
         RedactedWideChars(L"llama_server_path", options.llama_server_path) +
         L" " +
         RedactedWideChars(L"model_path", options.model_path));
-  Debug(L"port=" + std::to_wstring(options.port));
+
+  if (!options.random_ok) {
+    Debug(L"secure random initialization failed");
+    return 1;
+  }
+
+  Debug(L"http_port_mode=random");
+  Debug(L"api_key_bytes=" + std::to_wstring(options.api_key.size()));
   Debug(L"n_predict=" + std::to_wstring(options.n_predict));
 
   // Start llama-server in the background. Never block Mozc's request path on


### PR DESCRIPTION
## Summary

- Replace the fixed Zenz `llama-server.exe` localhost port with a random high port chosen by `mozc_zenz_scorer.exe`
- Protect scorer-to-`llama-server.exe` completion requests with a generated local API key
- Keep generated local transport details out of DebugView logs
- Disable release-build environment overrides for the Zenz runtime/model paths
- Launch `llama-server.exe` with an explicit application path
- Update README and security docs for the local-only Zenz transport model

## Notes

`mozc_zenz_scorer.exe` remains a narrow local-only WinHTTP exception. It is used only to call the bundled `llama-server.exe` through a localhost endpoint for local inference.

Detailed validation guidance is documented in:

- `docs/security/offline_guarantee.md`
- `docs/security/release_checklist.md`

## Validation

- Built `//zenz_scorer:mozc_zenz_scorer` with `--config oss_windows --config release_build`
- Confirmed release-disabled override markers are not present in the built scorer:
  - `MOZC_ZENZ_LLAMA_SERVER`
  - `MOZC_ZENZ_MODEL`
  - `MOZC_ZENZ_PORT`
- Confirmed runtime tuning markers remain present as expected:
  - `MOZC_ZENZ_CTX`
  - `MOZC_ZENZ_THREADS`
  - `MOZC_ZENZ_N_PREDICT`
- Replaced the installed `mozc_zenz_scorer.exe` and confirmed its hash matched the build output
- Confirmed DebugView shows random localhost transport mode and successful Zenz response
- Confirmed `llama-server.exe` listens only on `127.0.0.1`
- Confirmed `llama-server.exe` does not listen on the old fixed port

## Follow-ups

- Consider adding firewall rules for Zenz-related executables in a separate installer change
- Consider per-launch endpoint regeneration for stronger retry resilience
- Consider named-pipe hardening in a separate change