### PR TITLE
Restore Zenz feedback fast path for multi-segment live conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Windows 用のビルド済み MSI は [Releases](https://github.com/koyasi777/mo
 - Zenz 学習データを設定画面から安全に管理できる UI を追加。TSV を直接編集せず、検索、インポート、エクスポート、選択項目削除、全削除が可能
 - Zenz accepted feedback を通常変換候補の promotion に利用。1 文節の通常変換では、保存済み accepted feedback が既存候補にあれば先頭へ昇格し、候補にない場合は synthetic candidate として追加
 - 文節境界を壊さないため、複数文節に分かれた通常変換では Zenz feedback promotion を行わない
+- 複数文節に分かれるライブ変換では、全文補正の学習を保つため、accepted Zenz feedback を session-level live correction fast path として再利用
 - sensitive-like context で得られた feedback は、通常文脈の候補 promotion には使わない
 - accepted として確定した Zenz 候補は、条件を満たす場合は Mozc の user history にも外部変換結果として学習
 - Zenz prompt に使う左文脈は sanitizer を通し、URL、email、file path、token、長い数字列など sensitive-like な文脈は prompt に含めない
@@ -181,15 +182,17 @@ Zenz 補正は設定可能なデバウンス時間の後に実行されます。
 
 Zenz 出力は表示前に検証されます。空出力、短すぎる入力、Mozc 結果と同一の出力、長すぎる出力、不正な文字列、安全でない可能性のある文字列は拒否されます。拒否された場合は、通常の Mozc ライブ変換結果をそのまま表示します。
 
-Zenz ライブ補正は password field では実行されません。また、入力途中の romaji のように ASCII alphabet を含む読みも補正対象外です。
+Zenz ライブ補正は password field では実行されません。また、入力途中の raw romaji のように日本語文字シグナルを含まない読みは補正対象外です。日本語文字を含む英字混じりの入力は、privacy gate を通る場合に限り補正対象になり得ます。
 
 Zenz feedback learning は任意機能です。有効な場合でも、Zenz 補正結果が表示されただけでは保存されません。Enter や句読点・記号の単打確定などで、表示中の Zenz 結果が明示的に確定された場合だけ、accepted feedback の候補として保留されます。
 
 保留された accepted feedback は、次のユーザー操作で取り消されなかった場合だけローカル TSV に保存されます。Backspace、Escape、Revert、Undo、IME off などの修正操作が入った場合、保留 feedback は破棄されます。表示中の Zenz 補正から Space や候補移動などの通常変換操作へ移った場合、その Zenz 結果は rejected feedback として扱われます。
 
-accepted feedback は通常変換候補の promotion に再利用されます。1 文節の通常変換では、保存済み accepted feedback が既存候補にあれば先頭へ昇格し、候補にない場合は synthetic candidate として追加できます。複数文節に分かれた変換は、文節境界を converter の責務として保持するため、feedback promotion では書き換えません。
+accepted feedback の再利用方法は、単文節と複数文節で異なります。
 
-accepted feedback は session-level の live correction fast path としては再生しません。Zenz feedback は通常変換の rewriter chain 内で候補順位に反映され、その後 UserSegmentHistoryRewriter による明示的なユーザー選択履歴が最終順位を決めます。これにより、古い Zenz feedback が通常のユーザー履歴より常に後勝ちすることを避けます。
+単文節の通常変換では、Zenz feedback は rewriter chain 内の candidate promotion として再利用されます。保存済み accepted feedback が既存候補にあれば先頭へ昇格し、候補にない場合は synthetic candidate として追加できます。その後に UserSegmentHistoryRewriter が走るため、明示的なユーザー選択履歴が最終順位を決めます。
+
+複数文節に分かれるライブ変換では、converter の文節境界を feedback promotion で壊さないため、rewriter chain では通常変換候補を書き換えません。その代わり、session-level の live correction fast path として再利用します。これにより、`かれはてんてきです` → `彼は天敵です` のような全文補正の学習も再利用できます。
 
 `sensitive_like` context で得られた feedback は、通常文脈への候補 promotion には使いません。
 
@@ -460,6 +463,7 @@ Main features added in this fork
 - Adds a safe Zenz feedback management UI to the config dialog. Users can search, import, export, delete selected entries, and clear all entries without directly editing the TSV file
 - Reuses accepted Zenz feedback for normal conversion candidate promotion. In single-segment conversions, an accepted feedback candidate is promoted to the top if it already exists, or inserted as a synthetic candidate if it does not
 - Does not apply Zenz feedback promotion to multi-segment conversions, to avoid collapsing phrase boundaries
+- Reuses accepted Zenz feedback via the session-level live-correction fast path for multi-segment live conversion to preserve learned full-phrase corrections
 - Does not promote feedback obtained from `sensitive_like` context into ordinary context
 - Learns accepted Zenz candidates into Mozc user history as external conversion results when the runtime conditions allow it
 - Sanitizes left context before using it in Zenz prompts, and excludes sensitive-like context such as URLs, email addresses, file paths, tokens, and long digit sequences
@@ -533,8 +537,10 @@ identical to the Mozc result, too long, malformed, or likely to contain unsafe
 text are rejected. If validation fails, the normal Mozc live conversion result
 remains visible.
 
-Zenz live correction is disabled for password fields and for readings that still
-contain ASCII alphabet characters, such as intermediate romaji input.
+Zenz live correction is disabled for password fields and for composition text
+that has no Japanese-script signal, such as intermediate raw romaji input.
+Japanese text mixed with ASCII can still be eligible when it passes the privacy
+gate.
 
 Zenz feedback learning is optional. When enabled, a displayed Zenz result is not
 stored just because it was shown. It becomes a pending accepted feedback only
@@ -547,17 +553,21 @@ correction actions discard the pending feedback. Moving from a visible Zenz
 correction to normal conversion operations, such as Space or candidate movement,
 records the Zenz result as rejected feedback instead.
 
-Accepted feedback is reused for normal-conversion candidate promotion. During
-single-segment conversion, a learned feedback candidate can be promoted to the
-top if it already exists, or inserted as a synthetic candidate if it does not.
-Multi-segment conversions are not rewritten, because phrase boundaries are owned
-by the converter and should not be collapsed by feedback promotion.
+Accepted feedback is reused differently for single-segment and multi-segment
+conversions.
 
-Accepted feedback is not replayed as a session-level live-correction fast path.
-Zenz feedback participates in candidate ranking inside the rewriter chain, and
-UserSegmentHistoryRewriter can then make the final ranking decision based on
-explicit user selection history. This prevents stale Zenz feedback from always
-overriding newer normal user history.
+For single-segment normal conversion, Zenz feedback is reused as candidate
+promotion inside the rewriter chain. A learned feedback candidate can be
+promoted to the top if it already exists, or inserted as a synthetic candidate
+if it does not. ZenzFeedbackCandidateRewriter runs before
+UserSegmentHistoryRewriter, so explicit user selection history can still make
+the final ranking decision.
+
+For multi-segment live conversion, the rewriter-chain feedback promotion does
+not rewrite normal conversion candidates, because phrase boundaries are owned by
+the converter and should not be collapsed. Instead, accepted feedback can still be replayed via
+the session-level live-correction fast path. This preserves learned full-phrase
+corrections such as `かれはてんてきです` -> `彼は天敵です`.
 
 Feedback learned in a `sensitive_like` context is not promoted into ordinary-context conversion candidates.
 

--- a/src/session/session.cc
+++ b/src/session/session.cc
@@ -3344,30 +3344,168 @@ void Session::ClearZenzLiveCorrectionState() {
 
 bool Session::MaybeApplyZenzFeedbackLiveCorrection(
     commands::Command* command) {
-  (void)command;
+  const config::Config& config = context_->GetConfig();
 
-  // Do not replay accepted Zenz feedback as a session-level live correction.
+  if (!UseZenzFeedbackLearning(config)) {
+    return false;
+  }
+
+  if (!config.use_zenz_live_correction()) {
+    return false;
+  }
+
+  if (!config.use_live_conversion()) {
+    return false;
+  }
+
+  if (!live_conversion_active_) {
+    return false;
+  }
+
+  if (context_->state() != ImeContext::CONVERSION) {
+    return false;
+  }
+
+  if (context_->composer().GetInputFieldType() == commands::Context::PASSWORD) {
+    return false;
+  }
+
+  if (live_conversion_key_.empty() || live_conversion_value_.empty()) {
+    return false;
+  }
+
+  // Single-segment feedback is handled by ZenzFeedbackCandidateRewriter in the
+  // converter rewriter chain, before UserSegmentHistoryRewriter.  Do not replay
+  // it again here as a session-level fast path; otherwise stale Zenz feedback
+  // can override a newer explicit user-history selection.
   //
-  // Zenz feedback is already applied in the converter rewriter chain by
-  // ZenzFeedbackCandidateRewriter.  The rewriter order is:
-  //
-  //   ZenzFeedbackCandidateRewriter
-  //   UserSegmentHistoryRewriter
-  //
-  // This lets accepted Zenz feedback participate in candidate ranking while
-  // still allowing explicit user segment history to decide the final order.
-  //
-  // Keeping this session-level fast path would make Zenz feedback always win
-  // after the visible Mozc live-conversion result has already been generated.
-  // That breaks the "last learned result wins" rule.
-  //
-  // Example:
-  //   Existing Zenz feedback: たなべ -> 田辺
-  //   Later user selection:   たなべ -> 田邊
-  //
-  // UserSegmentHistoryRewriter correctly promotes 田邊, but this fast path
-  // would replay the stale Zenz feedback 田辺 afterwards and record it as
-  // accepted again.
+  // Multi-segment live conversions cannot be safely represented by
+  // ZenzFeedbackCandidateRewriter without collapsing converter-owned segment
+  // boundaries.  Keep the fast path only for those full-phrase corrections.
+  if (live_conversion_preedit_output_.segment_size() <= 1) {
+    return false;
+  }
+
+  const ZenzTextPrivacyDecision key_privacy =
+      EvaluateZenzLiveKeyPrivacy(live_conversion_key_);
+  if (!key_privacy.allow) {
+    ZenzDebugOutput(absl::StrCat(
+        "[zenz-feedback] fast path skip key_privacy reason=",
+        key_privacy.reason,
+        " ",
+        ZenzRedactedTextStats("key", live_conversion_key_)));
+    return false;
+  }
+
+  const ZenzTextPrivacyDecision mozc_value_privacy =
+      EvaluateZenzLiveValuePrivacy(live_conversion_value_);
+  if (!mozc_value_privacy.allow) {
+    ZenzDebugOutput(absl::StrCat(
+        "[zenz-feedback] fast path skip mozc_value_privacy reason=",
+        mozc_value_privacy.reason,
+        " ",
+        ZenzRedactedTextStats("value", live_conversion_value_)));
+    return false;
+  }
+
+  const uint32_t min_key_len = GetZenzLiveCorrectionMinKeyLength(config);
+  if (Util::CharsLen(live_conversion_key_) < min_key_len) {
+    return false;
+  }
+
+  const uint32_t left_context_len =
+      GetZenzLiveCorrectionLeftContextLength(config);
+
+  const std::string raw_left_context =
+      ExtractZenzLeftContext(left_context_len);
+  const ZenzContextSanitizationResult context_result =
+      zenz_context_sanitizer_.SanitizeForZenz(
+          raw_left_context, left_context_len);
+
+  const std::string left_context_for_validation =
+      context_result.allowed_for_prompt
+          ? context_result.sanitized_context
+          : std::string();
+
+  const std::string context_class =
+      context_result.context_class.empty()
+          ? std::string("empty")
+          : context_result.context_class;
+
+  const std::vector<ZenzFeedbackCandidate> feedback_candidates =
+      zenz_feedback_store_.GetAcceptedCandidates(
+          live_conversion_key_, context_class);
+
+  if (feedback_candidates.empty()) {
+    return false;
+  }
+
+  for (const ZenzFeedbackCandidate& feedback_candidate :
+       feedback_candidates) {
+    const std::string& feedback_value = feedback_candidate.value;
+
+    const ZenzTextPrivacyDecision feedback_value_privacy =
+        EvaluateZenzLiveValuePrivacy(feedback_value);
+    if (!feedback_value_privacy.allow) {
+      ZenzDebugOutput(absl::StrCat(
+          "[zenz-feedback] fast path candidate rejected reason=value_privacy_",
+          feedback_value_privacy.reason,
+          " ",
+          ZenzRedactedTextStats("key", live_conversion_key_),
+          " ",
+          ZenzRedactedTextStats("value", feedback_value),
+          " context_class=", context_class,
+          " accepted_count=", feedback_candidate.accepted_count,
+          " rejected_count=", feedback_candidate.rejected_count));
+      continue;
+    }
+
+    ZenzValidationInput validation_input;
+    validation_input.key = live_conversion_key_;
+    validation_input.mozc_value = live_conversion_value_;
+    validation_input.zenz_value = feedback_value;
+    validation_input.left_context = left_context_for_validation;
+    validation_input.min_key_length = min_key_len;
+    validation_input.allow_synthetic_candidate =
+        config.use_zenz_synthetic_candidate();
+
+    const ZenzValidationResult validation =
+        zenz_output_validator_.Validate(validation_input);
+
+    if (!validation.accept) {
+      ZenzDebugOutput(absl::StrCat(
+          "[zenz-feedback] fast path candidate rejected reason=",
+          validation.reason,
+          " ", ZenzRedactedTextStats("key", live_conversion_key_),
+          " ", ZenzRedactedTextStats("value", feedback_value),
+          " context_class=", context_class,
+          " accepted_count=", feedback_candidate.accepted_count,
+          " rejected_count=", feedback_candidate.rejected_count));
+      continue;
+    }
+
+    ++zenz_live_generation_;
+    pending_zenz_live_ = PendingZenzLiveCorrection();
+
+    zenz_live_visible_generation_ = zenz_live_generation_;
+    zenz_live_key_ = live_conversion_key_;
+    zenz_live_value_ = feedback_value;
+    zenz_live_mozc_value_ = live_conversion_value_;
+    zenz_live_context_class_ = context_class;
+    zenz_live_left_context_ = left_context_for_validation;
+
+    ZenzDebugOutput(absl::StrCat(
+        "[zenz-feedback] fast path applied ",
+        ZenzRedactedTextStats("key", zenz_live_key_),
+        " ", ZenzRedactedTextStats("value", zenz_live_value_),
+        " ", ZenzRedactedTextStats("mozc_value", zenz_live_mozc_value_),
+        " context_class=", zenz_live_context_class_,
+        " accepted_count=", feedback_candidate.accepted_count,
+        " rejected_count=", feedback_candidate.rejected_count));
+
+    return OutputZenzLiveCorrection(feedback_value, command);
+  }
+
   return false;
 }
 

--- a/src/session/session_test.cc
+++ b/src/session/session_test.cc
@@ -104,6 +104,7 @@ class SessionTestPeer : testing::TestPeer<Session> {
   PEER_VARIABLE(live_conversion_active_);
   PEER_VARIABLE(live_conversion_key_);
   PEER_VARIABLE(live_conversion_value_);
+  PEER_VARIABLE(live_conversion_preedit_output_);
   PEER_VARIABLE(zenz_live_key_);
   PEER_VARIABLE(zenz_live_value_);
   PEER_VARIABLE(zenz_live_mozc_value_);
@@ -989,7 +990,7 @@ TEST_F(SessionTest, PendingZenzFeedbackStoresContextClassOnly) {
 #if defined(_WIN32)
 
 TEST_F(SessionTest,
-       ZenzFeedbackFastPathDoesNotOverrideLiveConversionResult) {
+       ZenzFeedbackFastPathAppliesAcceptedCandidateForMultiSegmentLiveConversion) {
   MockEngine engine;
   std::shared_ptr<MockConverter> converter = CreateEngineConverterMock(&engine);
 
@@ -1011,6 +1012,71 @@ TEST_F(SessionTest,
   session_peer.live_conversion_active_() = true;
   session_peer.live_conversion_key_() = "かれはてんてきです";
   session_peer.live_conversion_value_() = "彼は点滴です";
+
+  commands::Preedit& live_preedit =
+      session_peer.live_conversion_preedit_output_();
+  live_preedit.Clear();
+
+  commands::Preedit::Segment* segment = live_preedit.add_segment();
+  segment->set_key("かれは");
+  segment->set_value("彼は");
+  segment->set_value_length(Util::CharsLen("彼は"));
+
+  segment = live_preedit.add_segment();
+  segment->set_key("てんてきです");
+  segment->set_value("点滴です");
+  segment->set_value_length(Util::CharsLen("点滴です"));
+
+  commands::Command command;
+  EXPECT_TRUE(session_peer.MaybeApplyZenzFeedbackLiveCorrection(&command));
+
+  EXPECT_TRUE(command.output().live_conversion());
+  EXPECT_FALSE(command.output().live_conversion_pending());
+  EXPECT_FALSE(command.output().zenz_live_correction_pending());
+  EXPECT_TRUE(command.output().zenz_live_correction_applied());
+  EXPECT_FALSE(command.output().has_callback());
+  EXPECT_SINGLE_SEGMENT_AND_KEY("彼は天敵です",
+                                "かれはてんてきです",
+                                command);
+
+  EXPECT_EQ(session_peer.zenz_live_key_(), "かれはてんてきです");
+  EXPECT_EQ(session_peer.zenz_live_value_(), "彼は天敵です");
+  EXPECT_EQ(session_peer.zenz_live_mozc_value_(), "彼は点滴です");
+  EXPECT_EQ(session_peer.zenz_live_context_class_(), "empty");
+}
+
+TEST_F(SessionTest,
+       ZenzFeedbackFastPathDoesNotOverrideSingleSegmentLiveConversion) {
+  MockEngine engine;
+  std::shared_ptr<MockConverter> converter = CreateEngineConverterMock(&engine);
+
+  ScopedUserProfileForZenzFeedbackSessionTest profile;
+  ASSERT_TRUE(profile.ok());
+
+  Session session(engine);
+  SessionTestPeer session_peer(session);
+  InitSessionToPrecomposition(&session);
+  EnableZenzLiveCorrectionWithFeedbackLearning(&session);
+
+  session_peer.zenz_feedback_store_().RecordAccepted(
+      "たなべ",
+      "japanese_only",
+      "田辺");
+  ASSERT_FALSE(session_peer.zenz_feedback_store_().ListEntries().empty());
+
+  session_peer.context_()->set_state(ImeContext::CONVERSION);
+  session_peer.live_conversion_active_() = true;
+  session_peer.live_conversion_key_() = "たなべ";
+  session_peer.live_conversion_value_() = "田邊";
+
+  commands::Preedit& live_preedit =
+      session_peer.live_conversion_preedit_output_();
+  live_preedit.Clear();
+
+  commands::Preedit::Segment* segment = live_preedit.add_segment();
+  segment->set_key("たなべ");
+  segment->set_value("田邊");
+  segment->set_value_length(Util::CharsLen("田邊"));
 
   commands::Command command;
   EXPECT_FALSE(session_peer.MaybeApplyZenzFeedbackLiveCorrection(&command));
@@ -1048,6 +1114,20 @@ TEST_F(SessionTest,
   session_peer.live_conversion_active_() = true;
   session_peer.live_conversion_key_() = "かれはてんてきです";
   session_peer.live_conversion_value_() = "彼は点滴です";
+
+  commands::Preedit& live_preedit =
+      session_peer.live_conversion_preedit_output_();
+  live_preedit.Clear();
+
+  commands::Preedit::Segment* segment = live_preedit.add_segment();
+  segment->set_key("かれは");
+  segment->set_value("彼は");
+  segment->set_value_length(Util::CharsLen("彼は"));
+
+  segment = live_preedit.add_segment();
+  segment->set_key("てんてきです");
+  segment->set_value("点滴です");
+  segment->set_value_length(Util::CharsLen("点滴です"));
 
   commands::Command command;
   EXPECT_FALSE(session_peer.MaybeApplyZenzFeedbackLiveCorrection(&command));
@@ -1088,6 +1168,20 @@ TEST_F(SessionTest,
   session_peer.live_conversion_active_() = true;
   session_peer.live_conversion_key_() = "かれはてんてきです";
   session_peer.live_conversion_value_() = "彼は点滴です";
+
+  commands::Preedit& live_preedit =
+      session_peer.live_conversion_preedit_output_();
+  live_preedit.Clear();
+
+  commands::Preedit::Segment* segment = live_preedit.add_segment();
+  segment->set_key("かれは");
+  segment->set_value("彼は");
+  segment->set_value_length(Util::CharsLen("彼は"));
+
+  segment = live_preedit.add_segment();
+  segment->set_key("てんてきです");
+  segment->set_value("点滴です");
+  segment->set_value_length(Util::CharsLen("点滴です"));
 
   commands::Command command;
   EXPECT_FALSE(session_peer.MaybeApplyZenzFeedbackLiveCorrection(&command));


### PR DESCRIPTION
## Summary

Restore accepted Zenz feedback reuse for multi-segment live conversion while keeping single-segment feedback priority under the rewriter chain.

The previous fix moved Zenz feedback candidate promotion before `UserSegmentHistoryRewriter` and disabled the session-level fast path. That fixed stale single-segment feedback overriding newer explicit user history, but it also removed reuse for learned full-phrase corrections such as:

- `かれはてんてきです` → `彼は天敵です`

This change restores the session-level Zenz feedback fast path only when the current live conversion output has multiple preedit segments.

Single-segment feedback remains handled by:

1. `ZenzFeedbackCandidateRewriter`
2. `UserSegmentHistoryRewriter`

This lets explicit user selection history make the final ranking decision for cases such as:

- stale Zenz feedback: `たなべ` → `田辺`
- newer user history: `たなべ` → `田邊`

For multi-segment live conversion, feedback promotion does not rewrite normal conversion candidates because phrase boundaries are owned by the converter. Instead, accepted feedback can still be replayed via the session-level live-correction fast path to preserve learned full-phrase corrections.

## Changes

- Restore `MaybeApplyZenzFeedbackLiveCorrection()` for multi-segment live conversion only
- Keep the fast path disabled for single-segment live conversion
- Add session tests for:
  - accepted feedback applied to multi-segment live conversion
  - accepted feedback not overriding single-segment live conversion
  - same-value feedback still not being applied
  - `sensitive_like` feedback still not being promoted
- Update README documentation for the single-segment vs multi-segment feedback behavior
- Update README wording for the current Zenz privacy gate behavior around raw romaji and ASCII-mixed Japanese input

## Validation

- `//session:session_test` passed with test cache disabled

```powershell
bazelisk --output_user_root=C:/bzl test `
  --config oss_windows `
  --config release_build `
  //session:session_test `
  --test_output=errors `
  --cache_test_results=no
````

* Manual test:

  * Learned multi-segment Zenz feedback such as `かれはてんてきです` → `彼は天敵です` is reused again
  * Single-segment stale Zenz feedback such as `たなべ` → `田辺` does not override newer explicit user history such as `田邊`