### PR TITLE
Fix live conversion edge cases for Shift ASCII and romaji ellipsis input

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,8 @@ Windows 版では、追加のオフライン防御層として、インストー
 - `kyouha` と入力
 - デバウンス時間の経過後、Space を押す前に未確定文字列が `今日は` のように表示される
 - 続けて文字を入力しても途中の変換結果は確定されず、同じ未確定文字列として再変換される
+- ローマ字テーブルで `v. -> …` や `v, -> ‥` のような省略記号を入力する場合も、直前まで表示されていたライブ変換結果を保ったまま入力を継続する
+- Shift による英字入力へ移る場合は、表示中のライブ変換結果を先に確定してから英字入力を開始する
 - Backspace / Delete では、削除後の状態をすぐにライブ変換結果へ反映する
 - Enter で現在のライブ変換結果を確定する
 
@@ -557,6 +559,8 @@ For example:
 - Type `kyouha`
 - After the debounce delay, the preedit can be shown as `今日は` before pressing Space
 - Typing more characters keeps the same uncommitted composition and schedules another live conversion
+- Romaji-table ellipsis rules such as `v. -> …` or `v, -> ‥` keep the visible live-converted prefix instead of falling back to raw kana
+- When Shift-based ASCII input starts, the visible live conversion result is committed first, and then ASCII input begins
 - Pressing Backspace or Delete updates the live conversion result immediately
 - Pressing Enter commits the current live conversion result
 

--- a/src/session/session.cc
+++ b/src/session/session.cc
@@ -207,6 +207,7 @@ bool IsLiveConversionTrailingDecorativeSymbol(char32_t c) {
     case 0x301C:  // 〜
     case 0x30FC:  // ー
     case 0x2015:  // ―
+    case 0x2025:  // ‥
     case 0x2026:  // …
     case 0x0021:  // !
     case 0xFF01:  // ！
@@ -4534,10 +4535,19 @@ bool Session::InsertCharacter(commands::Command* command) {
       return CommitPendingLiveConversionDisplayDirectly(command);
     }
 
-    // Defensive fallback. The pre-insert predicate accepted the key as a direct
-    // commit trigger, so this path should normally not be reached. Avoid inserting
-    // the same key twice.
+    // The physical key looked like a direct-commit trigger before insertion,
+    // but the romaji table may have turned it into a different character.
+    // Example: "v." -> "…" or "v," -> "‥".
+    //
+    // In that case, do not fall back to raw composition, because it discards
+    // the stable converted prefix shown by live conversion, e.g. "今日は".
+    // Treat it as ordinary continued composition and schedule live conversion
+    // for the updated preedit.
     CancelPendingLiveConversion();
+    if (MaybeScheduleLiveConversion(command)) {
+      return true;
+    }
+
     OutputComposition(command);
     return true;
   }

--- a/src/session/session.cc
+++ b/src/session/session.cc
@@ -937,6 +937,67 @@ bool IsPendingDirectCommitLearningDiscardKey(
   }
 }
 
+bool ShouldCommitLiveConversionBeforeShiftAsciiInput(
+    const config::Config& config,
+    const composer::Composer& composer,
+    const commands::KeyEvent& key_event) {
+  if (config.shift_key_mode_switch() !=
+      config::Config::ASCII_INPUT_MODE) {
+    return false;
+  }
+
+  if (key_event.input_style() != commands::KeyEvent::FOLLOW_MODE) {
+    return false;
+  }
+
+  if (key_event.has_special_key()) {
+    return false;
+  }
+
+  if (composer.GetInputFieldType() == commands::Context::PASSWORD) {
+    return false;
+  }
+
+  const transliteration::TransliterationType input_mode =
+      composer.GetInputMode();
+  if (input_mode == transliteration::HALF_ASCII ||
+      input_mode == transliteration::FULL_ASCII) {
+    return false;
+  }
+
+  const size_t length = composer.GetLength();
+  if (length == 0 || length != composer.GetCursor()) {
+    return false;
+  }
+
+  std::string input;
+  if (!key_event.key_string().empty()) {
+    if (key_event.key_string().size() != 1) {
+      return false;
+    }
+    input = key_event.key_string();
+  } else if (key_event.has_key_code()) {
+    if (key_event.key_code() > 0x7f) {
+      return false;
+    }
+    input.push_back(static_cast<char>(key_event.key_code()));
+  } else {
+    return false;
+  }
+
+  const uint32_t modifiers = KeyEventUtil::GetModifiers(key_event);
+  if (KeyEventUtil::HasCtrl(modifiers) ||
+      KeyEventUtil::HasAlt(modifiers)) {
+    return false;
+  }
+
+  const bool caps_locked = KeyEventUtil::HasCaps(modifiers);
+  const char key = input[0];
+
+  return (!caps_locked && ('A' <= key && key <= 'Z')) ||
+         (caps_locked && ('a' <= key && key <= 'z'));
+}
+
 void ExtractPreeditKeyAndValue(const commands::Preedit& preedit,
                                std::string* key,
                                std::string* value) {
@@ -4497,6 +4558,34 @@ bool Session::InsertCharacter(commands::Command* command) {
   const std::string zenz_value_before_edit = zenz_live_value_;
   const std::string zenz_context_class_before_edit =
       zenz_live_context_class_.empty() ? "empty" : zenz_live_context_class_;
+
+  if ((live_conversion_active_ || live_conversion_pending_) &&
+      ShouldCommitLiveConversionBeforeShiftAsciiInput(
+          context_->GetConfig(), context_->composer(), key)) {
+    if (had_visible_zenz_correction) {
+      CommitZenzLiveCorrectionResult(command);
+    } else if (live_conversion_active_) {
+      const std::string live_key =
+          live_conversion_key_.empty()
+              ? context_->composer().GetQueryForConversion()
+              : live_conversion_key_;
+      const std::string live_value =
+          live_conversion_value_.empty()
+              ? context_->composer().GetStringForSubmission()
+              : live_conversion_value_;
+
+      ClearLiveConversionState();
+      CommitStringDirectly(live_key, live_value, command);
+    } else if (live_conversion_pending_) {
+      CommitPendingLiveConversionDisplayDirectly(command);
+    }
+
+    context_->mutable_composer()->InsertCharacterKeyEvent(key);
+    ClearUndoContext();
+    SetSessionState(ImeContext::COMPOSITION, context_.get());
+    OutputComposition(command);
+    return true;
+  }
 
   // If the current conversion was started by live conversion, ordinary
   // character input should continue editing the composition.  So cancel

--- a/src/session/session_test.cc
+++ b/src/session/session_test.cc
@@ -1283,6 +1283,39 @@ TEST_F(SessionTest,
 
 #endif  // defined(_WIN32)
 
+TEST_F(SessionTest,
+       LiveConversionShiftAsciiCommitsVisibleResultBeforeAsciiInput) {
+  MockEngine engine;
+  std::shared_ptr<MockConverter> converter = CreateEngineConverterMock(&engine);
+
+  Session session(engine);
+  SessionTestPeer session_peer(session);
+  InitSessionToPrecomposition(&session);
+
+  config::Config config;
+  config::ConfigHandler::GetDefaultConfig(&config);
+  config.set_use_live_conversion(true);
+  config.set_shift_key_mode_switch(config::Config::ASCII_INPUT_MODE);
+  session.SetConfig(config);
+
+  commands::Command command;
+  InsertCharacterChars("kyou", &session, &command);
+  ASSERT_EQ(session.context().composer().GetQueryForConversion(), "きょう");
+
+  session_peer.context_()->set_state(ImeContext::CONVERSION);
+  session_peer.live_conversion_active_() = true;
+  session_peer.live_conversion_key_() = "きょう";
+  session_peer.live_conversion_value_() = "今日";
+
+  command.Clear();
+  ASSERT_TRUE(SendKey("A", &session, &command));
+
+  EXPECT_RESULT("今日", command);
+  EXPECT_PREEDIT("A", command);
+  EXPECT_EQ(command.output().mode(), commands::HALF_ASCII);
+  EXPECT_EQ(session.context().state(), ImeContext::COMPOSITION);
+}
+
 TEST_F(SessionTest, PendingDirectCommitLearningIsConfirmedByNextTextInput) {
   MockEngine engine;
   std::shared_ptr<MockConverter> converter = CreateEngineConverterMock(&engine);

--- a/src/session/session_test.cc
+++ b/src/session/session_test.cc
@@ -102,7 +102,9 @@ class SessionTestPeer : testing::TestPeer<Session> {
   PEER_VARIABLE(context_);
   PEER_VARIABLE(undo_contexts_);
   PEER_VARIABLE(live_conversion_active_);
+  PEER_VARIABLE(live_conversion_pending_);
   PEER_VARIABLE(live_conversion_key_);
+  PEER_VARIABLE(live_conversion_preedit_);
   PEER_VARIABLE(live_conversion_value_);
   PEER_VARIABLE(live_conversion_preedit_output_);
   PEER_VARIABLE(zenz_live_key_);
@@ -1282,6 +1284,108 @@ TEST_F(SessionTest,
 }
 
 #endif  // defined(_WIN32)
+
+TEST_F(SessionTest,
+       PendingLiveConversionKeepsConvertedPrefixForRomajiEllipsis) {
+  MockEngine engine;
+  std::shared_ptr<MockConverter> converter = CreateEngineConverterMock(&engine);
+
+  Session session(engine);
+  SessionTestPeer session_peer(session);
+  InitSessionToPrecomposition(&session);
+
+  config::Config config;
+  config::ConfigHandler::GetDefaultConfig(&config);
+  config.set_use_live_conversion(true);
+  config.set_use_direct_commit(true);
+  config.set_direct_commit_key(config::Config::DIRECT_COMMIT_KUTEN);
+  session.SetConfig(config);
+
+  auto table = std::make_shared<composer::Table>();
+  table->InitializeWithRequestAndConfig(
+      commands::Request::default_instance(),
+      config::ConfigHandler::DefaultConfig());
+  table->AddRule("v.", "…", "");
+  session.SetTable(table);
+
+  commands::Command command;
+  InsertCharacterChars("kyouhav", &session, &command);
+  ASSERT_EQ(session.context().composer().GetQueryForConversion(), "きょうはv");
+
+  session_peer.context_()->set_state(ImeContext::COMPOSITION);
+  session_peer.live_conversion_pending_() = true;
+  session_peer.live_conversion_key_() = "きょうは";
+  session_peer.live_conversion_preedit_() = "きょうは";
+  session_peer.live_conversion_value_() = "今日は";
+
+  commands::Preedit& live_preedit =
+      session_peer.live_conversion_preedit_output_();
+  live_preedit.Clear();
+
+  commands::Preedit::Segment* segment = live_preedit.add_segment();
+  segment->set_key("きょうは");
+  segment->set_value("今日は");
+  segment->set_value_length(Util::CharsLen("今日は"));
+
+  command.Clear();
+  ASSERT_TRUE(SendKey(".", &session, &command));
+
+  EXPECT_TRUE(command.output().live_conversion());
+  EXPECT_TRUE(command.output().live_conversion_pending());
+  EXPECT_PREEDIT("今日は…", command);
+  EXPECT_EQ(session.context().state(), ImeContext::COMPOSITION);
+}
+
+TEST_F(SessionTest,
+       PendingLiveConversionKeepsConvertedPrefixForRomajiTwoDotLeader) {
+  MockEngine engine;
+  std::shared_ptr<MockConverter> converter = CreateEngineConverterMock(&engine);
+
+  Session session(engine);
+  SessionTestPeer session_peer(session);
+  InitSessionToPrecomposition(&session);
+
+  config::Config config;
+  config::ConfigHandler::GetDefaultConfig(&config);
+  config.set_use_live_conversion(true);
+  config.set_use_direct_commit(true);
+  config.set_direct_commit_key(config::Config::DIRECT_COMMIT_TOUTEN);
+  session.SetConfig(config);
+
+  auto table = std::make_shared<composer::Table>();
+  table->InitializeWithRequestAndConfig(
+      commands::Request::default_instance(),
+      config::ConfigHandler::DefaultConfig());
+  table->AddRule("v,", "‥", "");
+  session.SetTable(table);
+
+  commands::Command command;
+  InsertCharacterChars("kyouhav", &session, &command);
+  ASSERT_EQ(session.context().composer().GetQueryForConversion(), "きょうはv");
+
+  session_peer.context_()->set_state(ImeContext::COMPOSITION);
+  session_peer.live_conversion_pending_() = true;
+  session_peer.live_conversion_key_() = "きょうは";
+  session_peer.live_conversion_preedit_() = "きょうは";
+  session_peer.live_conversion_value_() = "今日は";
+
+  commands::Preedit& live_preedit =
+      session_peer.live_conversion_preedit_output_();
+  live_preedit.Clear();
+
+  commands::Preedit::Segment* segment = live_preedit.add_segment();
+  segment->set_key("きょうは");
+  segment->set_value("今日は");
+  segment->set_value_length(Util::CharsLen("今日は"));
+
+  command.Clear();
+  ASSERT_TRUE(SendKey(",", &session, &command));
+
+  EXPECT_TRUE(command.output().live_conversion());
+  EXPECT_TRUE(command.output().live_conversion_pending());
+  EXPECT_PREEDIT("今日は‥", command);
+  EXPECT_EQ(session.context().state(), ImeContext::COMPOSITION);
+}
 
 TEST_F(SessionTest,
        LiveConversionShiftAsciiCommitsVisibleResultBeforeAsciiInput) {


### PR DESCRIPTION
## Summary #56

This PR fixes two live conversion edge cases.

1. When Shift-based ASCII input starts while a live conversion result is visible, Mozkey now commits the visible live conversion result first, then starts ASCII input.
2. When a romaji-table rule such as `v. -> …` or `v, -> ‥` is completed while delayed live conversion is pending, Mozkey now keeps the already visible live-converted prefix instead of falling back to raw kana.

It also updates README documentation for these live conversion edge cases.

## Details

### Commit visible live conversion before Shift ASCII input

Before this change, typing Shift-based ASCII while live conversion was active could continue editing the underlying composition instead of preserving the visible converted result.

For example, after `きょう` was live-converted to `今日`, typing `A` with Shift could fail to preserve the visible live conversion result cleanly.

This PR adds a guard for Shift ASCII input and commits the currently visible live conversion result before inserting the ASCII character.

### Keep live-converted prefix for romaji ellipsis rules

When delayed live conversion was pending, a physical key such as `.` or `,` could be treated as a direct-commit trigger before insertion.

However, custom romaji-table rules may transform those physical keys into non-direct-commit characters, for example:

- `v. -> …`
- `v, -> ‥`

In that case, the old fallback path cancelled pending live conversion and immediately output raw composition. This caused cases like:

```text
今日は…
```

to temporarily fall back to:

```text
きょうは…
```

This PR changes that fallback to reschedule live conversion first, so the stable live-converted prefix is preserved.

It also treats `‥` as a decorative trailing symbol for live conversion suppression logic, matching the existing treatment of `…`.

## Tests

Passed:

```powershell
bazelisk --output_user_root=C:/bzl test `
  --config oss_windows `
  --config release_build `
  //session:session_test `
  --test_filter=SessionTest.PendingLiveConversionKeepsConvertedPrefixForRomaji* `
  --test_output=errors
```

Passed:

```powershell
bazelisk --output_user_root=C:/bzl test `
  --config oss_windows `
  --config release_build `
  //session:session_test `
  --test_output=errors
```
