### PR TITLE
Fix/live conversion expressive kana

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Windows 用のビルド済み MSI は [Releases](https://github.com/koyasi777/mo
 - ライブ変換は入力直後の不要な変換ちらつきを抑えるため、文字入力後に短いデバウンスを挟んで実行
 - 1文字だけの未確定文字列では、助詞などの誤変換を避けるためライブ変換を実行しない
 - `え~`、`えー`、`ん？` のような「かな1文字 + 装飾的な末尾記号」でも、短すぎる漢字化を避けるためライブ変換を抑制
+- `ふん`、`ふむ`、`はて`、`うひょー`、`すっごい`、`なっがい`、`めっちゃ`、`ちーっす`、`ちょりーっす` のような感嘆詞・口語評価語・くだけた挨拶が、ライブ変換中に不自然な漢字やカタカナへ寄る挙動を抑制
 - 確定済みの左文脈や直前の文節、限定的な右文脈を参照し、`mainにマージしました`、`githubには`、`2名しかいない`、`追記したい`、`山梨県立美術館`、`滋賀方面` のような文脈で、助詞・複合機能語・機能表現・接尾的な語構成・地名接尾構成が同音漢字候補に負ける挙動を抑制
 - キー設定エディタで、1つのキー入力に対して複数のコマンドを順序付きで割り当て可能
 - 複数コマンドは `Commit|IMEOff` のような形式で保存され、設定画面では `Commit → IMEOff` のように編集可能
@@ -170,6 +171,18 @@ Windows 版では、追加のオフライン防御層として、インストー
 入力途中の不要な中間変換表示を抑えるため、この fork では文字入力後に短い設定可能なデバウンス時間を挟んでからライブ変換を実行します。`に`、`を`、`が` のような助詞として使われやすい入力を誤って漢字化しないように、1文字だけの未確定文字列ではライブ変換を行いません。
 
 また、`え~`、`えー`、`ん？` のように、かな1文字の後ろに装飾的な記号だけが続く場合もライブ変換を抑制します。これにより、入力途中の `え~` が `絵～` のように短すぎる漢字候補へ変換される挙動を避けます。
+
+さらに、短い感嘆詞、口語的な評価語、くだけた挨拶など、ひらがなのまま使われることが多い表現では、ライブ変換による過剰な漢字化・カタカナ化を抑制します。
+
+対象には、たとえば以下のような入力が含まれます。
+
+- `ふん`、`ふむ`、`はて`、`ほう`
+- `うひょー`、`うっひょーん`、`うっそん`
+- `すっごい`、`なっがい`、`たっかい`、`あっちぃ`
+- `めっちゃ`
+- `ちっす`、`ちーっす`、`ちょーっす`、`ちょりーっす`
+
+これらは通常変換そのものを禁止するものではありません。Space を押した場合は従来どおり変換候補を出せます。ライブ変換中だけ、入力途中の短い口語表現が意図せず別の漢字語やカタカナ語へ先走って表示されることを避けます。
 
 たとえば:
 
@@ -491,6 +504,7 @@ Main features added in this fork
 - Applies live conversion after a short debounce delay to avoid noisy intermediate conversions
 - Suppresses live conversion for one-character compositions to avoid over-converting particles
 - Suppresses live conversion for very short kana compositions with decorative trailing symbols such as `え~`, `えー`, or `ん？`
+- Suppresses over-eager live conversion for short expressive kana utterances, colloquial evaluative forms, and casual greetings such as `ふん`, `ふむ`, `うひょー`, `すっごい`, `なっがい`, `めっちゃ`, `ちーっす`, and `ちょりーっす`
 - Uses committed left context, previous segments, and limited right context to reduce unnatural homophone results in cases such as `mainにマージしました`, `githubには`, `2名しかいない`, `追記したい`, `山梨県立美術館`, and `滋賀方面`
 - Allows assigning multiple commands to a single key binding as an ordered command sequence
 - Stores command sequences as `Commit|IMEOff` and shows them in the keymap editor as `Commit → IMEOff`
@@ -561,6 +575,10 @@ With live conversion enabled, Mozc automatically converts the current compositio
 To reduce distracting intermediate conversions, this fork applies live conversion after a short configurable debounce delay instead of converting every character immediately. Single-character compositions are not live-converted, because they are often particles such as `に`, `を`, or `が`.
 
 Live conversion is also suppressed for very short kana compositions followed only by decorative trailing symbols, such as `え~`, `えー`, or `ん？`. This avoids noisy intermediate conversions such as `え~` becoming `絵～` while the user is still typing.
+
+This fork also keeps many short expressive kana utterances, colloquial evaluative forms, and casual greetings as kana during live conversion. Examples include `ふん`, `ふむ`, `はて`, `うひょー`, `うっそん`, `すっごい`, `なっがい`, `あっちぃ`, `めっちゃ`, `ちーっす`, and `ちょりーっす`.
+
+This does not disable normal conversion. Pressing Space still invokes ordinary conversion candidates. The suppression only prevents live conversion from prematurely showing unnatural kanji or katakana results while the user is still composing these short colloquial expressions.
 
 For example:
 

--- a/src/session/session.cc
+++ b/src/session/session.cc
@@ -47,6 +47,7 @@
 #include "absl/strings/string_view.h"
 #include "absl/time/time.h"
 #include "base/clock.h"
+#include "base/strings/unicode.h"
 #include "base/util.h"
 #include "composer/composer.h"
 #include "composer/key_event_util.h"
@@ -225,9 +226,963 @@ bool IsLiveConversionTrailingDecorativeSymbol(char32_t c) {
   }
 }
 
-bool ShouldSkipLiveConversionForCompositionKey(absl::string_view key) {
+enum class LiveConversionLeftBoundary {
+  kKnownBoundary,
+  kKnownNonBoundary,
+  kUnknown,
+};
+
+struct LiveConversionAtom {
+  absl::string_view text;
+  bool is_entire_composition = false;
+  LiveConversionLeftBoundary left_boundary =
+      LiveConversionLeftBoundary::kUnknown;
+};
+
+bool ContainsStringView(std::initializer_list<absl::string_view> values,
+                        absl::string_view target) {
+  for (absl::string_view value : values) {
+    if (value == target) {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool IsLiveConversionAtomBoundaryChar(char32_t c) {
+  switch (c) {
+    case 0x0009:  // tab
+    case 0x000A:  // LF
+    case 0x000D:  // CR
+    case 0x0020:  // space
+    case 0x3000:  // ideographic space
+    case 0x002C:  // ,
+    case 0xFF0C:  // ，
+    case 0x3001:  // 、
+    case 0x002E:  // .
+    case 0xFF0E:  // ．
+    case 0x3002:  // 。
+    case 0x0021:  // !
+    case 0xFF01:  // ！
+    case 0x003F:  // ?
+    case 0xFF1F:  // ？
+    case 0x2025:  // ‥
+    case 0x2026:  // …
+    case 0x003A:  // :
+    case 0xFF1A:  // ：
+    case 0x003B:  // ;
+    case 0xFF1B:  // ；
+    case 0x0028:  // (
+    case 0xFF08:  // （
+    case 0x005B:  // [
+    case 0x007B:  // {
+    case 0x300C:  // 「
+    case 0x300D:  // 」
+    case 0x300E:  // 『
+    case 0x300F:  // 』
+    case 0x3010:  // 【
+    case 0x3011:  // 】
+    case 0x3014:  // 〔
+    case 0x3015:  // 〕
+    case 0x201C:  // “
+    case 0x201D:  // ”
+    case 0x2018:  // ‘
+    case 0x2019:  // ’
+      return true;
+    default:
+      return false;
+  }
+}
+
+bool IsLiveConversionTrailingSentenceTailSymbol(char32_t c) {
+  switch (c) {
+    case 0x0009:  // tab
+    case 0x000A:  // LF
+    case 0x000D:  // CR
+    case 0x0020:  // space
+    case 0x3000:  // ideographic space
+    case 0x002C:  // ,
+    case 0xFF0C:  // ，
+    case 0x3001:  // 、
+    case 0x002E:  // .
+    case 0xFF0E:  // ．
+    case 0x3002:  // 。
+    case 0x0021:  // !
+    case 0xFF01:  // ！
+    case 0x003F:  // ?
+    case 0xFF1F:  // ？
+    case 0x2025:  // ‥
+    case 0x2026:  // …
+    case 0x003A:  // :
+    case 0xFF1A:  // ：
+    case 0x003B:  // ;
+    case 0xFF1B:  // ；
+    case 0x0029:  // )
+    case 0xFF09:  // ）
+    case 0x005D:  // ]
+    case 0x007D:  // }
+    case 0x300D:  // 」
+    case 0x300F:  // 』
+    case 0x3011:  // 】
+    case 0x3015:  // 〕
+    case 0x201D:  // ”
+    case 0x2019:  // ’
+      return true;
+    default:
+      return false;
+  }
+}
+
+bool IsLiveConversionProlongationMark(char32_t c) {
+  switch (c) {
+    case 0x007E:  // ~
+    case 0xFF5E:  // ～
+    case 0x301C:  // 〜
+    case 0x30FC:  // ー
+    case 0x2015:  // ―
+      return true;
+    default:
+      return false;
+  }
+}
+
+absl::string_view StripTrailingLiveConversionSentenceTail(
+    absl::string_view key) {
+  absl::string_view core = key;
+
+  while (!core.empty()) {
+    absl::string_view rest;
+    char32_t last = 0;
+    if (!Util::SplitLastChar32(core, &rest, &last)) {
+      break;
+    }
+    if (!IsLiveConversionTrailingSentenceTailSymbol(last)) {
+      break;
+    }
+    core = rest;
+  }
+
+  return core;
+}
+
+absl::string_view StripTrailingLiveConversionProlongationMarks(
+    absl::string_view key) {
+  absl::string_view core = key;
+
+  while (!core.empty()) {
+    absl::string_view rest;
+    char32_t last = 0;
+    if (!Util::SplitLastChar32(core, &rest, &last)) {
+      break;
+    }
+    if (!IsLiveConversionProlongationMark(last)) {
+      break;
+    }
+    core = rest;
+  }
+
+  return core;
+}
+
+LiveConversionLeftBoundary GetLiveConversionCommittedLeftBoundary(
+    const ImeContext& context) {
+  if (!context.client_context().has_preceding_text()) {
+    return LiveConversionLeftBoundary::kUnknown;
+  }
+
+  const std::string& preceding_text =
+      context.client_context().preceding_text();
+  if (preceding_text.empty()) {
+    return LiveConversionLeftBoundary::kKnownBoundary;
+  }
+
+  absl::string_view rest;
+  char32_t last = 0;
+  if (!Util::SplitLastChar32(preceding_text, &rest, &last)) {
+    return LiveConversionLeftBoundary::kUnknown;
+  }
+
+  return IsLiveConversionAtomBoundaryChar(last)
+             ? LiveConversionLeftBoundary::kKnownBoundary
+             : LiveConversionLeftBoundary::kKnownNonBoundary;
+}
+
+LiveConversionAtom ExtractTrailingLiveConversionAtom(
+    absl::string_view core,
+    LiveConversionLeftBoundary committed_left_boundary) {
+  LiveConversionAtom atom;
+  atom.text = core;
+  atom.is_entire_composition = true;
+  atom.left_boundary = committed_left_boundary;
+
+  absl::string_view cursor = core;
+  while (!cursor.empty()) {
+    absl::string_view rest;
+    char32_t last = 0;
+    if (!Util::SplitLastChar32(cursor, &rest, &last)) {
+      break;
+    }
+
+    if (IsLiveConversionAtomBoundaryChar(last)) {
+      atom.text =
+          absl::string_view(core.data() + cursor.size(),
+                            core.size() - cursor.size());
+      atom.is_entire_composition = false;
+      atom.left_boundary = LiveConversionLeftBoundary::kKnownBoundary;
+      return atom;
+    }
+
+    cursor = rest;
+  }
+
+  return atom;
+}
+
+bool IsStrongExpressiveKanaAtom(absl::string_view atom) {
+  return ContainsStringView(
+      {
+          "あっ",
+          "えっ",
+          "おっ",
+          "はっ",
+          "へっ",
+          "ちっ",
+          "ちぇっ",
+          "ほっ",
+          "いてっ",
+          "ぎゃっ",
+          "ひゃっ",
+      },
+      atom);
+}
+
+bool IsBoundarySensitiveExpressiveKanaAtom(absl::string_view atom) {
+  return ContainsStringView(
+      {
+          "ふん",
+          "くそ",
+          "よう",
+          "ふむ",
+          "はて",
+          "ふう",
+          "ほう",
+          "はいはい",
+          "うん",
+          "うんうん",
+          "そうそう",
+          "いやいや",
+          "まあまあ",
+      },
+      atom);
+}
+
+constexpr size_t kMaxRepeatedEInterjectionChars = 30;
+
+bool IsRepeatedEInterjectionAtom(absl::string_view atom) {
+  size_t count = 0;
+
+  for (absl::string_view c : Utf8AsChars(atom)) {
+    if (c != "え" && c != "ぇ") {
+      return false;
+    }
+    ++count;
+    if (count > kMaxRepeatedEInterjectionChars) {
+      return false;
+    }
+  }
+
+  return count >= 2;
+}
+
+bool IsHoFamilyExpressiveProsodyAtom(absl::string_view atom) {
+  return ContainsStringView(
+      {
+          "ほー",
+          "ほ〜",
+          "ほ～",
+          "ほお",
+          "ほほう",
+          "ほほお",
+          "ほほー",
+          "ほほ〜",
+          "ほほ～",
+          "ほほーん",
+          "ほほ〜ん",
+          "ほほ～ん",
+          "ほっほ",
+          "ほっほう",
+          "ほっほお",
+          "ほっほー",
+          "ほっほ〜",
+          "ほっほ～",
+          "ほっほーん",
+          "ほっほ〜ん",
+          "ほっほ～ん",
+      },
+      atom);
+}
+
+constexpr size_t kMaxExpressiveSokuonCount = 10;
+constexpr size_t kMaxEvaluativeSlangPrefixChars = 4;
+
+bool ConsumePrefixForLiveConversionMatcher(absl::string_view* text,
+                                           absl::string_view prefix) {
+  if (text->size() < prefix.size() ||
+      text->substr(0, prefix.size()) != prefix) {
+    return false;
+  }
+  *text = text->substr(prefix.size());
+  return true;
+}
+
+bool IsOnlyLiveConversionProlongationMarks(absl::string_view text) {
+  if (text.empty()) {
+    return false;
+  }
+
+  while (!text.empty()) {
+    absl::string_view rest;
+    char32_t last = 0;
+    if (!Util::SplitLastChar32(text, &rest, &last)) {
+      return false;
+    }
+    if (!IsLiveConversionProlongationMark(last)) {
+      return false;
+    }
+    text = rest;
+  }
+
+  return true;
+}
+
+bool IsLiveConversionProlongationMarksWithOptionalN(
+    absl::string_view text) {
+  if (text == "ん") {
+    return true;
+  }
+
+  absl::string_view rest;
+  char32_t last = 0;
+  if (!Util::SplitLastChar32(text, &rest, &last)) {
+    return false;
+  }
+
+  return last == U'ん' && IsOnlyLiveConversionProlongationMarks(rest);
+}
+
+bool IsLiveConversionProlongationMarksWithOptionalI(
+    absl::string_view text) {
+  if (text == "い") {
+    return true;
+  }
+
+  absl::string_view rest;
+  char32_t last = 0;
+  if (!Util::SplitLastChar32(text, &rest, &last)) {
+    return false;
+  }
+
+  return last == U'い' && IsOnlyLiveConversionProlongationMarks(rest);
+}
+
+bool ConsumeRepeatedExpressiveSokuon(absl::string_view* text) {
+  size_t sokuon_count = 0;
+
+  while (ConsumePrefixForLiveConversionMatcher(text, "っ")) {
+    ++sokuon_count;
+    if (sokuon_count > kMaxExpressiveSokuonCount) {
+      return false;
+    }
+  }
+
+  return sokuon_count > 0;
+}
+
+bool MatchesRepeatedSokuonPrefix(absl::string_view atom,
+                                 absl::string_view head) {
+  absl::string_view rest = atom;
+
+  if (!ConsumePrefixForLiveConversionMatcher(&rest, head)) {
+    return false;
+  }
+
+  if (!ConsumeRepeatedExpressiveSokuon(&rest)) {
+    return false;
+  }
+
+  return rest.empty();
+}
+
+constexpr size_t kMaxCasualGreetingProlongedTailChars = 30;
+
+bool IsLiveConversionProlongationMarkText(absl::string_view text) {
+  absl::string_view rest;
+  char32_t c = 0;
+  return Util::SplitLastChar32(text, &rest, &c) &&
+         rest.empty() &&
+         IsLiveConversionProlongationMark(c);
+}
+
+bool IsCasualGreetingProlongedTail(absl::string_view text) {
+  size_t count = 0;
+
+  for (absl::string_view c : Utf8AsChars(text)) {
+    if (c != "い" && c != "ぃ" &&
+        !IsLiveConversionProlongationMarkText(c)) {
+      return false;
+    }
+    ++count;
+    if (count > kMaxCasualGreetingProlongedTailChars) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+bool IsPendingRomanSForCasualSsuGreeting(absl::string_view text) {
+  return text == "s" || text == "ss";
+}
+
+bool IsCasualGreetingProlongedTailWithPendingRomanS(
+    absl::string_view text) {
+  if (text.empty()) {
+    return false;
+  }
+
+  if (IsPendingRomanSForCasualSsuGreeting(text)) {
+    return true;
+  }
+
+  if (text.ends_with("ss")) {
+    return IsCasualGreetingProlongedTail(
+        text.substr(0, text.size() - 2));
+  }
+
+  if (text.ends_with("s")) {
+    return IsCasualGreetingProlongedTail(
+        text.substr(0, text.size() - 1));
+  }
+
+  return IsCasualGreetingProlongedTail(text);
+}
+
+bool MatchesCasualSsuGreetingAtom(absl::string_view atom,
+                                  absl::string_view head) {
+  absl::string_view rest = atom;
+
+  if (!ConsumePrefixForLiveConversionMatcher(&rest, head)) {
+    return false;
+  }
+
+  const size_t sokuon_pos = rest.find("っ");
+  if (sokuon_pos == absl::string_view::npos) {
+    return false;
+  }
+
+  if (!IsCasualGreetingProlongedTail(rest.substr(0, sokuon_pos))) {
+    return false;
+  }
+
+  rest = rest.substr(sokuon_pos);
+
+  if (!ConsumeRepeatedExpressiveSokuon(&rest)) {
+    return false;
+  }
+
+  if (!ConsumePrefixForLiveConversionMatcher(&rest, "す")) {
+    return false;
+  }
+
+  return rest.empty() || IsOnlyLiveConversionProlongationMarks(rest);
+}
+
+bool IsCasualSsuGreetingAtom(absl::string_view atom) {
+  return MatchesCasualSsuGreetingAtom(atom, "ち") ||
+         MatchesCasualSsuGreetingAtom(atom, "ちょ") ||
+         MatchesCasualSsuGreetingAtom(atom, "ちょり");
+}
+
+bool MatchesCasualSsuGreetingPrefixAtom(absl::string_view atom,
+                                        absl::string_view head,
+                                        bool allow_bare_head) {
+  absl::string_view rest = atom;
+
+  if (!ConsumePrefixForLiveConversionMatcher(&rest, head)) {
+    return false;
+  }
+
+  if (allow_bare_head && rest.empty()) {
+    return true;
+  }
+
+  const size_t sokuon_pos = rest.find("っ");
+  if (sokuon_pos == absl::string_view::npos) {
+    return !rest.empty() &&
+           IsCasualGreetingProlongedTailWithPendingRomanS(rest);
+  }
+
+  if (!IsCasualGreetingProlongedTail(rest.substr(0, sokuon_pos))) {
+    return false;
+  }
+
+  rest = rest.substr(sokuon_pos);
+
+  if (!ConsumeRepeatedExpressiveSokuon(&rest)) {
+    return false;
+  }
+
+  return rest.empty() || IsPendingRomanSForCasualSsuGreeting(rest);
+}
+
+bool IsCasualSsuGreetingPrefixAtom(absl::string_view atom) {
+  return MatchesCasualSsuGreetingPrefixAtom(
+             atom, "ち", /*allow_bare_head=*/false) ||
+         MatchesCasualSsuGreetingPrefixAtom(
+             atom, "ちょ", /*allow_bare_head=*/true) ||
+         atom == "ちょr" ||
+         atom == "ちょri" ||
+         MatchesCasualSsuGreetingPrefixAtom(
+             atom, "ちょり", /*allow_bare_head=*/true);
+}
+
+enum class EvaluativeSlangTailType {
+  kNone,
+  kOptionalI,
+  kOptionalEe,
+  kRequiredIi,
+};
+
+struct RepeatedSokuonStemPattern {
+  absl::string_view head;
+  absl::string_view body;
+  EvaluativeSlangTailType tail_type;
+};
+
+constexpr size_t kMaxEvaluativeSlangVowelTailChars = 30;
+
+bool IsRepeatedKanaVowelTail(absl::string_view text,
+                             absl::string_view large,
+                             absl::string_view small_kana) {
+  size_t count = 0;
+
+  for (absl::string_view c : Utf8AsChars(text)) {
+    if (c != large && c != small_kana) {
+      return false;
+    }
+    ++count;
+    if (count > kMaxEvaluativeSlangVowelTailChars) {
+      return false;
+    }
+  }
+
+  return count > 0;
+}
+
+bool MatchesEvaluativeSlangTail(absl::string_view rest,
+                                EvaluativeSlangTailType tail_type) {
+  switch (tail_type) {
+    case EvaluativeSlangTailType::kNone:
+      return rest.empty();
+
+    case EvaluativeSlangTailType::kOptionalI:
+      return rest.empty() || rest == "い";
+
+    case EvaluativeSlangTailType::kOptionalEe:
+      return rest.empty() || rest == "ー" ||
+             IsRepeatedKanaVowelTail(rest, "え", "ぇ");
+
+    case EvaluativeSlangTailType::kRequiredIi:
+      return rest == "ー" || IsRepeatedKanaVowelTail(rest, "い", "ぃ");
+  }
+
+  return false;
+}
+
+bool MatchesRepeatedSokuonStemPattern(
+    absl::string_view atom,
+    const RepeatedSokuonStemPattern& pattern) {
+  absl::string_view rest = atom;
+
+  if (!ConsumePrefixForLiveConversionMatcher(&rest, pattern.head)) {
+    return false;
+  }
+
+  if (!ConsumeRepeatedExpressiveSokuon(&rest)) {
+    return false;
+  }
+
+  if (!ConsumePrefixForLiveConversionMatcher(&rest, pattern.body)) {
+    return false;
+  }
+
+  return MatchesEvaluativeSlangTail(rest, pattern.tail_type);
+}
+
+const RepeatedSokuonStemPattern kEvaluativeSlangPatterns[] = {
+    // やばい / やべぇ
+    {"や", "ば", EvaluativeSlangTailType::kOptionalI},
+    {"や", "べ", EvaluativeSlangTailType::kOptionalEe},
+
+    // すごい / すげぇ / 少ない口語形 / 酸っぱい口語形
+    {"す", "ご", EvaluativeSlangTailType::kOptionalI},
+    {"す", "げ", EvaluativeSlangTailType::kOptionalEe},
+    {"す", "くな", EvaluativeSlangTailType::kOptionalI},
+    {"す", "くね", EvaluativeSlangTailType::kOptionalEe},
+    {"す", "ぱ", EvaluativeSlangTailType::kNone},
+    {"す", "ぺ", EvaluativeSlangTailType::kOptionalEe},
+
+    // 怖い / 強い / 辛い
+    {"こ", "わ", EvaluativeSlangTailType::kOptionalI},
+    {"つ", "よ", EvaluativeSlangTailType::kOptionalI},
+    {"つ", "ら", EvaluativeSlangTailType::kOptionalI},
+    {"つ", "れ", EvaluativeSlangTailType::kOptionalEe},
+
+    // でかい / 長い / 高い / 高ぇ
+    {"で", "か", EvaluativeSlangTailType::kOptionalI},
+    {"な", "が", EvaluativeSlangTailType::kOptionalI},
+    {"た", "か", EvaluativeSlangTailType::kOptionalI},
+    {"た", "け", EvaluativeSlangTailType::kOptionalEe},
+
+    // 小さい / 小っちゃい / 小せぇ
+    {"ち", "さ", EvaluativeSlangTailType::kOptionalI},
+    {"ち", "ちゃ", EvaluativeSlangTailType::kOptionalI},
+    {"ち", "せ", EvaluativeSlangTailType::kOptionalEe},
+
+    // 低い / 広い
+    {"ひ", "く", EvaluativeSlangTailType::kOptionalI},
+    {"ひ", "ろ", EvaluativeSlangTailType::kOptionalI},
+
+    // 寒い / 寒ぃ
+    {"さ", "む", EvaluativeSlangTailType::kOptionalI},
+    {"さ", "み", EvaluativeSlangTailType::kRequiredIi},
+
+    // 暑い / 熱い / あっちぃ
+    {"あ", "つ", EvaluativeSlangTailType::kOptionalI},
+    {"あ", "ち", EvaluativeSlangTailType::kRequiredIi},
+
+    // うまい / うめぇ / うざい / うぜぇ / 薄い
+    {"う", "ま", EvaluativeSlangTailType::kOptionalI},
+    {"う", "め", EvaluativeSlangTailType::kOptionalEe},
+    {"う", "ざ", EvaluativeSlangTailType::kOptionalI},
+    {"う", "ぜ", EvaluativeSlangTailType::kOptionalEe},
+    {"う", "す", EvaluativeSlangTailType::kOptionalI},
+
+    // 軽い
+    {"か", "る", EvaluativeSlangTailType::kOptionalI},
+
+    // きつい / きちぃ / きもい / きれい
+    {"き", "つ", EvaluativeSlangTailType::kOptionalI},
+    {"き", "ち", EvaluativeSlangTailType::kRequiredIi},
+    {"き", "も", EvaluativeSlangTailType::kOptionalI},
+    {"き", "れい", EvaluativeSlangTailType::kNone},
+
+    // だるい / だりぃ / ださい / だせぇ
+    {"だ", "る", EvaluativeSlangTailType::kOptionalI},
+    {"だ", "り", EvaluativeSlangTailType::kRequiredIi},
+    {"だ", "さ", EvaluativeSlangTailType::kOptionalI},
+    {"だ", "せ", EvaluativeSlangTailType::kOptionalEe},
+
+    // えぐい
+    {"え", "ぐ", EvaluativeSlangTailType::kOptionalI},
+
+    // 臭い / くせぇ / 黒い
+    {"く", "さ", EvaluativeSlangTailType::kOptionalI},
+    {"く", "せ", EvaluativeSlangTailType::kOptionalEe},
+    {"く", "ろ", EvaluativeSlangTailType::kOptionalI},
+
+    // まぶしい
+    {"ま", "ぶし", EvaluativeSlangTailType::kOptionalI},
+
+    // 重い / 遅い / 早い
+    {"お", "も", EvaluativeSlangTailType::kOptionalI},
+    {"お", "そ", EvaluativeSlangTailType::kOptionalI},
+    {"は", "や", EvaluativeSlangTailType::kOptionalI},
+
+    // めっちゃ
+    {"め", "ちゃ", EvaluativeSlangTailType::kNone},
+
+    // 眠い / 細い / 狭い / 短い / 白い
+    {"ね", "む", EvaluativeSlangTailType::kOptionalI},
+    {"ほ", "そ", EvaluativeSlangTailType::kOptionalI},
+    {"せ", "ま", EvaluativeSlangTailType::kOptionalI},
+    {"み", "じか", EvaluativeSlangTailType::kOptionalI},
+    {"し", "ろ", EvaluativeSlangTailType::kOptionalI},
+};
+
+bool IsEvaluativeSlangAdjectiveAtom(absl::string_view atom) {
+  for (const RepeatedSokuonStemPattern& pattern :
+       kEvaluativeSlangPatterns) {
+    if (MatchesRepeatedSokuonStemPattern(atom, pattern)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+bool IsEvaluativeSlangAdjectivePrefixAtom(absl::string_view atom) {
+  for (const RepeatedSokuonStemPattern& pattern :
+       kEvaluativeSlangPatterns) {
+    if (MatchesRepeatedSokuonPrefix(atom, pattern.head)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+bool MatchesUsoOrKusoFamilyExpressiveProsodyAtom(
+    absl::string_view atom,
+    absl::string_view head,
+    bool allow_n_tail) {
+  absl::string_view rest = atom;
+
+  if (!ConsumePrefixForLiveConversionMatcher(&rest, head)) {
+    return false;
+  }
+
+  if (!ConsumeRepeatedExpressiveSokuon(&rest)) {
+    return false;
+  }
+
+  if (!ConsumePrefixForLiveConversionMatcher(&rest, "そ")) {
+    return false;
+  }
+
+  if (rest.empty()) {
+    return true;
+  }
+
+  if (IsOnlyLiveConversionProlongationMarks(rest)) {
+    return true;
+  }
+
+  if (allow_n_tail &&
+      IsLiveConversionProlongationMarksWithOptionalN(rest)) {
+    return true;
+  }
+
+  return false;
+}
+
+bool IsUsoOrKusoFamilyExpressiveProsodyAtom(absl::string_view atom) {
+  // Match 「うっそ」「うっっそ」「うっそー」「うっそん」 etc.
+  // Do not match bare 「うそ」 or 「うっそう」 because 「嘘」 and 「鬱蒼」
+  // are useful live-conversion targets.
+  if (MatchesUsoOrKusoFamilyExpressiveProsodyAtom(
+          atom, "う", /*allow_n_tail=*/true)) {
+    return true;
+  }
+
+  // Match 「くっそ」「くっっそ」「くっそー」 etc.  Keep bare 「くそ」
+  // in the boundary-sensitive lexical list, and do not match 「くそう」.
+  return MatchesUsoOrKusoFamilyExpressiveProsodyAtom(
+      atom, "く", /*allow_n_tail=*/false);
+}
+
+bool IsUsoOrKusoFamilyExpressiveProsodyPrefixAtom(
+    absl::string_view atom) {
+  return MatchesRepeatedSokuonPrefix(atom, "う") ||
+         MatchesRepeatedSokuonPrefix(atom, "く");
+}
+
+bool MatchesUhyoFamilyExpressiveProsodyAtom(absl::string_view atom) {
+  absl::string_view rest = atom;
+
+  if (!ConsumePrefixForLiveConversionMatcher(&rest, "う")) {
+    return false;
+  }
+
+  // Accept both 「うひょ」 and emphasized forms such as 「うっひょ」 and
+  // 「うっっひょ」.
+  if (!ConsumePrefixForLiveConversionMatcher(&rest, "ひょ")) {
+    if (!ConsumeRepeatedExpressiveSokuon(&rest)) {
+      return false;
+    }
+    if (!ConsumePrefixForLiveConversionMatcher(&rest, "ひょ")) {
+      return false;
+    }
+  }
+
+  if (rest.empty()) {
+    return true;
+  }
+
+  if (IsOnlyLiveConversionProlongationMarks(rest)) {
+    return true;
+  }
+
+  if (IsLiveConversionProlongationMarksWithOptionalN(rest)) {
+    return true;
+  }
+
+  if (IsLiveConversionProlongationMarksWithOptionalI(rest)) {
+    return true;
+  }
+
+  return false;
+}
+
+bool IsUhyoFamilyExpressiveProsodyAtom(absl::string_view atom) {
+  return MatchesUhyoFamilyExpressiveProsodyAtom(atom);
+}
+
+bool IsUhyoFamilyExpressiveProsodyPrefixAtom(absl::string_view atom) {
+  absl::string_view rest = atom;
+
+  if (!ConsumePrefixForLiveConversionMatcher(&rest, "う")) {
+    return false;
+  }
+
+  if (rest == "ひ") {
+    return true;
+  }
+
+  if (!ConsumeRepeatedExpressiveSokuon(&rest)) {
+    return false;
+  }
+
+  return rest == "ひ";
+}
+
+bool FindEvaluativeSlangAdjectiveOrPrefixSuffix(
+    absl::string_view text,
+    absl::string_view* suffix) {
+  size_t offset = 0;
+  for (absl::string_view c : Utf8AsChars(text)) {
+    const absl::string_view candidate = text.substr(offset);
+    if (IsEvaluativeSlangAdjectiveAtom(candidate) ||
+        IsEvaluativeSlangAdjectivePrefixAtom(candidate)) {
+      *suffix = candidate;
+      return true;
+    }
+    offset += c.size();
+  }
+
+  return false;
+}
+
+bool HasShortPrefixBeforeSuffix(absl::string_view text,
+                                absl::string_view suffix,
+                                size_t max_prefix_chars) {
+  if (suffix.data() < text.data() ||
+      suffix.data() + suffix.size() > text.data() + text.size()) {
+    return false;
+  }
+
+  const size_t prefix_bytes = suffix.data() - text.data();
+  return Util::CharsLen(text.substr(0, prefix_bytes)) <= max_prefix_chars;
+}
+
+bool ShouldHoldEvaluativeSlangAdjectiveForLiveConversion(
+    const LiveConversionAtom& atom,
+    absl::string_view lexical_core) {
+  if (IsEvaluativeSlangAdjectiveAtom(atom.text) ||
+      IsEvaluativeSlangAdjectivePrefixAtom(atom.text)) {
+    // Evaluative slang such as 「やっば」「なっがい」 is often typed after
+    // already-committed context, e.g. 「これ」 + 「やっば」.  Keep the atom
+    // as kana when the whole current composition is the slang atom, or when
+    // it appears after a clear in-composition boundary.
+    return atom.is_entire_composition ||
+           atom.left_boundary == LiveConversionLeftBoundary::kKnownBoundary;
+  }
+
+  absl::string_view suffix;
+  if (!FindEvaluativeSlangAdjectiveOrPrefixSuffix(lexical_core, &suffix)) {
+    return false;
+  }
+
+  // Also protect short colloquial phrases such as 「これやっば」 and
+  // 「まじでなっがい」, including their typing prefixes such as 「これやっ」.
+  // Avoid suppressing live conversion for long sentences whose tail merely
+  // happens to be evaluative slang.
+  return HasShortPrefixBeforeSuffix(
+      lexical_core, suffix, kMaxEvaluativeSlangPrefixChars);
+}
+
+bool CanHoldLowAmbiguityExpressiveAtom(const LiveConversionAtom& atom) {
+  return atom.is_entire_composition ||
+         atom.left_boundary == LiveConversionLeftBoundary::kKnownBoundary;
+}
+
+bool CanHoldBoundarySensitiveExpressiveAtom(const LiveConversionAtom& atom) {
+  if (atom.left_boundary == LiveConversionLeftBoundary::kKnownNonBoundary) {
+    return false;
+  }
+
+  return atom.is_entire_composition ||
+         atom.left_boundary == LiveConversionLeftBoundary::kKnownBoundary;
+}
+
+bool ShouldHoldExpressiveKanaAtomForLiveConversion(
+    const LiveConversionAtom& atom,
+    absl::string_view expressive_core) {
+  if (atom.text.empty()) {
+    return false;
+  }
+
+  if (IsHoFamilyExpressiveProsodyAtom(atom.text) ||
+      IsUhyoFamilyExpressiveProsodyAtom(atom.text) ||
+      IsUhyoFamilyExpressiveProsodyPrefixAtom(atom.text) ||
+      IsUsoOrKusoFamilyExpressiveProsodyAtom(atom.text) ||
+      IsUsoOrKusoFamilyExpressiveProsodyPrefixAtom(atom.text) ||
+      IsCasualSsuGreetingAtom(atom.text) ||
+      IsCasualSsuGreetingPrefixAtom(atom.text)) {
+    return CanHoldLowAmbiguityExpressiveAtom(atom);
+  }
+
+  const absl::string_view lexical_atom =
+      StripTrailingLiveConversionProlongationMarks(atom.text);
+  const absl::string_view lexical_core =
+      StripTrailingLiveConversionProlongationMarks(expressive_core);
+
+  if (!lexical_atom.empty() &&
+      Util::IsScriptType(lexical_atom, Util::HIRAGANA)) {
+    if (IsRepeatedEInterjectionAtom(lexical_atom)) {
+      return CanHoldLowAmbiguityExpressiveAtom(atom);
+    }
+
+    if (IsStrongExpressiveKanaAtom(lexical_atom)) {
+      return CanHoldLowAmbiguityExpressiveAtom(atom);
+    }
+
+    if (IsBoundarySensitiveExpressiveKanaAtom(lexical_atom)) {
+      return CanHoldBoundarySensitiveExpressiveAtom(atom);
+    }
+  }
+
+  if (!lexical_core.empty() &&
+      Util::IsScriptType(lexical_core, Util::HIRAGANA) &&
+      ShouldHoldEvaluativeSlangAdjectiveForLiveConversion(atom,
+                                                          lexical_core)) {
+    return true;
+  }
+
+  return false;
+}
+
+bool ShouldSkipLiveConversionForCompositionKey(
+    absl::string_view key,
+    LiveConversionLeftBoundary committed_left_boundary) {
   if (Util::CharsLen(key) < kMinLiveConversionCompositionLength) {
     return true;
+  }
+
+  // First, protect short expressive utterance atoms before applying the legacy
+  // decorative-tail rule.  In particular, do not strip "ー" here; otherwise
+  // forms such as 「ほほー」 would collapse to 「ほほ」 and lose their expressive
+  // prosody.
+  const absl::string_view expressive_core =
+      StripTrailingLiveConversionSentenceTail(key);
+  if (!expressive_core.empty()) {
+    const LiveConversionAtom atom =
+        ExtractTrailingLiveConversionAtom(expressive_core,
+                                          committed_left_boundary);
+    if (ShouldHoldExpressiveKanaAtomForLiveConversion(atom,
+                                                      expressive_core)) {
+      return true;
+    }
   }
 
   absl::string_view core = key;
@@ -2802,7 +3757,9 @@ bool Session::MaybeStartLiveConversion(commands::Command* command) {
   const std::string live_conversion_key =
       context_->composer().GetQueryForConversion();
 
-  if (ShouldSkipLiveConversionForCompositionKey(live_conversion_key) ||
+  if (ShouldSkipLiveConversionForCompositionKey(
+          live_conversion_key,
+          GetLiveConversionCommittedLeftBoundary(*context_)) ||
       length != context_->composer().GetCursor()) {
     return false;
   }
@@ -2961,7 +3918,8 @@ bool Session::MaybeScheduleLiveConversion(commands::Command* command) {
   const size_t length = context_->composer().GetLength();
   const std::string key = context_->composer().GetQueryForConversion();
 
-  if (ShouldSkipLiveConversionForCompositionKey(key) ||
+  if (ShouldSkipLiveConversionForCompositionKey(
+          key, GetLiveConversionCommittedLeftBoundary(*context_)) ||
       length != context_->composer().GetCursor()) {
     return false;
   }
@@ -3041,7 +3999,9 @@ bool Session::ApplyDelayedLiveConversion(commands::Command* command) {
   }
 
   const size_t length = context_->composer().GetLength();
-  if (ShouldSkipLiveConversionForCompositionKey(current_key) ||
+  if (ShouldSkipLiveConversionForCompositionKey(
+          current_key,
+          GetLiveConversionCommittedLeftBoundary(*context_)) ||
       length != context_->composer().GetCursor()) {
     return IgnoreStaleDelayedLiveConversion(command);
   }
@@ -3061,7 +4021,9 @@ bool Session::FlushPendingLiveConversion() {
 
   const std::string current_key = context_->composer().GetQueryForConversion();
   if (current_key != pending_live_conversion_key_ ||
-      ShouldSkipLiveConversionForCompositionKey(current_key)) {
+      ShouldSkipLiveConversionForCompositionKey(
+          current_key,
+          GetLiveConversionCommittedLeftBoundary(*context_))) {
     CancelPendingLiveConversion();
     return false;
   }

--- a/src/session/session_test.cc
+++ b/src/session/session_test.cc
@@ -119,6 +119,7 @@ class SessionTestPeer : testing::TestPeer<Session> {
 namespace {
 using ::mozc::commands::Request;
 using ::testing::_;
+using ::testing::AtLeast;
 using ::testing::DoAll;
 using ::testing::Mock;
 using ::testing::Return;
@@ -1385,6 +1386,554 @@ TEST_F(SessionTest,
   EXPECT_TRUE(command.output().live_conversion_pending());
   EXPECT_PREEDIT("今日は‥", command);
   EXPECT_EQ(session.context().state(), ImeContext::COMPOSITION);
+}
+
+TEST_F(SessionTest, LiveConversionKeepsExpressiveKanaAtomsAsComposition) {
+  constexpr absl::string_view kExpressiveAtoms[] = {
+      "ふん",
+      "ちっ",
+      "ちぇっ",
+      "くそ",
+      "よう",
+      "ふむ",
+      "はて",
+      "ほっ",
+      "ふう",
+      "いてっ",
+      "ぎゃっ",
+      "ひゃっ",
+      "ほう",
+      "はいはい",
+      "ほっほーん",
+
+      "ちっす",
+      "ちっっす",
+      "ちーっす",
+      "ちぃーっす",
+      "ちぃーーっす",
+      "ちーっすー",
+      "ちょっす",
+      "ちょーっす",
+      "ちょーっすー",
+      "ちょりっす",
+      "ちょりーっす",
+      "ちょりーっすー",
+
+      "うひょ",
+      "うひょー",
+      "うひょーん",
+      "うっひょ",
+      "うっひょー",
+      "うっひょーん",
+      "うっっひょ",
+      "うっっひょーん",
+
+      "うっそん",
+      "うっっそ",
+      "うっっっそーん",
+      "くっそ",
+      "くっっそ",
+      "くっっっそー",
+
+      "やっば",
+      "やっっばい",
+      "やっべぇ",
+      "やっっべー",
+
+      "すっご",
+      "すっっごい",
+      "すっげぇ",
+      "すっっげー",
+      "すっくな",
+      "すっっくない",
+      "すっくね",
+      "すっっくねぇ",
+      "すっくねえ",
+      "すっくねー",
+      "すっぱ",
+      "すっっぱ",
+      "すっっっぱ",
+      "すっぱー",
+      "すっっぱー",
+      "すっぺぇ",
+      "すっっぺー",
+
+      "こっわ",
+      "こっっわい",
+
+      "つっよ",
+      "つっっよい",
+      "つっら",
+      "つっっらい",
+      "つっれぇ",
+      "つっっれー",
+
+      "でっか",
+      "でっっかい",
+
+      "なっが",
+      "なっっがい",
+
+      "たっか",
+      "たっっかい",
+      "たっけぇ",
+      "たっっけー",
+
+      "ちっさ",
+      "ちっっさい",
+      "ちっちゃ",
+      "ちっっちゃい",
+      "ちっせぇ",
+      "ちっっせー",
+
+      "ひっく",
+      "ひっっくい",
+      "ひっろ",
+      "ひっっろい",
+
+      "さっむ",
+      "さっっむい",
+      "さっみぃ",
+      "さっっみー",
+
+      "あっつ",
+      "あっっつい",
+      "あっちぃ",
+      "あっっちー",
+
+      "うっま",
+      "うっっまい",
+      "うっめぇ",
+      "うっっめー",
+      "うっざ",
+      "うっっざい",
+      "うっぜぇ",
+      "うっっぜー",
+      "うっす",
+      "うっっすい",
+
+      "かっる",
+      "かっっるい",
+
+      "きっつ",
+      "きっっつい",
+      "きっちぃ",
+      "きっっちー",
+      "きっも",
+      "きっっもい",
+      "きっれい",
+      "きっっれい",
+
+      "だっる",
+      "だっっるい",
+      "だっりぃ",
+      "だっっりー",
+      "だっさ",
+      "だっっさい",
+      "だっせぇ",
+      "だっっせー",
+
+      "えっぐ",
+      "えっっぐい",
+
+      "くっさ",
+      "くっっさい",
+      "くっせぇ",
+      "くっっせー",
+      "くっろ",
+      "くっっろい",
+
+      "まっぶし",
+      "まっっぶしい",
+
+      "おっも",
+      "おっっもい",
+      "おっそ",
+      "おっっそい",
+
+      "はっや",
+      "はっっやい",
+
+      "めっちゃ",
+      "めっっちゃ",
+
+      "ねっむ",
+      "ねっっむい",
+
+      "ほっそ",
+      "ほっっそい",
+
+      "せっま",
+      "せっっまい",
+
+      "みっじか",
+      "みっっじかい",
+
+      "しっろ",
+      "しっっろい",
+
+      "ええ",
+      "えぇ",
+      "ぇぇ",
+      "えぇぇ",
+      "えぇー",
+  };
+
+  for (absl::string_view expressive_atom : kExpressiveAtoms) {
+    MockEngine engine;
+    std::shared_ptr<MockConverter> converter =
+        CreateEngineConverterMock(&engine);
+
+    Session session(engine);
+    InitSessionToPrecomposition(&session);
+
+    config::Config config;
+    config::ConfigHandler::GetDefaultConfig(&config);
+    config.set_use_live_conversion(true);
+    config.set_live_conversion_delay_msec(0);
+    session.SetConfig(config);
+
+    std::vector<std::string> chars;
+    for (absl::string_view c : Utf8AsChars(expressive_atom)) {
+      chars.emplace_back(c);
+    }
+    ASSERT_GE(chars.size(), 2);
+
+    std::string prefix;
+    std::string prefix_key_codes;
+    for (size_t i = 0; i + 1 < chars.size(); ++i) {
+      prefix.append(chars[i]);
+      prefix_key_codes.push_back('a');
+    }
+
+    // Some prefixes such as 「ちぇ」「いて」「はいは」 are intentionally not
+    // covered by the prefix test.  This test verifies that the completed
+    // expressive atom is held as kana during live conversion.
+    EXPECT_CALL(*converter, StartConversion(_, _))
+        .Times(::testing::AnyNumber())
+        .WillRepeatedly(Return(false));
+
+    commands::Command command;
+    InsertCharacterString(prefix, prefix_key_codes, &session, &command);
+
+    Mock::VerifyAndClearExpectations(converter.get());
+
+    EXPECT_CALL(*converter, StartConversion(_, _)).Times(0);
+
+    command.Clear();
+    InsertCharacterString(chars.back(), "a", &session, &command);
+
+    EXPECT_EQ(session.context().composer().GetQueryForConversion(),
+              expressive_atom);
+    EXPECT_EQ(session.context().state(), ImeContext::COMPOSITION);
+    EXPECT_PREEDIT(expressive_atom, command);
+
+    Mock::VerifyAndClearExpectations(converter.get());
+  }
+}
+
+TEST_F(SessionTest, LiveConversionKeepsExpressiveKanaPrefixesAsComposition) {
+  constexpr absl::string_view kExpressivePrefixes[] = {
+      "うひ",
+      "うっひ",
+      "うっっひ",
+
+      "うっ",
+      "うっっ",
+      "くっ",
+      "くっっ",
+
+      "やっ",
+      "やっっ",
+      "すっ",
+      "すっっ",
+      "こっ",
+      "こっっ",
+      "つっ",
+      "つっっ",
+      "でっ",
+      "でっっ",
+      "なっ",
+      "なっっ",
+      "たっ",
+      "たっっ",
+      "ちっ",
+      "ちっっ",
+      "ひっ",
+      "ひっっ",
+      "さっ",
+      "さっっ",
+      "あっ",
+      "あっっ",
+      "かっ",
+      "かっっ",
+      "きっ",
+      "きっっ",
+      "だっ",
+      "だっっ",
+      "えっ",
+      "えっっ",
+      "まっ",
+      "まっっ",
+      "おっ",
+      "おっっ",
+      "はっ",
+      "はっっ",
+      "めっ",
+      "めっっ",
+      "ねっ",
+      "ねっっ",
+      "ほっ",
+      "ほっっ",
+      "せっ",
+      "せっっ",
+      "みっ",
+      "みっっ",
+      "しっ",
+      "しっっ",
+
+      "ちー",
+      "ちぃー",
+      "ちーっ",
+      "ちぃーっ",
+      "ちょ",
+      "ちょー",
+      "ちょーっ",
+      "ちょり",
+      "ちょりー",
+      "ちょりーっ",
+  };
+
+  for (absl::string_view expressive_prefix : kExpressivePrefixes) {
+    MockEngine engine;
+    std::shared_ptr<MockConverter> converter =
+        CreateEngineConverterMock(&engine);
+
+    Session session(engine);
+    InitSessionToPrecomposition(&session);
+
+    config::Config config;
+    config::ConfigHandler::GetDefaultConfig(&config);
+    config.set_use_live_conversion(true);
+    config.set_live_conversion_delay_msec(0);
+    session.SetConfig(config);
+
+    EXPECT_CALL(*converter, StartConversion(_, _)).Times(0);
+
+    commands::Command command;
+    const std::string dummy_key_codes(
+        Util::CharsLen(expressive_prefix), 'a');
+    InsertCharacterString(expressive_prefix, dummy_key_codes,
+                          &session, &command);
+
+    EXPECT_EQ(session.context().composer().GetQueryForConversion(),
+              expressive_prefix);
+    EXPECT_EQ(session.context().state(), ImeContext::COMPOSITION);
+    EXPECT_PREEDIT(expressive_prefix, command);
+
+    Mock::VerifyAndClearExpectations(converter.get());
+  }
+}
+
+TEST_F(SessionTest,
+       LiveConversionKeepsCasualSsuGreetingRomanPendingPrefixesAsComposition) {
+  struct TestCase {
+    absl::string_view kana_prefix;
+    absl::string_view roman_suffix;
+    absl::string_view expected_query;
+  };
+
+  constexpr TestCase kTestCases[] = {
+      {"ち", "ssu", "ちっす"},
+      {"ちー", "ssu", "ちーっす"},
+      {"ちぃー", "ssu", "ちぃーっす"},
+      {"ちょ", "r", "ちょr"},
+      {"ちょー", "ssu", "ちょーっす"},
+      {"ちょり", "ssu", "ちょりっす"},
+      {"ちょりー", "ssu", "ちょりーっす"},
+  };
+
+  for (const TestCase& test_case : kTestCases) {
+    MockEngine engine;
+    std::shared_ptr<MockConverter> converter =
+        CreateEngineConverterMock(&engine);
+
+    Session session(engine);
+    InitSessionToPrecomposition(&session);
+
+    config::Config config;
+    config::ConfigHandler::GetDefaultConfig(&config);
+    config.set_use_live_conversion(true);
+    config.set_live_conversion_delay_msec(0);
+    session.SetConfig(config);
+
+    EXPECT_CALL(*converter, StartConversion(_, _))
+        .Times(::testing::AnyNumber())
+        .WillRepeatedly(Return(false));
+
+    commands::Command command;
+    const std::string dummy_key_codes(
+        Util::CharsLen(test_case.kana_prefix), 'a');
+    InsertCharacterString(test_case.kana_prefix, dummy_key_codes,
+                          &session, &command);
+
+    Mock::VerifyAndClearExpectations(converter.get());
+
+    EXPECT_CALL(*converter, StartConversion(_, _)).Times(0);
+
+    command.Clear();
+    InsertCharacterChars(test_case.roman_suffix, &session, &command);
+
+    EXPECT_EQ(session.context().composer().GetQueryForConversion(),
+              test_case.expected_query);
+    EXPECT_EQ(session.context().state(), ImeContext::COMPOSITION);
+
+    Mock::VerifyAndClearExpectations(converter.get());
+  }
+}
+
+TEST_F(SessionTest, LiveConversionDoesNotHoldHohoAsExpressiveAtom) {
+  MockEngine engine;
+  std::shared_ptr<MockConverter> converter =
+      CreateEngineConverterMock(&engine);
+
+  Session session(engine);
+  InitSessionToPrecomposition(&session);
+
+  config::Config config;
+  config::ConfigHandler::GetDefaultConfig(&config);
+  config.set_use_live_conversion(true);
+  config.set_live_conversion_delay_msec(0);
+  session.SetConfig(config);
+
+  Segments segments;
+  Segment* segment = segments.add_segment();
+  segment->set_key("ほほ");
+  converter::Candidate* candidate = segment->add_candidate();
+  candidate->key = "ほほ";
+  candidate->content_key = "ほほ";
+  candidate->value = "頬";
+
+  EXPECT_CALL(*converter, StartConversion(_, _))
+      .Times(AtLeast(1))
+      .WillRepeatedly(DoAll(SetArgPointee<1>(segments), Return(true)));
+
+  commands::Command command;
+  InsertCharacterString("ほほ", "ab", &session, &command);
+
+  EXPECT_EQ(session.context().state(), ImeContext::CONVERSION);
+  EXPECT_TRUE(command.output().live_conversion());
+  EXPECT_PREEDIT("頬", command);
+}
+
+TEST_F(SessionTest, LiveConversionDoesNotHoldHouhouAsExpressiveAtom) {
+  MockEngine engine;
+  std::shared_ptr<MockConverter> converter =
+      CreateEngineConverterMock(&engine);
+
+  Session session(engine);
+  InitSessionToPrecomposition(&session);
+
+  config::Config config;
+  config::ConfigHandler::GetDefaultConfig(&config);
+  config.set_use_live_conversion(true);
+  config.set_live_conversion_delay_msec(0);
+  session.SetConfig(config);
+
+  Segments segments;
+  Segment* segment = segments.add_segment();
+  segment->set_key("ほうほう");
+  converter::Candidate* candidate = segment->add_candidate();
+  candidate->key = "ほうほう";
+  candidate->content_key = "ほうほう";
+  candidate->value = "方法";
+
+  EXPECT_CALL(*converter, StartConversion(_, _))
+      .Times(AtLeast(1))
+      .WillRepeatedly(DoAll(SetArgPointee<1>(segments), Return(true)));
+
+  commands::Command command;
+  InsertCharacterString("ほうほう", "abcd", &session, &command);
+
+  EXPECT_EQ(session.context().state(), ImeContext::CONVERSION);
+  EXPECT_TRUE(command.output().live_conversion());
+  EXPECT_PREEDIT("方法", command);
+}
+
+TEST_F(SessionTest, LiveConversionDoesNotHoldNonExpressiveSokuonWords) {
+  constexpr absl::string_view kKeys[] = {
+      "うそ",
+      "うっそう",
+      "くそう",
+      "まっって",
+      "いっった",
+      "きっかけ",
+      "やっと",
+      "かって",
+      "まって",
+
+      "きれい",
+      "つらい",
+      "うざい",
+      "すくない",
+      "すっぱい",
+      "すっっぱい",
+      "おそい",
+      "おもい",
+      "はやい",
+      "きもい",
+      "ださい",
+      "ねむい",
+      "ほそい",
+      "ひろい",
+      "せまい",
+      "みじかい",
+      "しろい",
+      "くろい",
+      "うすい",
+
+      "あっち",
+      "きっちり",
+      "めちゃくちゃ",
+      "ちょっと",
+      "ちょうど",
+  };
+
+  for (absl::string_view key : kKeys) {
+    MockEngine engine;
+    std::shared_ptr<MockConverter> converter =
+        CreateEngineConverterMock(&engine);
+
+    Session session(engine);
+    InitSessionToPrecomposition(&session);
+
+    config::Config config;
+    config::ConfigHandler::GetDefaultConfig(&config);
+    config.set_use_live_conversion(true);
+    config.set_live_conversion_delay_msec(0);
+    session.SetConfig(config);
+
+    Segments segments;
+    Segment* segment = segments.add_segment();
+    segment->set_key(key);
+    converter::Candidate* candidate = segment->add_candidate();
+    candidate->key = std::string(key);
+    candidate->content_key = std::string(key);
+    candidate->value = std::string(key);
+
+    EXPECT_CALL(*converter, StartConversion(_, _))
+        .Times(AtLeast(1))
+        .WillRepeatedly(DoAll(SetArgPointee<1>(segments), Return(true)));
+
+    commands::Command command;
+    const std::string dummy_key_codes(Util::CharsLen(key), 'a');
+    InsertCharacterString(key, dummy_key_codes, &session, &command);
+
+    EXPECT_EQ(session.context().state(), ImeContext::CONVERSION);
+    EXPECT_TRUE(command.output().live_conversion());
+
+    Mock::VerifyAndClearExpectations(converter.get());
+  }
 }
 
 TEST_F(SessionTest,


### PR DESCRIPTION
## Summary #71

- Suppress over-eager live conversion for short expressive kana utterances, colloquial evaluative forms, and casual greetings.
- Keep forms such as `ふん`, `うひょー`, `やっば`, `すっくねぇ`, `めっちゃ`, `ちーっす`, and `ちょりーっす` as kana during live conversion.
- Add table-driven matching for repeated-sokuon colloquial evaluative forms.
- Add dedicated handling for casual `っす` greetings, including roman-pending intermediate states such as `ちーs` and `ちょりーs`.
- Preserve ordinary conversion behavior for non-expressive forms such as `すっぱい`, `きれい`, `ちょっと`, and `ちょうど`.
- Update README to describe the live-conversion behavior.

## Testing

- `git diff --check`
- `bazelisk --output_user_root=C:/bzl test --config oss_windows --config release_build //session:session_test --test_output=errors --verbose_failures`
- Real-machine test on Windows with live conversion enabled

## Notes

This change does not disable normal conversion. Pressing Space still invokes ordinary conversion candidates. The suppression only prevents live conversion from prematurely showing unnatural kanji or katakana results while composing short colloquial kana expressions.
