### PR TITLE
Allow keymapping with Left/Right Alt keys

### DIFF
--- a/src/gui/config_dialog/keybinding_editor.cc
+++ b/src/gui/config_dialog/keybinding_editor.cc
@@ -155,27 +155,46 @@ constexpr auto kWinVirtualKeyModifierNonRequiredTable = CreateFlatMap<
 constexpr quint32 kLeftShiftScanCode = 0x2A;
 constexpr quint32 kRightShiftScanCode = 0x36;
 
-QString GetCtrlKeyName(const QKeyEvent &key_event) {
+// Returns "Left..."/"Right..." for a modifier (Ctrl or Alt) whose left and
+// right variants share a base scan code and are distinguished by the extended
+// scan-code flag (0xE0 prefix). Returns an empty string if the event does not
+// match the modifier.
+QString GetLeftRightModifierName(const QKeyEvent &key_event, DWORD left_vk,
+                                 DWORD right_vk, quint32 base_scan_code,
+                                 const QString &left_name,
+                                 const QString &right_name) {
   const DWORD virtual_key = key_event.nativeVirtualKey();
-  if (virtual_key == VK_LCONTROL) {
-    return QStringLiteral("LeftCtrl");
+  if (virtual_key == left_vk) {
+    return left_name;
   }
-  if (virtual_key == VK_RCONTROL) {
-    return QStringLiteral("RightCtrl");
+  if (virtual_key == right_vk) {
+    return right_name;
   }
 
   const quint32 scan_code = key_event.nativeScanCode();
-
-  // Left Ctrl:  0x1D
-  // Right Ctrl: 0xE01D on Windows extended scan code paths.
-  if ((scan_code & 0xFF) == 0x1D) {
+  if ((scan_code & 0xFF) == base_scan_code) {
+    // The right variant uses the extended (0xE0..) scan code.
     if ((scan_code & 0xFF00) == 0xE000) {
-      return QStringLiteral("RightCtrl");
+      return right_name;
     }
-    return QStringLiteral("LeftCtrl");
+    return left_name;
   }
 
   return QString();
+}
+
+QString GetCtrlKeyName(const QKeyEvent &key_event) {
+  // Left Ctrl: scan 0x1D. Right Ctrl: extended scan 0xE01D.
+  return GetLeftRightModifierName(key_event, VK_LCONTROL, VK_RCONTROL, 0x1D,
+                                  QStringLiteral("LeftCtrl"),
+                                  QStringLiteral("RightCtrl"));
+}
+
+QString GetAltKeyName(const QKeyEvent &key_event) {
+  // Left Alt: scan 0x38. Right Alt: extended scan 0xE038.
+  return GetLeftRightModifierName(key_event, VK_LMENU, VK_RMENU, 0x38,
+                                  QStringLiteral("LeftAlt"),
+                                  QStringLiteral("RightAlt"));
 }
 
 QString GetShiftKeyName(const QKeyEvent &key_event) {
@@ -223,6 +242,7 @@ KeyBindingFilter::KeyBindingFilter(QLineEdit *line_edit, QPushButton *ok_button)
       alt_pressed_(false),
       shift_pressed_(false),
       ctrl_key_name_(),
+      alt_key_name_(),
       shift_key_name_(),
       line_edit_(line_edit),
       ok_button_(ok_button) {
@@ -235,6 +255,7 @@ void KeyBindingFilter::Reset() {
   shift_pressed_ = false;
   shift_key_name_.clear();
   ctrl_key_name_.clear();
+  alt_key_name_.clear();
   modifier_required_key_.clear();
   modifier_non_required_key_.clear();
   unknown_key_.clear();
@@ -280,10 +301,18 @@ KeyBindingFilter::KeyState KeyBindingFilter::Encode(QString *result) const {
   if (alt_pressed_) {
 #ifdef __APPLE__
     results << QStringLiteral("Option");
-#else   // __APPLE__
-    // Do not support and show keybindings with alt for Windows
+#elif defined(_WIN32)
+    // Generic "Alt" key is not implemented yet, but possible.
+
+    // Explicit LeftAlt / RightAlt single-key bindings are supported.
+    // It needs but use low-level keyboard handler
+    if (!alt_key_name_.isEmpty()) {
+      results << alt_key_name_;
+    }
+#else   // __APPLE__, _WIN32
+    // Do not support and show keybindings with alt for other platforms.
     // results << "Alt";
-#endif  // __APPLE__
+#endif  // __APPLE__, _WIN32
   }
 
   const bool has_modifier = !results.isEmpty();
@@ -326,10 +355,21 @@ KeyBindingFilter::KeyState KeyBindingFilter::Encode(QString *result) const {
       ctrl_pressed_ && !alt_pressed_ && !shift_pressed_ &&
       !has_non_modifier_key;
 
-  // Keep rejecting Alt-only, Ctrl+Shift-only, Ctrl+Alt-only, etc.
-  // Allow only explicit LeftCtrl/RightCtrl single-key bindings.
+  const bool is_explicit_left_or_right_alt =
+      (alt_key_name_ == QLatin1String("LeftAlt") ||
+       alt_key_name_ == QLatin1String("RightAlt"));
+
+  const bool alt_only =
+      alt_pressed_ && !ctrl_pressed_ && !shift_pressed_ &&
+      !has_non_modifier_key;
+
+  // Keep rejecting bare Alt-only, Ctrl+Shift-only, Ctrl+Alt-only, etc.
+  // Allow only explicit LeftCtrl/RightCtrl or LeftAlt/RightAlt single-key
+  // bindings.
   if (!has_non_modifier_key && (alt_pressed_ || ctrl_pressed_)) {
-    if (!(ctrl_only && is_explicit_left_or_right_ctrl)) {
+    const bool allowed = (ctrl_only && is_explicit_left_or_right_ctrl) ||
+                         (alt_only && is_explicit_left_or_right_alt);
+    if (!allowed) {
       result_state = KeyBindingFilter::DENY_KEY;
     }
   }
@@ -419,6 +459,11 @@ KeyBindingFilter::KeyState KeyBindingFilter::AddKey(const QKeyEvent &key_event,
       //    case Qt::Key_Meta:  // Windows key
     case Qt::Key_Alt:
       alt_pressed_ = true;
+#ifdef _WIN32
+      alt_key_name_ = GetAltKeyName(key_event);
+#else   // _WIN32
+      alt_key_name_.clear();
+#endif  // _WIN32
       return Encode(result);
 #endif  // __APPLE__
     case Qt::Key_Shift:

--- a/src/gui/config_dialog/keybinding_editor.h
+++ b/src/gui/config_dialog/keybinding_editor.h
@@ -65,6 +65,7 @@ class KeyBindingFilter : public QObject {
   bool alt_pressed_;
   bool shift_pressed_;
   QString ctrl_key_name_;
+  QString alt_key_name_;
   QString shift_key_name_;
   QString modifier_required_key_;
   QString modifier_non_required_key_;

--- a/src/session/key_info_util.cc
+++ b/src/session/key_info_util.cc
@@ -58,10 +58,25 @@ enum class ExtractKeyType {
   kDirectModeKey,
   kDirectModeImeOffKey,
   kActiveModeImeOnKey,
+  kActiveModeImeOffKey,
+  kDirectModeImeOnKey,
 };
 
 bool IsDirectModeStatus(absl::string_view status) {
   return status == "Direct" || status == "DirectInput";
+}
+
+// The keymap "command" field may be a command sequence such as "Commit|IMEOff".
+// The server splits these on '|' and runs each command, so mirror that here
+// when checking whether a binding contains a particular command.
+bool CommandSequenceContains(absl::string_view command,
+                             absl::string_view target) {
+  for (absl::string_view part : absl::StrSplit(command, '|')) {
+    if (part == target) {
+      return true;
+    }
+  }
+  return false;
 }
 
 bool ShouldExtractKey(absl::string_view status, absl::string_view command,
@@ -71,10 +86,20 @@ bool ShouldExtractKey(absl::string_view status, absl::string_view command,
       return IsDirectModeStatus(status);
 
     case ExtractKeyType::kDirectModeImeOffKey:
-      return IsDirectModeStatus(status) && command == "IMEOff";
+      return IsDirectModeStatus(status) &&
+             CommandSequenceContains(command, "IMEOff");
 
     case ExtractKeyType::kActiveModeImeOnKey:
-      return !IsDirectModeStatus(status) && command == "IMEOn";
+      return !IsDirectModeStatus(status) &&
+             CommandSequenceContains(command, "IMEOn");
+
+    case ExtractKeyType::kActiveModeImeOffKey:
+      return !IsDirectModeStatus(status) &&
+             CommandSequenceContains(command, "IMEOff");
+
+    case ExtractKeyType::kDirectModeImeOnKey:
+      return IsDirectModeStatus(status) &&
+             CommandSequenceContains(command, "IMEOn");
   }
   return false;
 }
@@ -172,6 +197,18 @@ std::vector<KeyInformation> KeyInfoUtil::ExtractSortedActiveModeImeOnKeys(
     const config::Config& config) {
   return ExtractSortedKeysFromConfig(config,
                                      ExtractKeyType::kActiveModeImeOnKey);
+}
+
+std::vector<KeyInformation> KeyInfoUtil::ExtractSortedActiveModeImeOffKeys(
+    const config::Config& config) {
+  return ExtractSortedKeysFromConfig(config,
+                                     ExtractKeyType::kActiveModeImeOffKey);
+}
+
+std::vector<KeyInformation> KeyInfoUtil::ExtractSortedDirectModeImeOnKeys(
+    const config::Config& config) {
+  return ExtractSortedKeysFromConfig(config,
+                                     ExtractKeyType::kDirectModeImeOnKey);
 }
 
 bool KeyInfoUtil::ContainsKey(absl::Span<const KeyInformation> sorted_keys,

--- a/src/session/key_info_util.h
+++ b/src/session/key_info_util.h
@@ -57,6 +57,18 @@ class KeyInfoUtil {
   static std::vector<KeyInformation> ExtractSortedActiveModeImeOnKeys(
       const config::Config& config);
 
+  // Returns a sorted list of keys bound to IMEOff in active IME modes such as
+  // Precomposition, Composition, Conversion, etc. These are the keys that turn
+  // the IME off, e.g. a left Alt tap mapped to IMEOff.
+  static std::vector<KeyInformation> ExtractSortedActiveModeImeOffKeys(
+      const config::Config& config);
+
+  // Returns a sorted list of keys bound to IMEOn in Direct/DirectInput mode.
+  // These are the keys that turn the IME on, e.g. a right Alt tap mapped to
+  // IMEOn.
+  static std::vector<KeyInformation> ExtractSortedDirectModeImeOnKeys(
+      const config::Config& config);
+
   // Returns true if |sorted_keys| contains |key_event|. |sorted_keys| must be
   // sorted.
   static bool ContainsKey(absl::Span<const KeyInformation> sorted_keys,

--- a/src/session/key_info_util_test.cc
+++ b/src/session/key_info_util_test.cc
@@ -88,6 +88,49 @@ TEST(KeyInfoUtilTest, ExtractSortedDirectModeKeys) {
   }
 }
 
+TEST(KeyInfoUtilTest, ExtractActiveModeImeOffAndDirectModeImeOnKeys) {
+  Config config;
+  ConfigHandler::GetDefaultConfig(&config);
+
+  // Mirrors the documented left/right Alt IME toggle configuration. The active
+  // modes use the "Commit|IMEOff" command *sequence*, which must still be
+  // recognized as an IMEOff binding.
+  constexpr char kCustomKeymapTable[] =
+      "status\tkey\tcommand\n"
+      "DirectInput\tRightAlt\tIMEOn\n"
+      "Precomposition\tLeftAlt\tIMEOff\n"
+      "Composition\tLeftAlt\tCommit|IMEOff\n"
+      "Conversion\tLeftAlt\tCommit|IMEOff\n";
+  config.set_session_keymap(Config::CUSTOM);
+  config.set_custom_keymap_table(kCustomKeymapTable);
+
+  {
+    // LeftAlt turns the IME off in the active modes, including via the
+    // "Commit|IMEOff" sequence.
+    const auto& actual = KeyInfoUtil::ExtractSortedActiveModeImeOffKeys(config);
+    std::vector<KeyInformation> expected;
+    PushKey("LeftAlt", &expected);
+    ASSERT_EQ(actual.size(), expected.size());
+    EXPECT_EQ(actual[0], expected[0]);
+
+    KeyEvent left_alt;
+    KeyParser::ParseKey("LeftAlt", &left_alt);
+    EXPECT_TRUE(KeyInfoUtil::ContainsKey(actual, left_alt));
+    KeyEvent right_alt;
+    KeyParser::ParseKey("RightAlt", &right_alt);
+    EXPECT_FALSE(KeyInfoUtil::ContainsKey(actual, right_alt));
+  }
+
+  {
+    // RightAlt turns the IME on from direct mode.
+    const auto& actual = KeyInfoUtil::ExtractSortedDirectModeImeOnKeys(config);
+    std::vector<KeyInformation> expected;
+    PushKey("RightAlt", &expected);
+    ASSERT_EQ(actual.size(), expected.size());
+    EXPECT_EQ(actual[0], expected[0]);
+  }
+}
+
 TEST(KeyInfoUtilTest, ContainsKey) {
   std::vector<KeyInformation> direct_mode_keys;
   PushKey("HENKAN", &direct_mode_keys);

--- a/src/session/keymap_test.cc
+++ b/src/session/keymap_test.cc
@@ -191,6 +191,39 @@ TEST_F(KeyMapTest, GetCommand) {
   }
 }
 
+TEST_F(KeyMapTest, GetCommandLeftRightAltAreDistinguished) {
+  // Verifies that single-key LeftAlt / RightAlt bindings (used for IME on/off)
+  // are matched via the exact-match path and that left and right are not
+  // confused with each other, just like LeftCtrl / RightCtrl.
+  KeyMap<PrecompositionState> keymap;
+
+  commands::KeyEvent left_alt_rule;
+  ASSERT_TRUE(KeyParser::ParseKey("LeftAlt", &left_alt_rule));
+  EXPECT_TRUE(keymap.AddRule(left_alt_rule, PrecompositionState::IME_OFF));
+
+  commands::KeyEvent right_alt_rule;
+  ASSERT_TRUE(KeyParser::ParseKey("RightAlt", &right_alt_rule));
+  EXPECT_TRUE(keymap.AddRule(right_alt_rule, PrecompositionState::IME_ON));
+
+  PrecompositionState::Commands command;
+
+  // LeftAlt -> IMEOff
+  {
+    commands::KeyEvent key_event;
+    ASSERT_TRUE(KeyParser::ParseKey("LeftAlt", &key_event));
+    EXPECT_TRUE(keymap.GetCommand(key_event, &command));
+    EXPECT_EQ(command, PrecompositionState::IME_OFF);
+  }
+
+  // RightAlt -> IMEOn (must not be confused with LeftAlt)
+  {
+    commands::KeyEvent key_event;
+    ASSERT_TRUE(KeyParser::ParseKey("RightAlt", &key_event));
+    EXPECT_TRUE(keymap.GetCommand(key_event, &command));
+    EXPECT_EQ(command, PrecompositionState::IME_ON);
+  }
+}
+
 TEST_F(KeyMapTest, GetCommandSequence) {
   KeyMap<CompositionState> keymap;
 

--- a/src/win32/base/config_snapshot.cc
+++ b/src/win32/base/config_snapshot.cc
@@ -59,6 +59,12 @@ struct StaticConfigSnapshot {
 
   size_t num_active_mode_ime_on_keys;
   KeyInformation active_mode_ime_on_keys[kMaxModeSwitchKeys];
+
+  size_t num_active_mode_ime_off_keys;
+  KeyInformation active_mode_ime_off_keys[kMaxModeSwitchKeys];
+
+  size_t num_direct_mode_ime_on_keys;
+  KeyInformation direct_mode_ime_on_keys[kMaxModeSwitchKeys];
 };
 
 void CopyKeys(const std::vector<KeyInformation>& keys, size_t max_size,
@@ -97,6 +103,18 @@ StaticConfigSnapshot GetConfigSnapshotImpl() {
           &snapshot.num_active_mode_ime_on_keys,
           snapshot.active_mode_ime_on_keys);
 
+  const auto active_mode_ime_off_keys =
+      KeyInfoUtil::ExtractSortedActiveModeImeOffKeys(*config);
+  CopyKeys(active_mode_ime_off_keys, kMaxModeSwitchKeys,
+          &snapshot.num_active_mode_ime_off_keys,
+          snapshot.active_mode_ime_off_keys);
+
+  const auto direct_mode_ime_on_keys =
+      KeyInfoUtil::ExtractSortedDirectModeImeOnKeys(*config);
+  CopyKeys(direct_mode_ime_on_keys, kMaxModeSwitchKeys,
+          &snapshot.num_direct_mode_ime_on_keys,
+          snapshot.direct_mode_ime_on_keys);
+
   return snapshot;
 }
 
@@ -132,6 +150,20 @@ bool ConfigSnapshot::Get(Info* info) {
   for (size_t i = 0; i < cached_snapshot.num_active_mode_ime_on_keys; ++i) {
     info->active_mode_ime_on_keys[i] =
         cached_snapshot.active_mode_ime_on_keys[i];
+  }
+
+  info->active_mode_ime_off_keys.resize(
+      cached_snapshot.num_active_mode_ime_off_keys);
+  for (size_t i = 0; i < cached_snapshot.num_active_mode_ime_off_keys; ++i) {
+    info->active_mode_ime_off_keys[i] =
+        cached_snapshot.active_mode_ime_off_keys[i];
+  }
+
+  info->direct_mode_ime_on_keys.resize(
+      cached_snapshot.num_direct_mode_ime_on_keys);
+  for (size_t i = 0; i < cached_snapshot.num_direct_mode_ime_on_keys; ++i) {
+    info->direct_mode_ime_on_keys[i] =
+        cached_snapshot.direct_mode_ime_on_keys[i];
   }
 
   return true;

--- a/src/win32/base/config_snapshot.h
+++ b/src/win32/base/config_snapshot.h
@@ -46,6 +46,8 @@ class ConfigSnapshot {
     std::vector<KeyInformation> direct_mode_keys;
     std::vector<KeyInformation> direct_mode_ime_off_keys;
     std::vector<KeyInformation> active_mode_ime_on_keys;
+    std::vector<KeyInformation> active_mode_ime_off_keys;
+    std::vector<KeyInformation> direct_mode_ime_on_keys;
 
     Info();
   };

--- a/src/win32/base/input_state.h
+++ b/src/win32/base/input_state.h
@@ -71,6 +71,15 @@ struct InputBehavior {
   // Used to show the mode indicator when IMEOn is explicitly pressed while
   // IME is already on.
   std::vector<KeyInformation> active_mode_ime_on_keys;
+
+  // Keys bound to IMEOff in active IME modes (Precomposition, Composition,
+  // Conversion, etc.). These keys turn the IME off. Used by the Alt-tap
+  // keyboard hook to turn the IME off on a left Alt tap (see tip_text_service).
+  std::vector<KeyInformation> active_mode_ime_off_keys;
+
+  // Keys bound to IMEOn in Direct/DirectInput mode. These keys turn the IME on.
+  // Used by the Alt-tap keyboard hook to turn the IME on on a right Alt tap.
+  std::vector<KeyInformation> direct_mode_ime_on_keys;
 };
 
 }  // namespace win32

--- a/src/win32/base/keyevent_handler.cc
+++ b/src/win32/base/keyevent_handler.cc
@@ -355,7 +355,8 @@ void ClearModifyerKeyIfNeeded(const KeyEvent* key,
 BYTE GetPhysicalVirtualKey(const VirtualKey& virtual_key, UINT scan_code) {
   switch (virtual_key.virtual_key()) {
     case VK_SHIFT:
-    case VK_CONTROL: {
+    case VK_CONTROL:
+    case VK_MENU: {
       const UINT physical_virtual_key =
           ::MapVirtualKeyW(scan_code, MAPVK_VSC_TO_VK_EX);
       switch (physical_virtual_key) {
@@ -363,6 +364,8 @@ BYTE GetPhysicalVirtualKey(const VirtualKey& virtual_key, UINT scan_code) {
         case VK_RSHIFT:
         case VK_LCONTROL:
         case VK_RCONTROL:
+        case VK_LMENU:
+        case VK_RMENU:
           return static_cast<BYTE>(physical_virtual_key);
         default:
           break;
@@ -486,6 +489,16 @@ bool ConvertToKeyEventMain(const VirtualKey& virtual_key, UINT scan_code,
     modifer_keys->insert(KeyEvent::ALT);
   }
 
+  if (keyboard_status.IsPressed(VK_LMENU)) {
+    modifer_keys->insert(KeyEvent::ALT);
+    modifer_keys->insert(KeyEvent::LEFT_ALT);
+  }
+
+  if (keyboard_status.IsPressed(VK_RMENU)) {
+    modifer_keys->insert(KeyEvent::ALT);
+    modifer_keys->insert(KeyEvent::RIGHT_ALT);
+  }
+
   if (keyboard_status.IsPressed(VK_CAPITAL)) {
     modifer_keys->insert(KeyEvent::CAPS);
   }
@@ -536,6 +549,16 @@ bool ConvertToKeyEventMain(const VirtualKey& virtual_key, UINT scan_code,
 
     case VK_MENU:
       modifer_keys->insert(KeyEvent::ALT);
+      return true;
+
+    case VK_LMENU:
+      modifer_keys->insert(KeyEvent::ALT);
+      modifer_keys->insert(KeyEvent::LEFT_ALT);
+      return true;
+
+    case VK_RMENU:
+      modifer_keys->insert(KeyEvent::ALT);
+      modifer_keys->insert(KeyEvent::RIGHT_ALT);
       return true;
 
     case VK_CAPITAL:
@@ -823,6 +846,8 @@ KeyEventHandlerResult KeyEventHandler::HandleKey(
     case VK_LCONTROL:
     case VK_RCONTROL:
     case VK_MENU:
+    case VK_LMENU:
+    case VK_RMENU:
       if (is_key_down) {
         // Will not eat this message.
         result.succeeded = true;

--- a/src/win32/base/keyevent_handler_test.cc
+++ b/src/win32/base/keyevent_handler_test.cc
@@ -1669,6 +1669,224 @@ TEST_F(KeyEventHandlerTest, ProtocolAnomalyModiferKeyMayBeSentOnKeyUp) {
   }
 }
 
+TEST_F(KeyEventHandlerTest, LeftAltTapShouldBeSentToServerWithLeftAltModifier) {
+  // A tap (press then release without any intervening key) of the left Alt key
+  // should be sent to the server with the LEFT_ALT modifier so that it can be
+  // bound to commands such as IMEOff.
+  constexpr bool kKanaLocked = false;
+
+  Output mock_output;
+  mock_output.set_consumed(true);
+
+  MockState mock(mock_output);
+  KeyboardMock keyboard(kKanaLocked);
+
+  InputState next_state;
+  KeyEventHandlerResult result;
+
+  InputBehavior behavior;
+  behavior.prefer_kana_input = kKanaLocked;
+  behavior.disabled = false;
+  behavior.direct_mode_keys = GetDefaultDirectModeKeys();
+
+  Context context;
+
+  // Left Alt: scan code 0x38, not extended.
+  constexpr BYTE kAltScanCode = 0x38;
+
+  // Press LeftAlt
+  {
+    KeyboardStatus keyboard_status;
+    keyboard_status.SetState(VK_MENU, kPressed);
+    keyboard_status.SetState(VK_LMENU, kPressed);
+
+    constexpr VirtualKey kVirtualKey = VirtualKey::FromVirtualKey(VK_MENU);
+    const LParamKeyInfo lparam(CreateLParam(0x0001,        // repeat_count
+                                            kAltScanCode,  // scan_code
+                                            false,    // is_extended_key,
+                                            false,    // has_context_code,
+                                            false,    // is_previous_state_down,
+                                            false));  // is_in_transition_state
+
+    InputState initial_state;
+    initial_state.logical_conversion_mode =
+        IME_CMODE_NATIVE | IME_CMODE_FULLSHAPE | IME_CMODE_ROMAN;
+    initial_state.visible_conversion_mode =
+        initial_state.logical_conversion_mode;
+    initial_state.open = true;
+
+    Output output;
+    result = TestableKeyEventHandler::ImeProcessKey(
+        kVirtualKey, lparam.GetScanCodeForMapVirtualKey(),
+        lparam.IsKeyDownInImeProcessKey(), keyboard_status, behavior,
+        initial_state, context, mock.mutable_client(), &keyboard, &next_state,
+        &output);
+
+    EXPECT_TRUE(result.succeeded);
+    EXPECT_FALSE(result.should_be_eaten);
+    EXPECT_FALSE(result.should_be_sent_to_server);
+    EXPECT_FALSE(mock.start_server_called());
+  }
+
+  // Release LeftAlt
+  {
+    KeyboardStatus keyboard_status;
+    keyboard_status.SetState(VK_MENU, kPressed);
+
+    constexpr VirtualKey kVirtualKey = VirtualKey::FromVirtualKey(VK_MENU);
+    const LParamKeyInfo lparam(CreateLParam(0x0001,        // repeat_count
+                                            kAltScanCode,  // scan_code
+                                            false,   // is_extended_key,
+                                            false,   // has_context_code,
+                                            false,   // is_previous_state_down,
+                                            true));  // is_in_transition_state
+
+    InputState initial_state;
+    initial_state.logical_conversion_mode =
+        IME_CMODE_NATIVE | IME_CMODE_FULLSHAPE | IME_CMODE_ROMAN;
+    initial_state.visible_conversion_mode =
+        initial_state.logical_conversion_mode;
+    initial_state.open = true;
+    // The physical key recorded on key-down is the left Alt.
+    initial_state.last_down_key = VirtualKey::FromVirtualKey(VK_LMENU);
+
+    Output output;
+    result = TestableKeyEventHandler::ImeProcessKey(
+        kVirtualKey, lparam.GetScanCodeForMapVirtualKey(),
+        lparam.IsKeyDownInImeProcessKey(), keyboard_status, behavior,
+        initial_state, context, mock.mutable_client(), &keyboard, &next_state,
+        &output);
+
+    EXPECT_TRUE(result.succeeded);
+    EXPECT_TRUE(result.should_be_eaten);
+    EXPECT_TRUE(result.should_be_sent_to_server);
+  }
+
+  {
+    commands::Input actual_input;
+    EXPECT_TRUE(mock.GetGeneratedRequest(&actual_input));
+    EXPECT_EQ(actual_input.type(), commands::Input::TEST_SEND_KEY);
+    EXPECT_TRUE(actual_input.has_key());
+    EXPECT_FALSE(actual_input.key().has_key_code());
+    EXPECT_FALSE(actual_input.key().has_key_string());
+    EXPECT_EQ(actual_input.key().modifier_keys_size(), 2);
+    // ALT (=2) is sorted before LEFT_ALT (=64).
+    EXPECT_EQ(actual_input.key().modifier_keys(0), commands::KeyEvent::ALT);
+    EXPECT_EQ(actual_input.key().modifier_keys(1),
+              commands::KeyEvent::LEFT_ALT);
+    EXPECT_FALSE(actual_input.key().has_special_key());
+  }
+}
+
+TEST_F(KeyEventHandlerTest,
+       RightAltTapShouldBeSentToServerWithRightAltModifier) {
+  // A tap of the right Alt key should be sent to the server with the RIGHT_ALT
+  // modifier so that it can be bound to commands such as IMEOn.
+  constexpr bool kKanaLocked = false;
+
+  Output mock_output;
+  mock_output.set_consumed(true);
+
+  MockState mock(mock_output);
+  KeyboardMock keyboard(kKanaLocked);
+
+  InputState next_state;
+  KeyEventHandlerResult result;
+
+  InputBehavior behavior;
+  behavior.prefer_kana_input = kKanaLocked;
+  behavior.disabled = false;
+  behavior.direct_mode_keys = GetDefaultDirectModeKeys();
+
+  Context context;
+
+  // Right Alt: scan code 0x38, extended.
+  constexpr BYTE kAltScanCode = 0x38;
+
+  // Press RightAlt
+  {
+    KeyboardStatus keyboard_status;
+    keyboard_status.SetState(VK_MENU, kPressed);
+    keyboard_status.SetState(VK_RMENU, kPressed);
+
+    constexpr VirtualKey kVirtualKey = VirtualKey::FromVirtualKey(VK_MENU);
+    const LParamKeyInfo lparam(CreateLParam(0x0001,        // repeat_count
+                                            kAltScanCode,  // scan_code
+                                            true,     // is_extended_key,
+                                            false,    // has_context_code,
+                                            false,    // is_previous_state_down,
+                                            false));  // is_in_transition_state
+
+    InputState initial_state;
+    initial_state.logical_conversion_mode =
+        IME_CMODE_NATIVE | IME_CMODE_FULLSHAPE | IME_CMODE_ROMAN;
+    initial_state.visible_conversion_mode =
+        initial_state.logical_conversion_mode;
+    initial_state.open = true;
+
+    Output output;
+    result = TestableKeyEventHandler::ImeProcessKey(
+        kVirtualKey, lparam.GetScanCodeForMapVirtualKey(),
+        lparam.IsKeyDownInImeProcessKey(), keyboard_status, behavior,
+        initial_state, context, mock.mutable_client(), &keyboard, &next_state,
+        &output);
+
+    EXPECT_TRUE(result.succeeded);
+    EXPECT_FALSE(result.should_be_eaten);
+    EXPECT_FALSE(result.should_be_sent_to_server);
+    EXPECT_FALSE(mock.start_server_called());
+  }
+
+  // Release RightAlt
+  {
+    KeyboardStatus keyboard_status;
+    keyboard_status.SetState(VK_MENU, kPressed);
+
+    constexpr VirtualKey kVirtualKey = VirtualKey::FromVirtualKey(VK_MENU);
+    const LParamKeyInfo lparam(CreateLParam(0x0001,        // repeat_count
+                                            kAltScanCode,  // scan_code
+                                            true,    // is_extended_key,
+                                            false,   // has_context_code,
+                                            false,   // is_previous_state_down,
+                                            true));  // is_in_transition_state
+
+    InputState initial_state;
+    initial_state.logical_conversion_mode =
+        IME_CMODE_NATIVE | IME_CMODE_FULLSHAPE | IME_CMODE_ROMAN;
+    initial_state.visible_conversion_mode =
+        initial_state.logical_conversion_mode;
+    initial_state.open = true;
+    // The physical key recorded on key-down is the right Alt.
+    initial_state.last_down_key = VirtualKey::FromVirtualKey(VK_RMENU);
+
+    Output output;
+    result = TestableKeyEventHandler::ImeProcessKey(
+        kVirtualKey, lparam.GetScanCodeForMapVirtualKey(),
+        lparam.IsKeyDownInImeProcessKey(), keyboard_status, behavior,
+        initial_state, context, mock.mutable_client(), &keyboard, &next_state,
+        &output);
+
+    EXPECT_TRUE(result.succeeded);
+    EXPECT_TRUE(result.should_be_eaten);
+    EXPECT_TRUE(result.should_be_sent_to_server);
+  }
+
+  {
+    commands::Input actual_input;
+    EXPECT_TRUE(mock.GetGeneratedRequest(&actual_input));
+    EXPECT_EQ(actual_input.type(), commands::Input::TEST_SEND_KEY);
+    EXPECT_TRUE(actual_input.has_key());
+    EXPECT_FALSE(actual_input.key().has_key_code());
+    EXPECT_FALSE(actual_input.key().has_key_string());
+    EXPECT_EQ(actual_input.key().modifier_keys_size(), 2);
+    // ALT (=2) is sorted before RIGHT_ALT (=512).
+    EXPECT_EQ(actual_input.key().modifier_keys(0), commands::KeyEvent::ALT);
+    EXPECT_EQ(actual_input.key().modifier_keys(1),
+              commands::KeyEvent::RIGHT_ALT);
+    EXPECT_FALSE(actual_input.key().has_special_key());
+  }
+}
+
 TEST_F(KeyEventHandlerTest,
        ProtocolAnomalyModifierShiftShouldBeRemovedForPrintableChar) {
   // Currently, the Mozc server expects the client remove Shift modifier if

--- a/src/win32/tip/BUILD.bazel
+++ b/src/win32/tip/BUILD.bazel
@@ -227,6 +227,7 @@ mozc_cc_library(
         "//base/win32:hresult",
         "//base/win32:hresultor",
         "//protocol:commands_cc_proto",
+        "//win32/base:input_state",
         "//win32/base:msctf_dll",  # buildcleaner: keep
         "//win32/base:win32_window_util",
         "@com_google_absl//absl/base",

--- a/src/win32/tip/tip_keyevent_handler.cc
+++ b/src/win32/tip/tip_keyevent_handler.cc
@@ -580,6 +580,121 @@ HRESULT TipKeyeventHandler::OnKeyUp(TipTextService* text_service,
   return OnKey(text_service, context, kKeyUp, wparam, lparam, eaten);
 }
 
+HRESULT TipKeyeventHandler::OnModifierTap(TipTextService* text_service,
+                                          ITfContext* context, BYTE vk) {
+  DCHECK(text_service);
+  TipPrivateContext* private_context = text_service->GetPrivateContext(context);
+  if (private_context == nullptr) {
+    return S_OK;
+  }
+
+  BYTE key_state[256] = {};
+  if (!::GetKeyboardState(key_state)) {
+    return S_OK;
+  }
+
+  bool open = false;
+  uint32_t logical_mode = 0;
+  uint32_t visible_mode = 0;
+  if (!GetOpenAndMode(text_service, context, &open, &logical_mode,
+                      &visible_mode)) {
+    return S_OK;
+  }
+
+  const KeyboardStatus keyboard_status(key_state);
+  const VirtualKey virtual_key = VirtualKey::FromVirtualKey(vk);
+  // Left Alt: scan code 0x38. Right Alt: extended scan code 0xE038. The scan
+  // code lets ConvertToKeyEvent set the LEFT_ALT / RIGHT_ALT modifier so the
+  // server keymap can match "LeftAlt" / "RightAlt".
+  const UINT scan_code = (vk == VK_RMENU) ? 0xE038 : 0x38;
+
+  std::unique_ptr<Win32KeyboardInterface> keyboard(
+      Win32KeyboardInterface::CreateDefault());
+  // A lone IMEOn/IMEOff (or Commit) command never consults surrounding text, so
+  // use the lightweight context fill and skip the synchronous surrounding-text
+  // round-trip that FillMozcContextForOnKey would perform.
+  Context mozc_context;
+  FillMozcContextCommon(text_service, context, &mozc_context);
+
+  // The server recognizes a lone modifier toggle differently depending on the
+  // current state (see KeyEventHandler::HandleKey). OnModifierTap is only
+  // invoked (by the keyboard hook) when the tap will actually toggle in the
+  // current state, so deriving the edge from the open state is correct here:
+  //   * While the IME is ON, an active-mode command (e.g. Commit|IMEOff) fires
+  //     on the modifier *key-up* whose key matches the last key pressed.
+  //   * While the IME is OFF, a direct-mode force-activation command (IMEOn)
+  //     fires only on the modifier *key-down*.
+  // So drive a key-down when the IME is off and a key-up when it is on.
+  const bool is_key_down = !open;
+  InputState ime_state;
+  ime_state.logical_conversion_mode = logical_mode;
+  ime_state.visible_conversion_mode = visible_mode;
+  ime_state.open = open;
+  // Pretend this modifier was the last key pressed so the key-up case is
+  // treated as a tap.
+  ime_state.last_down_key = virtual_key;
+
+  InputState next_state;
+  commands::Output output;
+  const KeyEventHandlerResult result = KeyEventHandler::ImeToAsciiEx(
+      virtual_key, scan_code, is_key_down, keyboard_status,
+      private_context->input_behavior(), ime_state, mozc_context,
+      private_context->GetClient(), keyboard.get(), &next_state, &output);
+
+  if (!result.succeeded || !result.should_be_sent_to_server) {
+    return S_OK;
+  }
+
+  *private_context->mutable_last_down_key() = next_state.last_down_key;
+
+  // Apply the IME open/close and conversion mode from the server output here,
+  // outside of any edit session. The normal output path applies these inside a
+  // document-locked edit session (UpdatePrivateContext), but that lock cannot
+  // be obtained while the IME is off, which would otherwise make turning the
+  // IME *on* via a right Alt tap silently fail. Routing through the input mode
+  // manager keeps its internal state in sync (unlike a bare SetIMEOpen).
+  //
+  // TODO(mozkey): This open/close + conversion-mode block mirrors
+  // tip_edit_session_impl.cc's UpdatePrivateContext. A shared helper would
+  // avoid the duplication, but the natural homes create a dependency cycle
+  // (tip_keyevent_handler -> tip_edit_session -> ... -> tip_keyevent_handler),
+  // so it is left inline for now.
+  if (output.has_status()) {
+    const commands::Status &status = output.status();
+    TipInputModeManager *input_mode_manager =
+        text_service->GetThreadContext()->GetInputModeManager();
+    const TipInputModeManager::NotifyActionSet action_set =
+        input_mode_manager->OnReceiveCommand(
+            status.activated(), status.comeback_mode(), status.mode());
+    if ((action_set & TipInputModeManager::kNotifySystemOpenClose) ==
+        TipInputModeManager::kNotifySystemOpenClose) {
+      TipStatus::SetIMEOpen(text_service->GetThreadManager(),
+                            text_service->GetClientID(),
+                            input_mode_manager->GetEffectiveOpenClose());
+    }
+    if ((action_set & TipInputModeManager::kNotifySystemConversionMode) ==
+        TipInputModeManager::kNotifySystemConversionMode) {
+      const CompositionMode mozc_mode = static_cast<CompositionMode>(
+          input_mode_manager->GetEffectiveConversionMode());
+      uint32_t native_mode = 0;
+      if (ConversionModeUtil::ToNativeMode(
+              mozc_mode, private_context->input_behavior().prefer_kana_input,
+              &native_mode)) {
+        TipStatus::SetInputModeConversion(text_service->GetThreadManager(),
+                                          text_service->GetClientID(),
+                                          native_mode);
+      }
+    }
+  }
+
+  // Apply the rest of the output (committed text, composition, candidates)
+  // asynchronously: a synchronous edit session is only allowed inside a TSF
+  // key-event handler, and OnModifierTap runs from the task window message
+  // loop.
+  TipEditSession::OnOutputReceivedAsync(text_service, context, output);
+  return S_OK;
+}
+
 }  // namespace tsf
 }  // namespace win32
 }  // namespace mozc

--- a/src/win32/tip/tip_keyevent_handler.cc
+++ b/src/win32/tip/tip_keyevent_handler.cc
@@ -616,14 +616,15 @@ HRESULT TipKeyeventHandler::OnModifierTap(TipTextService* text_service,
   Context mozc_context;
   FillMozcContextCommon(text_service, context, &mozc_context);
 
-  // The server recognizes a lone modifier toggle differently depending on the
-  // current state (see KeyEventHandler::HandleKey). OnModifierTap is only
-  // invoked (by the keyboard hook) when the tap will actually toggle in the
-  // current state, so deriving the edge from the open state is correct here:
+  // The server recognizes a lone modifier command differently depending on the
+  // current state (see KeyEventHandler::HandleKey). OnModifierTap is invoked
+  // (by the keyboard hook) only when the current state's keymap should process
+  // the tap, so deriving the edge from the open state is correct here:
   //   * While the IME is ON, an active-mode command (e.g. Commit|IMEOff) fires
   //     on the modifier *key-up* whose key matches the last key pressed.
-  //   * While the IME is OFF, a direct-mode force-activation command (IMEOn)
-  //     fires only on the modifier *key-down*.
+  //   * While the IME is OFF, a direct-mode command (e.g. IMEOn or the
+  //     same-state IMEOff indicator command) fires only on the modifier
+  //     *key-down*.
   // So drive a key-down when the IME is off and a key-up when it is on.
   const bool is_key_down = !open;
   InputState ime_state;

--- a/src/win32/tip/tip_keyevent_handler.h
+++ b/src/win32/tip/tip_keyevent_handler.h
@@ -57,6 +57,15 @@ class TipKeyeventHandler {
                              WPARAM wparam, LPARAM lparam, BOOL* eaten);
   static HRESULT OnKeyUp(TipTextService* text_service, ITfContext* context,
                          WPARAM wparam, LPARAM lparam, BOOL* eaten);
+
+  // Processes a synthetic lone modifier-key tap (e.g. a left/right Alt tap
+  // detected by the keyboard hook). Sends the corresponding modifier key event
+  // to the server so that the configured command (e.g. "Commit|IMEOff" or
+  // "IMEOn") runs, and applies the resulting output via an async edit session.
+  // |vk| must be a modifier virtual key such as VK_LMENU or VK_RMENU. Unlike
+  // OnKeyUp, this is safe to call outside of a TSF key-event handler.
+  static HRESULT OnModifierTap(TipTextService* text_service,
+                               ITfContext* context, BYTE vk);
 };
 
 }  // namespace tsf

--- a/src/win32/tip/tip_private_context.cc
+++ b/src/win32/tip/tip_private_context.cc
@@ -99,6 +99,8 @@ void TipPrivateContext::EnsureInitialized() {
     behavior->direct_mode_keys = snapshot.direct_mode_keys;
     behavior->direct_mode_ime_off_keys = snapshot.direct_mode_ime_off_keys;
     behavior->active_mode_ime_on_keys = snapshot.active_mode_ime_on_keys;
+    behavior->active_mode_ime_off_keys = snapshot.active_mode_ime_off_keys;
+    behavior->direct_mode_ime_on_keys = snapshot.direct_mode_ime_on_keys;
     behavior->initialized = true;
   }
 }

--- a/src/win32/tip/tip_text_service.cc
+++ b/src/win32/tip/tip_text_service.cc
@@ -57,7 +57,10 @@
 #include "base/win32/hresult.h"
 #include "base/win32/hresultor.h"
 #include "base/win32/win_util.h"
+#include "composer/key_event_util.h"
 #include "protocol/commands.pb.h"
+#include "session/key_info_util.h"
+#include "win32/base/input_state.h"
 #include "win32/base/win32_window_util.h"
 #include "win32/tip/tip_display_attributes.h"
 #include "win32/tip/tip_dll_module.h"
@@ -111,7 +114,20 @@ volatile bool g_module_unloaded = false;
 volatile DWORD g_tls_index = TLS_OUT_OF_INDEXES;
 
 constexpr UINT kUpdateUIMessage = WM_USER;
+// Posted from the Alt-tap keyboard hook to the task window to drive the
+// synthetic modifier tap. wParam is the modifier virtual key (VK_LMENU or
+// VK_RMENU).
+constexpr UINT kAltTapToggleMessage = WM_USER + 1;
 constexpr UINT_PTR kDelayedSessionCommandTimerId = 1;
+
+// The "menu mask" key injected to prevent the application menu from activating
+// on a lone Alt tap. VK 0xE8 is unassigned (the same key AutoHotkey uses for
+// this purpose), so it has no effect on applications.
+constexpr WORD kMenuMaskVk = 0xE8;
+
+// Marker placed in dwExtraInfo of the synthetic input injected by
+// InjectAltDisguise so that this and other tools can recognize it as our own.
+constexpr ULONG_PTR kAltDisguiseExtraInfo = 0x6D7A4B79;  // 'mzKy'
 
 bool NeedsRendererUpdateOnLayoutChange(TipTextService* text_service,
                                        ITfContext* context) {
@@ -490,6 +506,9 @@ class TipTextServiceImpl
       return S_OK;
     }
 
+    // Remove the Alt-tap keyboard hook if it is still installed.
+    UninstallAltTapHook();
+
     // Stop advising the ITfThreadFocusSink events.
     UninitThreadFocusSink();
 
@@ -754,6 +773,9 @@ class TipTextServiceImpl
                           ITfDocumentMgr* previous) override {
     GetThreadContext()->IncrementFocusRevision();
     OnDocumentMgrChanged(focused);
+    // The private context (and thus the Alt-tap configuration) may not have
+    // been ready when OnSetThreadFocus() fired. Retry installing here.
+    MaybeInstallAltTapHook();
     return S_OK;
   }
   STDMETHODIMP OnPushContext(ITfContext* context) override {
@@ -790,10 +812,12 @@ class TipTextServiceImpl
       return S_OK;
     }
     TipUiHandler::OnFocusChange(this, document_manager.get());
+    MaybeInstallAltTapHook();
     return S_OK;
   }
   STDMETHODIMP OnKillThreadFocus() override {
     // See the comment in OnSetThreadFocus().
+    UninstallAltTapHook();
     TipUiHandler::OnFocusChange(this, nullptr);
     return S_OK;
   }
@@ -1065,6 +1089,213 @@ class TipTextServiceImpl
       return nullptr;
     }
     return static_cast<TipTextServiceImpl*>(::TlsGetValue(g_tls_index));
+  }
+
+  // Builds the KeyInformation for a lone left/right Alt tap (ALT + LEFT_ALT or
+  // ALT + RIGHT_ALT), matching how the keymap "LeftAlt" / "RightAlt" entries are
+  // parsed. Returns false if the information could not be built.
+  static bool BuildAltKeyInformation(DWORD alt_vk, KeyInformation* key_info) {
+    commands::KeyEvent key_event;
+    key_event.add_modifier_keys(commands::KeyEvent::ALT);
+    key_event.add_modifier_keys(alt_vk == VK_LMENU
+                                    ? commands::KeyEvent::LEFT_ALT
+                                    : commands::KeyEvent::RIGHT_ALT);
+    return KeyEventUtil::GetKeyInformation(key_event, key_info);
+  }
+
+  // Returns true if the user has actually bound a left or right Alt tap to an
+  // IME on/off command. Note that this must check for the *Alt* keys
+  // specifically: active_mode_ime_off_keys / direct_mode_ime_on_keys contain
+  // every key bound to IMEOff / IMEOn (Hankaku/Zenkaku, Henkan, Ctrl-based
+  // shortcuts, ...), which are non-empty in virtually every config, so an
+  // emptiness check would install the keyboard hook for users who never
+  // configured Alt.
+  bool IsAltTapEnabled() {
+    TipPrivateContext* private_context = GetFocusedPrivateContext();
+    if (private_context == nullptr) {
+      return false;
+    }
+    const InputBehavior& behavior = private_context->input_behavior();
+    for (const DWORD alt_vk : {VK_LMENU, VK_RMENU}) {
+      KeyInformation key_info;
+      if (!BuildAltKeyInformation(alt_vk, &key_info)) {
+        continue;
+      }
+      if (KeyInfoUtil::ContainsKeyInformation(behavior.active_mode_ime_off_keys,
+                                              key_info) ||
+          KeyInfoUtil::ContainsKeyInformation(behavior.direct_mode_ime_on_keys,
+                                              key_info)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  // Installs the low-level keyboard hook used to detect lone Alt taps, but only
+  // while this thread owns the OS keyboard focus and the feature is enabled.
+  // Idempotent.
+  void MaybeInstallAltTapHook() {
+    if (alt_tap_hook_ != nullptr) {
+      return;
+    }
+    BOOL thread_focus = FALSE;
+    if (thread_mgr_ == nullptr ||
+        FAILED(thread_mgr_->IsThreadFocus(&thread_focus)) || !thread_focus) {
+      return;
+    }
+    if (!IsAltTapEnabled()) {
+      return;
+    }
+    alt_tap_pending_vk_ = 0;
+    const HMODULE module_handle = g_module;
+    alt_tap_hook_ = ::SetWindowsHookExW(WH_KEYBOARD_LL, AltTapKeyboardHookProc,
+                                        module_handle, 0);
+  }
+
+  void UninstallAltTapHook() {
+    if (alt_tap_hook_ == nullptr) {
+      return;
+    }
+    ::UnhookWindowsHookEx(alt_tap_hook_);
+    alt_tap_hook_ = nullptr;
+    alt_tap_pending_vk_ = 0;
+  }
+
+  // Called from the keyboard hook when a lone left/right Alt tap is detected.
+  // Returns true if the tap is reserved for IME toggling and therefore the
+  // Alt key-up should be swallowed (to suppress the application menu).
+  static bool OnAltTap(DWORD alt_vk) {
+    TipTextServiceImpl* self = Self();
+    if (self == nullptr || self->thread_mgr_ == nullptr ||
+        !::IsWindow(self->task_window_handle_)) {
+      return false;
+    }
+
+    // Only react when the keyboard focus is on an editable (non-disabled)
+    // context, so menus keep working where text input is not possible.
+    wil::com_ptr_nothrow<ITfDocumentMgr> document_mgr;
+    if (FAILED(self->thread_mgr_->GetFocus(&document_mgr)) || !document_mgr) {
+      return false;
+    }
+    wil::com_ptr_nothrow<ITfContext> context;
+    if (FAILED(document_mgr->GetTop(&context)) || !context) {
+      return false;
+    }
+    if (TipStatus::IsDisabledContext(context.get())) {
+      return false;
+    }
+    TipPrivateContext* private_context = self->GetPrivateContext(context.get());
+    if (private_context == nullptr) {
+      return false;
+    }
+    const InputBehavior& behavior = private_context->input_behavior();
+
+    // Look this Alt tap up in the configured IME on/off key lists, exactly as
+    // the server keymap would.
+    KeyInformation key_info;
+    if (!BuildAltKeyInformation(alt_vk, &key_info)) {
+      return false;
+    }
+    const bool is_off_key = KeyInfoUtil::ContainsKeyInformation(
+        behavior.active_mode_ime_off_keys, key_info);
+    const bool is_on_key = KeyInfoUtil::ContainsKeyInformation(
+        behavior.direct_mode_ime_on_keys, key_info);
+
+    // Only consume the Alt tap when it will actually toggle the IME in the
+    // *current* state: an active-mode off key while the IME is on, or a
+    // direct-mode on key while the IME is off. In any other state this tap is a
+    // no-op, so let the Alt key keep its normal (menu) behavior instead of
+    // swallowing it. This is what keeps a configured Alt key from breaking the
+    // application menu in the state where it has no IME effect.
+    const bool open = TipStatus::IsOpen(self->thread_mgr_.get());
+    const bool will_toggle = (open && is_off_key) || (!open && is_on_key);
+    if (!will_toggle) {
+      return false;
+    }
+
+    // Hand the actual processing to the task window, which runs in the normal
+    // message loop where the server key event and an async edit session can be
+    // driven safely (the server keymap decides the command, e.g. Commit|IMEOff
+    // or IMEOn, based on the current composition/open state).
+    ::PostMessageW(self->task_window_handle_, kAltTapToggleMessage,
+                   static_cast<WPARAM>(alt_vk), 0);
+    return true;
+  }
+
+  // Runs in the task window message loop: drives the synthetic modifier tap
+  // through the server keymap and applies the resulting output.
+  void OnAltTapToggle(BYTE alt_vk) {
+    if (thread_mgr_ == nullptr) {
+      return;
+    }
+    wil::com_ptr_nothrow<ITfDocumentMgr> document_mgr;
+    if (FAILED(thread_mgr_->GetFocus(&document_mgr)) || !document_mgr) {
+      return;
+    }
+    wil::com_ptr_nothrow<ITfContext> context;
+    if (FAILED(document_mgr->GetTop(&context)) || !context) {
+      return;
+    }
+    TipKeyeventHandler::OnModifierTap(this, context.get(), alt_vk);
+  }
+
+  // After a lone Alt tap is consumed, the real Alt key-up is swallowed. To
+  // keep the application's key state balanced (otherwise it believes Alt is
+  // still held) and to prevent the menu bar from activating, inject a benign
+  // "mask" key (pressed while Alt is logically down) followed by an Alt key-up.
+  static void InjectAltDisguise(DWORD alt_vk) {
+    INPUT inputs[3] = {};
+    inputs[0].type = INPUT_KEYBOARD;
+    inputs[0].ki.wVk = kMenuMaskVk;
+    inputs[0].ki.dwExtraInfo = kAltDisguiseExtraInfo;
+    inputs[1].type = INPUT_KEYBOARD;
+    inputs[1].ki.wVk = kMenuMaskVk;
+    inputs[1].ki.dwFlags = KEYEVENTF_KEYUP;
+    inputs[1].ki.dwExtraInfo = kAltDisguiseExtraInfo;
+    inputs[2].type = INPUT_KEYBOARD;
+    inputs[2].ki.wVk = static_cast<WORD>(alt_vk);
+    inputs[2].ki.dwFlags =
+        KEYEVENTF_KEYUP | (alt_vk == VK_RMENU ? KEYEVENTF_EXTENDEDKEY : 0);
+    inputs[2].ki.dwExtraInfo = kAltDisguiseExtraInfo;
+    ::SendInput(3, inputs, sizeof(INPUT));
+  }
+
+  static LRESULT CALLBACK AltTapKeyboardHookProc(int code, WPARAM wparam,
+                                                 LPARAM lparam) {
+    // The hook callback runs on the thread that installed it, which is the
+    // thread whose TipTextServiceImpl is stored in TLS. Resolve it so the
+    // pending-tap state stays per-thread.
+    TipTextServiceImpl* self = Self();
+    if (self != nullptr && code == HC_ACTION) {
+      const auto* info = reinterpret_cast<const KBDLLHOOKSTRUCT*>(lparam);
+      if (info != nullptr && (info->flags & LLKHF_INJECTED) == 0) {
+        const bool is_key_down =
+            (wparam == WM_KEYDOWN || wparam == WM_SYSKEYDOWN);
+        const bool is_key_up = (wparam == WM_KEYUP || wparam == WM_SYSKEYUP);
+        const DWORD vk = info->vkCode;
+        const bool is_alt = (vk == VK_LMENU || vk == VK_RMENU);
+        if (is_key_down) {
+          // A lone Alt press starts a potential tap. Any other key (including a
+          // second modifier or an auto-repeat of Alt) cancels it.
+          self->alt_tap_pending_vk_ =
+              (is_alt && self->alt_tap_pending_vk_ == 0) ? vk : 0;
+        } else if (is_key_up) {
+          if (is_alt && vk == self->alt_tap_pending_vk_) {
+            self->alt_tap_pending_vk_ = 0;
+            if (OnAltTap(vk)) {
+              // Swallow the real Alt key-up and replace it with a disguised
+              // sequence so the application neither activates its menu bar nor
+              // believes Alt is stuck down.
+              InjectAltDisguise(vk);
+              return 1;
+            }
+          } else if (is_alt) {
+            self->alt_tap_pending_vk_ = 0;
+          }
+        }
+      }
+    }
+    return ::CallNextHookEx(nullptr, code, wparam, lparam);
   }
 
   HRESULT OnDocumentMgrChanged(ITfDocumentMgr* document_mgr) {
@@ -1423,6 +1654,14 @@ class TipTextServiceImpl
         return 0;
       }
 
+      if (message == kAltTapToggleMessage) {
+        // Drive the synthetic modifier tap through the server keymap in the
+        // normal message context (the low-level keyboard hook callback is not
+        // a safe place to run a key event / edit session).
+        self->OnAltTapToggle(static_cast<BYTE>(wparam));
+        return 0;
+      }
+
       if (message == WM_TIMER &&
           wparam == kDelayedSessionCommandTimerId) {
         self->OnDelayedSessionCommandTimer();
@@ -1592,6 +1831,15 @@ class TipTextServiceImpl
   bool has_pending_delayed_session_command_;
   commands::SessionCommand pending_delayed_session_command_;
   wil::com_ptr_nothrow<ITfContext> pending_delayed_session_context_;
+
+  // Alt-tap keyboard hook state. A WH_KEYBOARD_LL hook is owned by the thread
+  // that installs it, and each TSF UI thread has its own TipTextServiceImpl
+  // (resolved via the thread-local Self()), so this state is per-instance
+  // rather than process-global.
+  HHOOK alt_tap_hook_ = nullptr;
+  // The virtual key (VK_LMENU or VK_RMENU) of a lone Alt press that has not yet
+  // been released, or 0 if the current key sequence cannot be a lone Alt tap.
+  DWORD alt_tap_pending_vk_ = 0;
 };
 
 }  // namespace

--- a/src/win32/tip/tip_text_service.cc
+++ b/src/win32/tip/tip_text_service.cc
@@ -1124,6 +1124,10 @@ class TipTextServiceImpl
       if (KeyInfoUtil::ContainsKeyInformation(behavior.active_mode_ime_off_keys,
                                               key_info) ||
           KeyInfoUtil::ContainsKeyInformation(behavior.direct_mode_ime_on_keys,
+                                              key_info) ||
+          KeyInfoUtil::ContainsKeyInformation(behavior.active_mode_ime_on_keys,
+                                              key_info) ||
+          KeyInfoUtil::ContainsKeyInformation(behavior.direct_mode_ime_off_keys,
                                               key_info)) {
         return true;
       }
@@ -1196,29 +1200,39 @@ class TipTextServiceImpl
     if (!BuildAltKeyInformation(alt_vk, &key_info)) {
       return false;
     }
-    const bool is_off_key = KeyInfoUtil::ContainsKeyInformation(
+    const bool is_active_off_key = KeyInfoUtil::ContainsKeyInformation(
         behavior.active_mode_ime_off_keys, key_info);
-    const bool is_on_key = KeyInfoUtil::ContainsKeyInformation(
+    const bool is_direct_on_key = KeyInfoUtil::ContainsKeyInformation(
         behavior.direct_mode_ime_on_keys, key_info);
+    const bool is_active_on_key = KeyInfoUtil::ContainsKeyInformation(
+        behavior.active_mode_ime_on_keys, key_info);
+    const bool is_direct_off_key = KeyInfoUtil::ContainsKeyInformation(
+        behavior.direct_mode_ime_off_keys, key_info);
 
-    // Only consume the Alt tap when it will actually toggle the IME in the
-    // *current* state: an active-mode off key while the IME is on, or a
-    // direct-mode on key while the IME is off. In any other state this tap is a
-    // no-op, so let the Alt key keep its normal (menu) behavior instead of
-    // swallowing it. This is what keeps a configured Alt key from breaking the
-    // application menu in the state where it has no IME effect.
-    const bool open = TipStatus::IsOpen(self->thread_mgr_.get());
-    const bool will_toggle = (open && is_off_key) || (!open && is_on_key);
-    if (!will_toggle) {
+    // In an editable context, any Alt key explicitly assigned to an IME on/off
+    // command is reserved for the IME even when pressing it is a no-op in the
+    // current state. This prevents a configured right Alt from activating the
+    // application menu while IME is already on, and a configured left Alt from
+    // doing so while IME is already off. Alt still passes through when the key
+    // is not assigned to an IME command, or when the focus is not editable.
+    const bool is_active_mode_key = is_active_off_key || is_active_on_key;
+    const bool is_direct_mode_key = is_direct_on_key || is_direct_off_key;
+    const bool should_consume = is_active_mode_key || is_direct_mode_key;
+    if (!should_consume) {
       return false;
     }
 
-    // Hand the actual processing to the task window, which runs in the normal
-    // message loop where the server key event and an async edit session can be
-    // driven safely (the server keymap decides the command, e.g. Commit|IMEOff
-    // or IMEOn, based on the current composition/open state).
-    ::PostMessageW(self->task_window_handle_, kAltTapToggleMessage,
-                   static_cast<WPARAM>(alt_vk), 0);
+    const bool open = TipStatus::IsOpen(self->thread_mgr_.get());
+    const bool should_send_to_server =
+        open ? is_active_mode_key : is_direct_mode_key;
+    if (should_send_to_server) {
+      // Hand the actual processing to the task window, which runs in the normal
+      // message loop where the server key event and an async edit session can
+      // be driven safely (the server keymap decides the command, e.g.
+      // Commit|IMEOff or IMEOn, based on the current composition/open state).
+      ::PostMessageW(self->task_window_handle_, kAltTapToggleMessage,
+                     static_cast<WPARAM>(alt_vk), 0);
+    }
     return true;
   }
 


### PR DESCRIPTION
## Description
LeftAlt / RightAltをwin32のキーコンフィグで使えるようにしました

### 目的
alt-ime-ahkの置き換えを主眼においています。これは左Altキーの空打ちで直接入力、右Altキーの空打ちでIME ONを切り替えるためのAutoHotKeyスクリプトで、様々な人がその時々で改変を加えながら維持しているものです。USキーボードで快適にIMEを切り替えるために必要になる設定です。
Macでは"英かな"や"Karabiner-elements"などを利用してどうようの挙動をしている人が多く、どちらの環境でも需要が高い機能です。

ただあくまで追加スクリプトであるため、IMEの状態などを正確に把握しきれていなかったり、テキスト入力以外でもAltキーの挙動（メニューを出す・ハイライトする）など奪ってしまうなどの問題がありました。

いままではIMEを直接機能追加できないためこのようなものを利用していたのですがMozkeyであれば可能であろうということでやってみたものとなります

### 技術的な詳細
#### ローレベルのキーボードハンドラ
Altキー単独で押した場合にText Services FrameworkはイベントをIMEのハンドラまで伝えません。そのため `WH_KEYBOARD_LL`  を追加して、ここから取得するようにしています。このハンドラはAlt空打ちを使ったコンフィグを利用している場合、かつ編集可能コンテキストでのみ追加し、フォーカスが外れるとすぐに解除する挙動にしています。

下記のようなキーコンフィグを登録していない場合はハンドラは登録されないため、この機能にバグがあった場合でも影響を与えないはずです。

#### メニュー抑止・Alt 押しっぱなし防止（disguise）
空打ち検出時、本物の Alt key upを飲み込み、`無害なkey (VK 0xE8) down→up→Alt key up` を注入。これにより「Alt 中に別キーが押された」と OS が認識してメニューを起動せず、かつ Alt のdown/upが釣り合うため押しっぱなし状態にもなりません（AutoHotkey と同系の手法）。単打以外（Alt+Tab / Alt+F4 等の組み合わせ）には一切手を加えません

### 設定例

```
DirectInput    RightAlt    IMEOn
Precomposition LeftAlt     IMEOff
Composition    LeftAlt     Commit|IMEOff
Conversion     LeftAlt     Commit|IMEOff
Suggestion     LeftAlt     Commit|IMEOff
Prediction     LeftAlt     Commit|IMEOff
```

この設定で数日間使用して問題がなく動作することを確認しています。