### PR TITLE
feat(config): enable live conversion and direct commit by default

### DIFF
--- a/src/config/config_handler.cc
+++ b/src/config/config_handler.cc
@@ -145,6 +145,24 @@ void NormalizeConfig(Config* config) {
       !config->has_use_emoji_conversion()) {
     config->set_use_emoji_conversion(true);
   }
+
+  if (!config->has_use_live_conversion()) {
+    config->set_use_live_conversion(true);
+  }
+
+  if (!config->has_use_direct_commit()) {
+    config->set_use_direct_commit(true);
+  }
+
+  if (!config->has_direct_commit_key()) {
+    config->set_direct_commit_key(
+        Config::DIRECT_COMMIT_KUTEN |
+        Config::DIRECT_COMMIT_TOUTEN |
+        Config::DIRECT_COMMIT_QUESTION_MARK |
+        Config::DIRECT_COMMIT_EXCLAMATION_MARK |
+        Config::DIRECT_COMMIT_OPEN_BRACKET |
+        Config::DIRECT_COMMIT_CLOSE_BRACKET);
+  }
 }
 
 class ConfigHandlerImpl final {

--- a/src/config/config_handler_test.cc
+++ b/src/config/config_handler_test.cc
@@ -70,6 +70,18 @@ class ConfigHandlerTest : public testing::TestWithTempUserProfile {
   std::string default_config_filename_;
 };
 
+void SetMozkeyInputDefaultsForTesting(Config* config) {
+  config->set_use_live_conversion(true);
+  config->set_use_direct_commit(true);
+  config->set_direct_commit_key(
+      Config::DIRECT_COMMIT_KUTEN |
+      Config::DIRECT_COMMIT_TOUTEN |
+      Config::DIRECT_COMMIT_QUESTION_MARK |
+      Config::DIRECT_COMMIT_EXCLAMATION_MARK |
+      Config::DIRECT_COMMIT_OPEN_BRACKET |
+      Config::DIRECT_COMMIT_CLOSE_BRACKET);
+}
+
 TEST_F(ConfigHandlerTest, SetConfig) {
   Config input;
   Config output;
@@ -87,29 +99,57 @@ TEST_F(ConfigHandlerTest, SetConfig) {
 #ifndef NDEBUG
   input.set_verbose_level(2);
 #endif  // NDEBUG
+  Config expected = input;
+  SetMozkeyInputDefaultsForTesting(&expected);
+
   ConfigHandler::SetConfig(input);
   output = ConfigHandler::GetCopiedConfig();
   config::Config output2 = ConfigHandler::GetCopiedConfig();
-  input.clear_general_config();
+  expected.clear_general_config();
   output.clear_general_config();
   output2.clear_general_config();
-  EXPECT_EQ(absl::StrCat(output), absl::StrCat(input));
-  EXPECT_EQ(absl::StrCat(output2), absl::StrCat(input));
+  EXPECT_EQ(absl::StrCat(output), absl::StrCat(expected));
+  EXPECT_EQ(absl::StrCat(output2), absl::StrCat(expected));
 
   ConfigHandler::GetDefaultConfig(&input);
   input.set_incognito_mode(false);
 #ifndef NDEBUG
   input.set_verbose_level(0);
 #endif  // NDEBUG
+  expected = input;
+  SetMozkeyInputDefaultsForTesting(&expected);
+
   ConfigHandler::SetConfig(input);
   output = ConfigHandler::GetCopiedConfig();
   output2 = ConfigHandler::GetCopiedConfig();
 
-  input.clear_general_config();
+  expected.clear_general_config();
   output.clear_general_config();
   output2.clear_general_config();
-  EXPECT_EQ(absl::StrCat(output), absl::StrCat(input));
-  EXPECT_EQ(absl::StrCat(output2), absl::StrCat(input));
+  EXPECT_EQ(absl::StrCat(output), absl::StrCat(expected));
+  EXPECT_EQ(absl::StrCat(output2), absl::StrCat(expected));
+}
+
+TEST_F(ConfigHandlerTest, NormalizeMozkeyInputDefaults) {
+  TempDirectory temp_dir = testing::MakeTempDirectoryOrDie();
+  const std::string config_file =
+      FileUtil::JoinPath(temp_dir.path(), "mozc_config_test_tmp");
+  ASSERT_OK(FileUtil::UnlinkIfExists(config_file));
+  ConfigHandler::SetConfigFileNameForTesting(config_file);
+  ConfigHandler::Reload();
+
+  const Config output = ConfigHandler::GetCopiedConfig();
+
+  EXPECT_TRUE(output.use_live_conversion());
+  EXPECT_TRUE(output.use_direct_commit());
+  EXPECT_EQ(
+      output.direct_commit_key(),
+      Config::DIRECT_COMMIT_KUTEN |
+          Config::DIRECT_COMMIT_TOUTEN |
+          Config::DIRECT_COMMIT_QUESTION_MARK |
+          Config::DIRECT_COMMIT_EXCLAMATION_MARK |
+          Config::DIRECT_COMMIT_OPEN_BRACKET |
+          Config::DIRECT_COMMIT_CLOSE_BRACKET);
 }
 
 TEST_F(ConfigHandlerTest, SetMetadata) {
@@ -243,6 +283,7 @@ TEST_F(ConfigHandlerTest, GetDefaultConfig) {
 #else   // __APPLE__ || OS_CHROMEOS
   EXPECT_EQ(output.session_keymap(), Config::MSIME);
 #endif  // __APPLE__ || OS_CHROMEOS
+
   EXPECT_EQ(output.character_form_rules_size(), 13);
 
   struct TestCase {

--- a/src/session/session_handler_scenario_test.cc
+++ b/src/session/session_handler_scenario_test.cc
@@ -44,6 +44,7 @@
 #include "absl/strings/str_replace.h"
 #include "base/file_stream.h"
 #include "base/file_util.h"
+#include "config/config_handler.h"
 #include "engine/engine_interface.h"
 #include "engine/mock_data_engine_factory.h"
 #include "protocol/commands.pb.h"
@@ -56,6 +57,23 @@
 ABSL_DECLARE_FLAG(bool, use_history_rewriter);
 
 namespace mozc {
+namespace {
+
+void SetLegacyInputDefaultsForScenarioTest() {
+  config::Config config;
+  config::ConfigHandler::GetDefaultConfig(&config);
+
+  // Scenario files are golden tests for the traditional Mozc session behavior.
+  // Keep live conversion and punctuation/symbol direct commit disabled unless a
+  // scenario explicitly opts into those features.
+  config.set_use_live_conversion(false);
+  config.set_use_direct_commit(false);
+  config.set_direct_commit_key(0);
+
+  config::ConfigHandler::SetConfig(config);
+}
+
+}  // namespace
 
 using ::mozc::session::SessionHandlerInterpreter;
 using ::mozc::session::testing::SessionHandlerTestBase;
@@ -66,15 +84,19 @@ class SessionHandlerScenarioTestBase : public SessionHandlerTestBase {
  protected:
   void SetUp() override {
     flagsaver_ = std::make_unique<absl::FlagSaver>();
+
     // Make sure to include history rewriter for testing.
     absl::SetFlag(&FLAGS_use_history_rewriter, true);
+
     // Note that singleton Config instance is backed up and restored
     // by SessionHandlerTestBase's SetUp and TearDown methods.
     SessionHandlerTestBase::SetUp();
+
+    SetLegacyInputDefaultsForScenarioTest();
+
     std::unique_ptr<EngineInterface> engine =
         MockDataEngineFactory::Create().value();
     handler_ = std::make_unique<SessionHandlerInterpreter>(std::move(engine));
-
   }
 
   void TearDown() override {


### PR DESCRIPTION
## 概要 #77 #78

この PR では、Mozkey の未設定 config に対する製品デフォルトとして以下を有効化します。

- ライブ変換をデフォルトで有効化
- 句読点・記号の単打確定をデフォルトで有効化
- 単打確定の初期対象を `、。？！「」` に設定
- 未設定 config の正規化処理に対するテストを追加
- 既存の session scenario test では、従来の Mozc セッション挙動を明示的に維持

## 意図

Mozkey 独自の目玉機能であるライブ変換を、初期状態から体験できるようにするための変更です。

Mozkey では、スペースキーを押してから変換する従来型の入力だけでなく、入力中の未確定文字列が自然に変換されていく入力体験を重視しています。  
この体験は、ユーザーが明示的に設定を探して ON にしないと触れられないものではなく、Mozkey を使い始めた時点で自然に体感できる方がよいであろうということから変更に至りました。

また、句読点・記号の単打確定はライブ変換と相性が良い機能です。

日本語の文章入力では、句読点や括弧は単なる記号ではなく、思考や文節の切れ目を示す役割を持っています。  
ライブ変換中に `、` や `。`、`？`、`！`、`「」` を入力したタイミングで現在の変換結果を確定できるようにすることで、入力者は自然な文の区切りで一拍置くことができます。

これは操作感の面でも、学習データの面でも利点があります。

- 句読点を打つだけで、表示中のライブ変換結果を自然に確定できる
- 確定操作のために Enter を明示的に押す回数を減らせる
- 文や文節の切れ目に近い単位で、変換結果を綺麗に学習させやすい
- 句読点が本来持っている「思考の区切り」「文の区切り」という役割と、IME の確定タイミングが近づく

そのため、この PR ではライブ変換だけでなく、句読点・記号の単打確定もあわせて初期有効にしています。

## 実装方針

当初は `config.proto` の default や `CreateDefaultConfig()` を直接変更する方針も検討しましたが、最終的には `NormalizeConfig()` で未設定 config を補完する形にしています。

`config.proto` の proto default は従来どおり維持します。

つまり、以下の低レイヤー default は変更しません。

- `use_live_conversion`
  - proto default は `false` のまま
- `use_direct_commit`
  - proto default は `false` のまま
- `direct_commit_key`
  - proto default は `0` のまま

これは、`Config` を直接生成する低レイヤー処理や既存 session test にまで暗黙に新挙動を広げないためです。

一方で、通常利用時に `ConfigHandler` を通って読み込まれる config については、該当 field が未設定の場合に Mozkey の製品デフォルトとして以下を補完します。

- `use_live_conversion = true`
- `use_direct_commit = true`
- `direct_commit_key = 207`

これにより、既存の低レイヤー挙動や golden scenario test の前提を壊さず、Mozkey を通常利用するユーザーには新しい初期入力体験を提供できます。

## 変更内容

### `config_handler.cc`

`NormalizeConfig()` で、未設定 config に対して Mozkey の製品デフォルトを補完します。

具体的には、該当 field が存在しない場合に以下を設定します。

```cpp
if (!config->has_use_live_conversion()) {
  config->set_use_live_conversion(true);
}

if (!config->has_use_direct_commit()) {
  config->set_use_direct_commit(true);
}

if (!config->has_direct_commit_key()) {
  config->set_direct_commit_key(
      Config::DIRECT_COMMIT_KUTEN |
      Config::DIRECT_COMMIT_TOUTEN |
      Config::DIRECT_COMMIT_QUESTION_MARK |
      Config::DIRECT_COMMIT_EXCLAMATION_MARK |
      Config::DIRECT_COMMIT_OPEN_BRACKET |
      Config::DIRECT_COMMIT_CLOSE_BRACKET);
}
````

`direct_commit_key` の bitmask は以下です。

```text
DIRECT_COMMIT_KUTEN             = 1    // 。
DIRECT_COMMIT_TOUTEN            = 2    // 、
DIRECT_COMMIT_QUESTION_MARK     = 4    // ？
DIRECT_COMMIT_EXCLAMATION_MARK  = 8    // ！
DIRECT_COMMIT_OPEN_BRACKET      = 64   // 「
DIRECT_COMMIT_CLOSE_BRACKET     = 128  // 」

1 | 2 | 4 | 8 | 64 | 128 = 207
```

初期対象は以下です。

```text
、。？！「」
```

### `config.proto`

`config.proto` の default は変更しません。

当初案では proto default を変更していましたが、それだと空の `Config` を直接生成する session 系テストや低レイヤー処理にも影響が広がるため、最終的には元の値を維持しています。

維持する値は以下です。

```proto
optional bool use_direct_commit = 1001 [default = false];
optional uint32 direct_commit_key = 1002 [default = 0];
optional bool use_live_conversion = 69 [default = false];
```

### `config_handler_test.cc`

未設定 config の正規化により、Mozkey の input defaults が補完されることを確認するテストを追加しました。

また、`SetConfig()` は内部で `NormalizeConfig()` を通るため、既存の `SetConfig` テストの期待値も正規化後の config に合わせています。

追加・修正した確認内容:

* 未設定 config の reload 後にライブ変換が有効になること
* 未設定 config の reload 後に句読点・記号の単打確定が有効になること
* 未設定 config の reload 後に単打確定対象が `、。？！「」` になること
* `SetConfig()` 後の config 比較では、正規化によって補完される Mozkey input defaults を期待値に含めること

### `session_handler_scenario_test.cc`

`session_handler_scenario_test` は、既存の scenario file に基づく golden test です。

これらの scenario は、従来の Mozc セッション挙動を前提にしているため、このテストではライブ変換と句読点・記号単打確定を明示的に無効化しています。

```cpp
config.set_use_live_conversion(false);
config.set_use_direct_commit(false);
config.set_direct_commit_key(0);
```

これにより、通常利用時の未設定 config には Mozkey の新しい製品デフォルトを適用しつつ、既存 scenario files の期待値は従来挙動として維持します。

## テスト

```powershell
bazelisk --output_user_root=C:/bzl test `
  --config oss_windows `
  --config release_build `
  //config:config_handler_test `
  //session:session_test `
  //session:session_regression_test `
  //session:session_handler_scenario_test `
  --verbose_failures
```

```powershell
bazelisk --output_user_root=C:/bzl build `
  --config oss_windows `
  --config release_build `
  package `
  --verbose_failures
```


## 備考

この変更は、既存機能の設定項目を削除したり、ユーザーが OFF にできなくしたりするものではありません。

ライブ変換と句読点・記号の単打確定は、引き続き設定画面から変更できます。

既存ユーザーでも、該当 field が未設定の場合は新しい Mozkey デフォルトが適用されます。
一方で、既に明示的な設定値が保存されている場合は、その値を尊重します。
