### PR TITLE
fix(session): let Space revert zenz live correction

### DIFF
--- a/src/session/session.cc
+++ b/src/session/session.cc
@@ -3181,8 +3181,20 @@ bool Session::SendKeyConversionState(commands::Command* command) {
       return ExecuteCommandSequence(remaining_sequence, command);
     }
 
+    // While a zenz correction is visible, the first plain Space should peel off
+    // only the speculative correction layer and return to the stable Mozc live
+    // conversion result.  The next Space can then enter normal candidate
+    // navigation as usual.  Other candidate-navigation keys keep their explicit
+    // navigation semantics.
+    if (key_command == keymap::ConversionState::CONVERT_NEXT &&
+        IsPureSpaceKey(input_key) &&
+        HasVisibleZenzLiveCorrection()) {
+      return RevertZenzLiveCorrectionToLiveConversion(command);
+    }
+
     // Explicit conversion operations such as Space, candidate movement, or Cancel
-    // promote live conversion back to normal conversion behavior.
+    // promote live conversion back to normal conversion behavior.  When a visible
+    // zenz layer exists, plain Space is consumed above to peel off that layer first.
     if (key_command != keymap::ConversionState::INSERT_CHARACTER) {
       if (key_command != keymap::ConversionState::COMMIT) {
         if (key_command == keymap::ConversionState::CANCEL ||
@@ -5324,6 +5336,50 @@ bool Session::OutputZenzLiveCorrection(
   // as user acceptance. Acceptance must be recorded only when the user commits
   // the visible zenz result.
   zenz_live_preedit_output_ = *preedit;
+  return true;
+}
+
+bool Session::RevertZenzLiveCorrectionToLiveConversion(
+    commands::Command* command) {
+  if (!HasVisibleZenzLiveCorrection()) {
+    return false;
+  }
+
+  ZenzDebugOutput(absl::StrCat(
+      "[zenz-feedback] revert zenz correction to mozc live conversion ",
+      ZenzRedactedTextStats("key", zenz_live_key_),
+      " ", ZenzRedactedTextStats("zenz_value", zenz_live_value_),
+      " ", ZenzRedactedTextStats("mozc_value", zenz_live_mozc_value_),
+      " visible_generation=", zenz_live_visible_generation_));
+
+  SetPendingZenzFeedbackRejected("space_revert_zenz_to_mozc");
+
+  const commands::Preedit live_preedit = live_conversion_preedit_output_;
+  ClearZenzLiveCorrectionState();
+
+  command->mutable_output()->set_consumed(true);
+  OutputMode(command);
+
+  commands::Output* output = command->mutable_output();
+  output->clear_candidate_window();
+  output->set_live_conversion(true);
+  output->set_live_conversion_pending(false);
+  output->set_zenz_live_correction_pending(false);
+  output->set_zenz_live_correction_applied(false);
+
+  if (live_preedit.segment_size() > 0) {
+    *output->mutable_preedit() = live_preedit;
+    output->mutable_preedit()->set_cursor(
+        Util::CharsLen(live_conversion_value_));
+  } else {
+    Output(command);
+    output->clear_candidate_window();
+    output->set_live_conversion(true);
+    output->set_live_conversion_pending(false);
+    output->set_zenz_live_correction_pending(false);
+    output->set_zenz_live_correction_applied(false);
+  }
+
   return true;
 }
 

--- a/src/session/session.h
+++ b/src/session/session.h
@@ -497,6 +497,8 @@ class Session {
   bool OutputZenzLiveCorrection(
       absl::string_view value,
       mozc::commands::Command* command);
+  bool RevertZenzLiveCorrectionToLiveConversion(
+      mozc::commands::Command* command);
   bool CommitZenzLiveCorrectionResult(mozc::commands::Command* command);
 
   std::string BuildZenzFeedbackContextClass(

--- a/src/session/session_test.cc
+++ b/src/session/session_test.cc
@@ -1139,6 +1139,77 @@ TEST_F(SessionTest,
 }
 
 TEST_F(SessionTest,
+       SpaceWhileZenzLiveCorrectionVisibleRevertsToMozcLiveConversion) {
+  MockEngine engine;
+  std::shared_ptr<MockConverter> converter = CreateEngineConverterMock(&engine);
+
+  ScopedUserProfileForZenzFeedbackSessionTest profile;
+  ASSERT_TRUE(profile.ok());
+
+  Session session(engine);
+  SessionTestPeer session_peer(session);
+  InitSessionToPrecomposition(&session);
+  EnableZenzLiveCorrectionWithFeedbackLearning(&session);
+
+  session_peer.zenz_feedback_store_().RecordAccepted(
+      "かれはてんてきです",
+      "japanese_only",
+      "彼は天敵です");
+  ASSERT_FALSE(session_peer.zenz_feedback_store_().ListEntries().empty());
+
+  session_peer.context_()->set_state(ImeContext::CONVERSION);
+  session_peer.live_conversion_active_() = true;
+  session_peer.live_conversion_key_() = "かれはてんてきです";
+  session_peer.live_conversion_preedit_() = "かれはてんてきです";
+  session_peer.live_conversion_value_() = "彼は点滴です";
+
+  commands::Preedit& live_preedit =
+      session_peer.live_conversion_preedit_output_();
+  live_preedit.Clear();
+
+  commands::Preedit::Segment* segment = live_preedit.add_segment();
+  segment->set_key("かれは");
+  segment->set_value("彼は");
+  segment->set_value_length(Util::CharsLen("彼は"));
+
+  segment = live_preedit.add_segment();
+  segment->set_key("てんてきです");
+  segment->set_value("点滴です");
+  segment->set_value_length(Util::CharsLen("点滴です"));
+
+  commands::Command command;
+  ASSERT_TRUE(session_peer.MaybeApplyZenzFeedbackLiveCorrection(&command));
+  ASSERT_TRUE(command.output().zenz_live_correction_applied());
+  EXPECT_PREEDIT("彼は天敵です", command);
+
+  command.Clear();
+  EXPECT_TRUE(SendSpecialKey(commands::KeyEvent::SPACE, &session, &command));
+
+  EXPECT_TRUE(command.output().consumed());
+  EXPECT_TRUE(command.output().live_conversion());
+  EXPECT_FALSE(command.output().live_conversion_pending());
+  EXPECT_FALSE(command.output().zenz_live_correction_pending());
+  EXPECT_FALSE(command.output().zenz_live_correction_applied());
+  EXPECT_FALSE(command.output().has_candidate_window());
+  EXPECT_PREEDIT("彼は点滴です", command);
+
+  EXPECT_EQ(session.context().state(), ImeContext::CONVERSION);
+  EXPECT_TRUE(session_peer.live_conversion_active_());
+  EXPECT_TRUE(session_peer.zenz_live_key_().empty());
+  EXPECT_TRUE(session_peer.zenz_live_value_().empty());
+  EXPECT_TRUE(session_peer.zenz_live_mozc_value_().empty());
+  EXPECT_TRUE(session_peer.zenz_live_context_class_().empty());
+
+  ASSERT_TRUE(session_peer.pending_zenz_feedback_().pending);
+  EXPECT_EQ(session_peer.pending_zenz_feedback_().key,
+            "かれはてんてきです");
+  EXPECT_EQ(session_peer.pending_zenz_feedback_().value,
+            "彼は天敵です");
+  EXPECT_EQ(session_peer.pending_zenz_feedback_().reason,
+            "space_revert_zenz_to_mozc");
+}
+
+TEST_F(SessionTest,
        ZenzFeedbackFastPathDoesNotOverrideSingleSegmentLiveConversion) {
   MockEngine engine;
   std::shared_ptr<MockConverter> converter = CreateEngineConverterMock(&engine);


### PR DESCRIPTION
## 概要 #83 #84 

ライブ変換と Zenz 補正を併用している場合に、Zenz 補正表示中の `Space` で、Zenz 補正前の Mozc ライブ変換結果へ戻せるようにします。

これまでは、Zenz 補正結果が表示された状態で `Space` を押すと、通常のライブ変換中に `Space` を押した場合と同様に、変換候補ウィンドウが開き、次候補へ進む挙動になっていました。

この PR では、Zenz 補正表示中の plain `Space` 1回目だけを「Zenz 補正レイヤーを剥がす」操作として扱います。

```text
Zenz補正結果
  ↓ Space
Mozcライブ変換結果
  ↓ Space
通常の候補選択
```

## 変更内容

* Zenz 補正表示中の plain `Space` を検出し、通常候補操作へ進める前に Mozc ライブ変換結果へ戻す処理を追加
* `RevertZenzLiveCorrectionToLiveConversion()` を追加

  * Zenz 補正を rejected feedback として記録
  * Zenz 補正状態のみをクリア
  * `live_conversion_active_` は維持
  * 保存済みの Mozc ライブ変換 preedit を再出力
  * 候補ウィンドウは表示しない
* 上記挙動を確認する `session_test` を追加

## 意図

Zenz 補正は、ユーザーが候補一覧から明示的に選んだ結果ではなく、ライブ変換結果に対して後から重なる補正レイヤーです。

そのため、Zenz 補正結果が意図と違った場合には、すぐに補正前の安定した Mozc ライブ変換結果へ戻れる動線があるほうが自然です。

従来の挙動では、Zenz 補正を取り消したいだけの `Space` が、そのまま通常変換の次候補操作として扱われ、候補ウィンドウ表示と次候補選択まで進んでいました。

この PR により、Zenz 補正表示中の操作は次のようになります。

```text
Space 1回目:
  Zenz補正を却下して、Mozcライブ変換結果へ戻す

Space 2回目:
  従来どおり通常変換候補へ進む
```

## 仕様上の注意

対象は plain `Space` のみです。

`Down` など Space 以外の候補移動操作は、従来どおり通常変換候補操作へ進みます。これにより、候補操作系キーの既存挙動を不用意に変更しないようにしています。

また、Zenz 補正が表示されていない通常のライブ変換中は、従来どおり `Space` で通常変換候補へ進みます。

## テスト

以下を確認済みです。

```powershell
bazelisk --output_user_root=C:/bzl test `
  --config oss_windows `
  --config release_build `
  //session:session_test `
  --verbose_failures
```

## 実機確認

Windows 環境で `mozc_server.exe` を差し替えて、以下の挙動を確認しました。

* ライブ変換 ON
* Zenz 補正 ON
* Zenz 補正表示中に `Space` 1回目で Mozc ライブ変換結果へ戻る
* この時点では候補ウィンドウは開かない
* さらに `Space` を押すと、従来どおり候補ウィンドウが開き、次候補へ進む
* Zenz 補正が表示されていない通常ライブ変換中の `Space` は従来どおり動作する

