### PR TITLE
fix(conversion): improve expressive kana and mimetic handling

### DIFF
--- a/src/session/session.cc
+++ b/src/session/session.cc
@@ -456,7 +456,7 @@ bool IsStrongExpressiveKanaAtom(absl::string_view atom) {
       atom);
 }
 
-bool IsBoundarySensitiveExpressiveKanaAtom(absl::string_view atom) {
+bool IsBoundarySensitiveExpressiveKanaCoreAtom(absl::string_view atom) {
   return ContainsStringView(
       {
           "ふん",
@@ -466,6 +466,16 @@ bool IsBoundarySensitiveExpressiveKanaAtom(absl::string_view atom) {
           "はて",
           "ふう",
           "ほう",
+          "ほい",
+          "ほいほい",
+          "へい",
+          "てへ",
+          "くちゃ",
+          "くちょ",
+          "ぐちょ",
+          "ぐちょぐちょ",
+          "どろどろ",
+          "つるつる",
           "はいはい",
           "うん",
           "うんうん",
@@ -525,6 +535,51 @@ bool IsHoFamilyExpressiveProsodyAtom(absl::string_view atom) {
 constexpr size_t kMaxExpressiveSokuonCount = 10;
 constexpr size_t kMaxEvaluativeSlangPrefixChars = 4;
 
+bool StripRepeatedExpressiveSokuonTail(absl::string_view atom,
+                                       absl::string_view* core) {
+  size_t sokuon_count = 0;
+  absl::string_view cursor = atom;
+
+  while (!cursor.empty()) {
+    absl::string_view rest;
+    char32_t last = 0;
+    if (!Util::SplitLastChar32(cursor, &rest, &last)) {
+      return false;
+    }
+
+    if (last != U'っ') {
+      break;
+    }
+
+    ++sokuon_count;
+    if (sokuon_count > kMaxExpressiveSokuonCount) {
+      return false;
+    }
+
+    cursor = rest;
+  }
+
+  if (sokuon_count == 0 || cursor.empty()) {
+    return false;
+  }
+
+  *core = cursor;
+  return true;
+}
+
+bool IsBoundarySensitiveExpressiveKanaAtom(absl::string_view atom) {
+  if (IsBoundarySensitiveExpressiveKanaCoreAtom(atom)) {
+    return true;
+  }
+
+  absl::string_view core;
+  if (!StripRepeatedExpressiveSokuonTail(atom, &core)) {
+    return false;
+  }
+
+  return IsBoundarySensitiveExpressiveKanaCoreAtom(core);
+}
+
 bool ConsumePrefixForLiveConversionMatcher(absl::string_view* text,
                                            absl::string_view prefix) {
   if (text->size() < prefix.size() ||
@@ -533,6 +588,19 @@ bool ConsumePrefixForLiveConversionMatcher(absl::string_view* text,
   }
   *text = text->substr(prefix.size());
   return true;
+}
+
+bool ConsumeAnyPrefixForLiveConversionMatcher(
+    absl::string_view* text,
+    std::initializer_list<absl::string_view> prefixes) {
+  for (absl::string_view prefix : prefixes) {
+    absl::string_view rest = *text;
+    if (ConsumePrefixForLiveConversionMatcher(&rest, prefix)) {
+      *text = rest;
+      return true;
+    }
+  }
+  return false;
 }
 
 bool IsOnlyLiveConversionProlongationMarks(absl::string_view text) {
@@ -596,6 +664,33 @@ bool ConsumeRepeatedExpressiveSokuon(absl::string_view* text) {
   }
 
   return sokuon_count > 0;
+}
+
+bool MatchesSokuonEndingMimeticAtom(absl::string_view atom,
+                                    absl::string_view stem) {
+  absl::string_view rest = atom;
+
+  if (!ConsumePrefixForLiveConversionMatcher(&rest, stem)) {
+    return false;
+  }
+
+  if (!ConsumeRepeatedExpressiveSokuon(&rest)) {
+    return false;
+  }
+
+  if (rest.empty()) {
+    return true;
+  }
+
+  return IsOnlyLiveConversionProlongationMarks(rest);
+}
+
+bool IsSokuonEndingMimeticAtom(absl::string_view atom) {
+  return MatchesSokuonEndingMimeticAtom(atom, "しゃ") ||
+         MatchesSokuonEndingMimeticAtom(atom, "どろ") ||
+         MatchesSokuonEndingMimeticAtom(atom, "とろ") ||
+         MatchesSokuonEndingMimeticAtom(atom, "さわ") ||
+         MatchesSokuonEndingMimeticAtom(atom, "つる");
 }
 
 bool MatchesRepeatedSokuonPrefix(absl::string_view atom,
@@ -995,13 +1090,13 @@ bool MatchesUhyoFamilyExpressiveProsodyAtom(absl::string_view atom) {
     return false;
   }
 
-  // Accept both 「うひょ」 and emphasized forms such as 「うっひょ」 and
-  // 「うっっひょ」.
-  if (!ConsumePrefixForLiveConversionMatcher(&rest, "ひょ")) {
+  // Accept both 「うひょ」/「うひゃ」 and emphasized forms such as
+  // 「うっひょ」, 「うっひゃ」, 「うっっひょ」 and 「うっっひゃ」.
+  if (!ConsumeAnyPrefixForLiveConversionMatcher(&rest, {"ひょ", "ひゃ"})) {
     if (!ConsumeRepeatedExpressiveSokuon(&rest)) {
       return false;
     }
-    if (!ConsumePrefixForLiveConversionMatcher(&rest, "ひょ")) {
+    if (!ConsumeAnyPrefixForLiveConversionMatcher(&rest, {"ひょ", "ひゃ"})) {
       return false;
     }
   }
@@ -1148,6 +1243,10 @@ bool ShouldHoldExpressiveKanaAtomForLiveConversion(
       return CanHoldLowAmbiguityExpressiveAtom(atom);
     }
 
+    if (IsSokuonEndingMimeticAtom(lexical_atom)) {
+      return CanHoldBoundarySensitiveExpressiveAtom(atom);
+    }
+
     if (IsBoundarySensitiveExpressiveKanaAtom(lexical_atom)) {
       return CanHoldBoundarySensitiveExpressiveAtom(atom);
     }
@@ -1163,10 +1262,59 @@ bool ShouldHoldExpressiveKanaAtomForLiveConversion(
   return false;
 }
 
+bool IsAsciiLetterForPendingRomanSuffix(char c) {
+  return ('a' <= c && c <= 'z') || ('A' <= c && c <= 'Z');
+}
+
+bool StripTrailingAsciiLetterSuffix(absl::string_view text,
+                                    absl::string_view* core) {
+  size_t suffix_len = 0;
+
+  while (!text.empty() &&
+         IsAsciiLetterForPendingRomanSuffix(text.back())) {
+    text.remove_suffix(1);
+    ++suffix_len;
+  }
+
+  if (suffix_len == 0 || text.empty()) {
+    return false;
+  }
+
+  *core = text;
+  return true;
+}
+
+bool ShouldSkipLiveConversionForPendingRomanSuffixAfterExpressiveKana(
+    absl::string_view key,
+    LiveConversionLeftBoundary committed_left_boundary) {
+  absl::string_view kana_core;
+  if (!StripTrailingAsciiLetterSuffix(key, &kana_core)) {
+    return false;
+  }
+
+  const absl::string_view expressive_core =
+      StripTrailingLiveConversionSentenceTail(kana_core);
+  if (expressive_core.empty()) {
+    return false;
+  }
+
+  const LiveConversionAtom atom =
+      ExtractTrailingLiveConversionAtom(expressive_core,
+                                        committed_left_boundary);
+
+  return ShouldHoldExpressiveKanaAtomForLiveConversion(atom,
+                                                       expressive_core);
+}
+
 bool ShouldSkipLiveConversionForCompositionKey(
     absl::string_view key,
     LiveConversionLeftBoundary committed_left_boundary) {
   if (Util::CharsLen(key) < kMinLiveConversionCompositionLength) {
+    return true;
+  }
+
+  if (ShouldSkipLiveConversionForPendingRomanSuffixAfterExpressiveKana(
+          key, committed_left_boundary)) {
     return true;
   }
 
@@ -3934,6 +4082,7 @@ bool Session::MaybeScheduleLiveConversion(commands::Command* command) {
   if (ShouldSkipLiveConversionForCompositionKey(
           key, GetLiveConversionCommittedLeftBoundary(*context_)) ||
       length != context_->composer().GetCursor()) {
+    CancelPendingLiveConversion();
     return false;
   }
 
@@ -4016,7 +4165,9 @@ bool Session::ApplyDelayedLiveConversion(commands::Command* command) {
           current_key,
           GetLiveConversionCommittedLeftBoundary(*context_)) ||
       length != context_->composer().GetCursor()) {
-    return IgnoreStaleDelayedLiveConversion(command);
+    CancelPendingLiveConversion();
+    OutputFromState(command);
+    return true;
   }
 
   return MaybeStartLiveConversion(command);

--- a/src/session/session_test.cc
+++ b/src/session/session_test.cc
@@ -1462,6 +1462,11 @@ TEST_F(SessionTest,
 TEST_F(SessionTest, LiveConversionKeepsExpressiveKanaAtomsAsComposition) {
   constexpr absl::string_view kExpressiveAtoms[] = {
       "ふん",
+      "ふんっ",
+      "ふんっっ",
+      "ふんっっっー",
+      "ふむっ",
+      "ほうっっ",
       "ちっ",
       "ちぇっ",
       "くそ",
@@ -1476,6 +1481,48 @@ TEST_F(SessionTest, LiveConversionKeepsExpressiveKanaAtomsAsComposition) {
       "ほう",
       "はいはい",
       "ほっほーん",
+
+      "ほい",
+      "ほいっ",
+      "ほいっっ",
+      "ほいほい",
+      "ほいほいっ",
+      "へい",
+      "へいっ",
+      "へいっっ",
+
+      "しゃっ",
+      "しゃっっ",
+      "しゃっー",
+
+      "てへ",
+      "てへっ",
+      "てへっっ",
+
+      "くちゃ",
+      "くちょ",
+      "ぐちょ",
+      "ぐちょっ",
+      "ぐちょっっ",
+      "ぐちょぐちょ",
+      "ぐちょぐちょっ",
+
+      "どろっ",
+      "どろっっ",
+      "どろっー",
+      "どろどろ",
+      "どろどろっ",
+      "とろっ",
+      "とろっっ",
+      "とろっー",
+      "さわっ",
+      "さわっっ",
+      "さわっー",
+      "つるっ",
+      "つるっっ",
+      "つるっー",
+      "つるつる",
+      "つるつるっ",
 
       "ちっす",
       "ちっっす",
@@ -1498,6 +1545,16 @@ TEST_F(SessionTest, LiveConversionKeepsExpressiveKanaAtomsAsComposition) {
       "うっひょーん",
       "うっっひょ",
       "うっっひょーん",
+
+      "うひゃ",
+      "うひゃー",
+      "うひゃ～",
+      "うひゃーん",
+      "うっひゃ",
+      "うっひゃー",
+      "うっひゃーん",
+      "うっっひゃ",
+      "うっっひゃーん",
 
       "うっそん",
       "うっっそ",
@@ -1948,6 +2005,7 @@ TEST_F(SessionTest, LiveConversionDoesNotHoldNonExpressiveSokuonWords) {
       "いっった",
       "きっかけ",
       "やっと",
+      "ふんっか",
       "かって",
       "まって",
 
@@ -1978,6 +2036,13 @@ TEST_F(SessionTest, LiveConversionDoesNotHoldNonExpressiveSokuonWords) {
       "ちょうど",
       "もっとく",
       "もっとも",
+
+      "へいわ",
+      "しゃっくり",
+      "くちゃくちゃ",
+      "くちょう",
+      "とろとろ",
+      "さわった",
   };
 
   for (absl::string_view key : kKeys) {
@@ -2012,6 +2077,145 @@ TEST_F(SessionTest, LiveConversionDoesNotHoldNonExpressiveSokuonWords) {
 
     EXPECT_EQ(session.context().state(), ImeContext::CONVERSION);
     EXPECT_TRUE(command.output().live_conversion());
+
+    Mock::VerifyAndClearExpectations(converter.get());
+  }
+}
+
+TEST_F(SessionTest,
+       DelayedLiveConversionClearsPendingOutputWhenCurrentKeyIsSkipped) {
+  MockEngine engine;
+  std::shared_ptr<MockConverter> converter =
+      CreateEngineConverterMock(&engine);
+
+  Session session(engine);
+  InitSessionToPrecomposition(&session);
+
+  config::Config config;
+  config::ConfigHandler::GetDefaultConfig(&config);
+  config.set_use_live_conversion(true);
+  config.set_live_conversion_delay_msec(100);
+  session.SetConfig(config);
+
+  commands::Command command;
+
+  EXPECT_CALL(*converter, StartConversion(_, _)).Times(0);
+  InsertCharacterString("かき", "aa", &session, &command);
+  ASSERT_TRUE(command.output().has_callback());
+  ASSERT_TRUE(command.output().callback().has_session_command());
+
+  const commands::SessionCommand delayed_command =
+      command.output().callback().session_command();
+
+  Mock::VerifyAndClearExpectations(converter.get());
+
+  EXPECT_CALL(*converter, StartConversion(_, _)).Times(0);
+
+  command.Clear();
+  EXPECT_TRUE(SendKey("Escape", &session, &command));
+
+  command.Clear();
+  InsertCharacterString("ふんっっ", "aaaa", &session, &command);
+
+  command.Clear();
+  command.mutable_input()->set_type(commands::Input::SEND_COMMAND);
+  *command.mutable_input()->mutable_command() = delayed_command;
+
+  EXPECT_TRUE(session.SendCommand(&command));
+  EXPECT_FALSE(command.output().live_conversion());
+  EXPECT_FALSE(command.output().live_conversion_pending());
+  EXPECT_TRUE(EnsurePreedit("ふんっっ", command));
+}
+
+TEST_F(SessionTest,
+       DelayedLiveConversionClearsPendingOutputForExpressiveKanaWithPendingRomanSuffix) {
+  MockEngine engine;
+  std::shared_ptr<MockConverter> converter =
+      CreateEngineConverterMock(&engine);
+
+  Session session(engine);
+  InitSessionToPrecomposition(&session);
+
+  config::Config config;
+  config::ConfigHandler::GetDefaultConfig(&config);
+  config.set_use_live_conversion(true);
+  config.set_live_conversion_delay_msec(100);
+  session.SetConfig(config);
+
+  commands::Command command;
+
+  EXPECT_CALL(*converter, StartConversion(_, _)).Times(0);
+  InsertCharacterString("かき", "aa", &session, &command);
+  ASSERT_TRUE(command.output().has_callback());
+  ASSERT_TRUE(command.output().callback().has_session_command());
+
+  const commands::SessionCommand delayed_command =
+      command.output().callback().session_command();
+
+  Mock::VerifyAndClearExpectations(converter.get());
+
+  EXPECT_CALL(*converter, StartConversion(_, _)).Times(0);
+
+  command.Clear();
+  EXPECT_TRUE(SendKey("Escape", &session, &command));
+
+  command.Clear();
+  InsertCharacterString("ふんっlt", "aaaaa", &session, &command);
+
+  command.Clear();
+  command.mutable_input()->set_type(commands::Input::SEND_COMMAND);
+  *command.mutable_input()->mutable_command() = delayed_command;
+
+  EXPECT_TRUE(session.SendCommand(&command));
+  EXPECT_FALSE(command.output().live_conversion());
+  EXPECT_FALSE(command.output().live_conversion_pending());
+  EXPECT_TRUE(EnsurePreedit("ふんっｌｔ", command));
+}
+
+TEST_F(SessionTest,
+       LiveConversionKeepsExpressiveKanaWithPendingRomanSuffixAsComposition) {
+  struct TestCase {
+    absl::string_view key;
+    absl::string_view expected_preedit;
+  };
+
+  constexpr TestCase kTestCases[] = {
+      {"ふんl", "ふんｌ"},
+      {"ふんlt", "ふんｌｔ"},
+      {"ふんっl", "ふんっｌ"},
+      {"ふんっlt", "ふんっｌｔ"},
+      {"ふんっっl", "ふんっっｌ"},
+      {"ふんっっlt", "ふんっっｌｔ"},
+      {"ふむl", "ふむｌ"},
+      {"ふむっlt", "ふむっｌｔ"},
+      {"ほうlt", "ほうｌｔ"},
+      {"ほうっlt", "ほうっｌｔ"},
+  };
+
+  for (const TestCase& test_case : kTestCases) {
+    MockEngine engine;
+    std::shared_ptr<MockConverter> converter =
+        CreateEngineConverterMock(&engine);
+
+    Session session(engine);
+    InitSessionToPrecomposition(&session);
+
+    config::Config config;
+    config::ConfigHandler::GetDefaultConfig(&config);
+    config.set_use_live_conversion(true);
+    config.set_live_conversion_delay_msec(0);
+    session.SetConfig(config);
+
+    EXPECT_CALL(*converter, StartConversion(_, _)).Times(0);
+
+    commands::Command command;
+    const std::string dummy_key_codes(Util::CharsLen(test_case.key), 'a');
+    InsertCharacterString(test_case.key, dummy_key_codes, &session, &command);
+
+    EXPECT_EQ(session.context().state(), ImeContext::COMPOSITION);
+    EXPECT_FALSE(command.output().live_conversion());
+    EXPECT_FALSE(command.output().live_conversion_pending());
+    EXPECT_TRUE(EnsurePreedit(test_case.expected_preedit, command));
 
     Mock::VerifyAndClearExpectations(converter.get());
   }

--- a/tools/dictionary/generate_syntax_guard_dictionary.py
+++ b/tools/dictionary/generate_syntax_guard_dictionary.py
@@ -65,6 +65,15 @@ SEEDED_PREFIX_GUARDS = (
 
     # Secondary useful variant.
     ("にわける", "に別ける", "に", "わける"),
+
+    # Fix:
+    #   になったりします -> 担ったりします
+    # Keep the grammar boundary between the particle に and なったり...
+    ("になったり", "になったり", "に", "なったり"),
+    ("になったりする", "になったりする", "に", "なったりする"),
+    ("になったりします", "になったりします", "に", "なったりします"),
+    ("になったりして", "になったりして", "に", "なったりして"),
+    ("になったりした", "になったりした", "に", "なったりした"),
 )
 
 SEEDED_FIXED_GUARDS = (
@@ -91,13 +100,25 @@ SEEDED_FIXED_GUARDS = (
     ("とうちたいのに", "と打ちたいのに", "と", "のに"),
 )
 
-DIRECT_IDIOM_GUARDS = (
+DIRECT_FIXED_GUARDS = (
     # Idiom rescue:
     # 肌身離さず is a fixed idiomatic expression.  This is not a broad
     # syntax-boundary guard; keep it explicit so generation remains
     # reproducible without depending on whether component entries exist.
-    ("はだみはなさ", 1851, 1851, 3600, "肌身離さ"),
-    ("はだみはなさず", 1851, 1851, 3600, "肌身離さず"),
+    ("はだみはなさ", 1851, 1851, 3600, "肌身離さ", "direct_idiom_guard"),
+    ("はだみはなさず", 1851, 1851, 3600, "肌身離さず", "direct_idiom_guard"),
+
+    # Mimetic rescue:
+    # ぐちょぐちょ and ぐちょっと are natural hiragana mimetic expressions,
+    # but the base dictionary does not contain them, so conversion can fall
+    # back to unnatural segmentation such as 愚著具著 or 具ちょっと.
+    #
+    # Use ids/costs close to existing hiragana mimetic entries such as
+    # つるつる and どろどろ.
+    ("ぐちょぐちょ", 12, 12, 4300, "ぐちょぐちょ", "direct_mimetic_guard"),
+    ("ぐちょぐちょ", 1841, 1841, 6200, "ぐちょぐちょ", "direct_mimetic_guard"),
+    ("ぐちょっと", 12, 12, 4300, "ぐちょっと", "direct_mimetic_guard"),
+    ("ぐちょっと", 1841, 1841, 6200, "ぐちょっと", "direct_mimetic_guard"),
 )
 
 DANGEROUS_READING_SUFFIXES = (
@@ -434,12 +455,13 @@ def make_seeded_fixed_guard(
     )
 
 
-def make_direct_idiom_guard(
+def make_direct_fixed_guard(
     key: str,
     lid: int,
     rid: int,
     cost: int,
     value: str,
+    reason: str,
 ) -> GuardEntry:
     return GuardEntry(
         key=key,
@@ -447,7 +469,7 @@ def make_direct_idiom_guard(
         rid=rid,
         cost=cost,
         value=value,
-        reason="direct_idiom_guard",
+        reason=reason,
         source_key=key,
         source_value=value,
         collision_value="",
@@ -610,13 +632,14 @@ def generate_guards(
         guards.append(guard)
         stats["seeded_fixed_guards"] += 1
 
-    for key, lid, rid, cost, value in DIRECT_IDIOM_GUARDS:
-        guard = make_direct_idiom_guard(
+    for key, lid, rid, cost, value, reason in DIRECT_FIXED_GUARDS:
+        guard = make_direct_fixed_guard(
             key=key,
             lid=lid,
             rid=rid,
             cost=cost,
             value=value,
+            reason=reason,
         )
         signature = (guard.key, guard.lid, guard.rid, guard.value)
         if signature in seen:
@@ -624,7 +647,7 @@ def generate_guards(
             continue
         seen.add(signature)
         guards.append(guard)
-        stats["direct_idiom_guards"] += 1
+        stats[reason] += 1
 
     guards.sort(key=lambda e: (e.key, e.value, e.lid, e.rid, e.cost))
 


### PR DESCRIPTION
## Summary

This PR improves live-conversion behavior for expressive kana and mimetic expressions.

It keeps short expressive kana utterances and sokuon-tail forms from being prematurely converted during live conversion, and adds small generated dictionary guards for mimetic / grammar-boundary cases that should work even inside longer phrases.

## Changes

- Keep expressive kana atoms with trailing sokuon as kana during live conversion.
  - Examples: `ふんっ`, `ふんっっ`, `ふむっ`, `ほうっっ`
- Suppress stale delayed live-conversion output when the current composition should be skipped.
  - This prevents brief ruby/live-conversion overlay flicker.
- Treat pending roman suffixes after expressive kana as in-progress composition.
  - Examples: `ふんl`, `ふんlt`, `ふんっl`, `ふんっlt`
  - This avoids hard-coding specific romaji table entries such as `ltu` or `xtu`.
- Expand expressive kana coverage.
  - Examples: `ほい`, `ほいっ`, `ほいほい`, `へい`, `てへ`, `うひゃ`, `ぐちょ`, `ぐちょぐちょ`, `どろどろ`, `つるつる`
- Add direct mimetic dictionary guards for:
  - `ぐちょぐちょ`
  - `ぐちょっと`
- Add grammar-boundary guards for `になったり...` forms to avoid conversions such as:
  - `になったりします` → `担ったりします`

## Design notes

Session-side guards are used only for live-conversion timing and short expressive atoms, where suppressing conversion is appropriate.

Dictionary-side guards are used for mimetic expressions and grammar-boundary cases that must work inside longer phrases. This avoids broad suffix heuristics in the session layer and keeps normal live conversion behavior intact for longer sentences.

## Testing

- `git diff --check`
- `bazelisk --output_user_root=C:/bzl test --config oss_windows --config release_build //session:session_test --test_output=errors --verbose_failures`
- `py ..\tools\dictionary\generate_syntax_guard_dictionary.py`
- `.\tools\dictionary\prepare_daily_dictionary.ps1`
- `bazelisk --output_user_root=C:/bzl build --config oss_windows --config release_build //server:mozc_server --verbose_failures`

## Real-machine verification

Verified on Windows with live conversion enabled.

Confirmed kana retention / no flicker for expressive inputs such as:

- `ふんっ`
- `ふんっっ`
- `ふんっlt`
- `ほい`
- `ほいっ`
- `ほいほい`
- `てへっ`
- `うひゃ`
- `ぐちょっ`
- `ぐちょぐちょ`
- `どろどろ`
- `つるつる`

Confirmed dictionary guard behavior for:

- `ぐちょぐちょ`
- `今日はぐちょぐちょ`
- `ぐちょっと`
- `道がぐちょっとしている`
- `になったりします`
