### PR TITLE
fix(conversion): move expressive kana rescue to dictionary

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Windows 用のビルド済み MSI は [Releases](https://github.com/koyasi777/mo
 - 本 fork のリリースは個人用の experimental build として公開しています。
 - Zenz 同梱版は、ローカル推論 runtime と GGUF model を含むため、従来の offline MSI よりファイルサイズが大きくなります。
 - Windows 向けリリース MSI には、ローカル生成した `daily` system dictionary profile を同梱する場合があります。
-- `daily` profile には、Mozc 標準辞書に加えて、merge-ut-dictionaries、dic-nico-intersection-pixiv、mozcdic-ut-personal-names、Mozkey syntax guard dictionary 由来の生成辞書が含まれます。
+- `daily` profile には、Mozc 標準辞書に加えて、merge-ut-dictionaries、dic-nico-intersection-pixiv、mozcdic-ut-personal-names、Mozkey syntax / expressive kana guard dictionary 由来の生成辞書が含まれます。
 - 外部辞書・同梱 runtime・model の出典とライセンス note については [Third-party notices](THIRD_PARTY_NOTICES.md) を参照してください。
 
 > [!WARNING]
@@ -69,7 +69,7 @@ Windows 用のビルド済み MSI は [Releases](https://github.com/koyasi777/mo
 - ライブ変換は入力直後の不要な変換ちらつきを抑えるため、文字入力後に短いデバウンスを挟んで実行
 - 1文字だけの未確定文字列では、助詞などの誤変換を避けるためライブ変換を実行しない
 - `え~`、`えー`、`ん？` のような「かな1文字 + 装飾的な末尾記号」でも、短すぎる漢字化を避けるためライブ変換を抑制
-- `ふん`、`ふむ`、`はて`、`うひょー`、`すっごい`、`なっがい`、`めっちゃ`、`ちーっす`、`ちょりーっす` のような感嘆詞・口語評価語・くだけた挨拶が、ライブ変換中に不自然な漢字やカタカナへ寄る挙動を抑制
+- 感嘆詞・口語評価語・くだけた挨拶の入力途中ではライブ変換のちらつきを抑えつつ、完成した `うっそ`、`くっそ`、`やっば`、`すっげぇ`、`めっちゃ`、`ちっす`、`ちょりっす`、`ほえ～`、`ほぇ～`、`ほっほーん` などは生成辞書候補として自然なかな表記を救出
 - 確定済みの左文脈や直前の文節、限定的な右文脈を参照し、`mainにマージしました`、`githubには`、`2名しかいない`、`追記したい`、`山梨県立美術館`、`滋賀方面` のような文脈で、助詞・複合機能語・機能表現・接尾的な語構成・地名接尾構成が同音漢字候補に負ける挙動を抑制
 - キー設定エディタで、1つのキー入力に対して複数のコマンドを順序付きで割り当て可能
 - 複数コマンドは `Commit|IMEOff` のような形式で保存され、設定画面では `Commit → IMEOff` のように編集可能
@@ -176,17 +176,19 @@ Windows 版では、追加のオフライン防御層として、インストー
 
 また、`え~`、`えー`、`ん？` のように、かな1文字の後ろに装飾的な記号だけが続く場合もライブ変換を抑制します。これにより、入力途中の `え~` が `絵～` のように短すぎる漢字候補へ変換される挙動を避けます。
 
-さらに、短い感嘆詞、口語的な評価語、くだけた挨拶など、ひらがなのまま使われることが多い表現では、ライブ変換による過剰な漢字化・カタカナ化を抑制します。
+さらに、短い感嘆詞、口語的な評価語、くだけた挨拶などでは、入力途中の prefix や pending roman suffix によるライブ変換のちらつきを抑えます。一方で、完成した表現は session 側でライブ変換を止めず、converter と辞書候補に渡します。
+
+完成した expressive kana については、生成辞書に自然なかな候補を追加します。これにより初期状態では不自然な漢字分割に寄りにくくしつつ、ユーザーが `ウッソ`、`クッソ`、`ヤッバ`、`チッス`、`ホェ～` などのカタカナ表記を明示的に選んだ場合には、ユーザー履歴やユーザー辞書による表記選好が反映される余地を残します。
 
 対象には、たとえば以下のような入力が含まれます。
 
-- `ふん`、`ふむ`、`はて`、`ほう`
-- `うひょー`、`うっひょーん`、`うっそん`
-- `すっごい`、`なっがい`、`たっかい`、`あっちぃ`
-- `めっちゃ`
-- `ちっす`、`ちーっす`、`ちょーっす`、`ちょりーっす`
+- `うっそ`、`くっそ`、`やっば`、`やっべぇ`
+- `すっご`、`すっげぇ`、`めっちゃ`
+- `ちっす`、`ちょっす`、`ちょりっす`
+- `うひょ`、`うひゃ`、`ほほう`、`ほっほーん`
+- `ほえー`、`ほえ～`、`ほぇ`、`ほぇー`、`ほぇ～`
 
-これらは通常変換そのものを禁止するものではありません。Space を押した場合は従来どおり変換候補を出せます。ライブ変換中だけ、入力途中の短い口語表現が意図せず別の漢字語やカタカナ語へ先走って表示されることを避けます。
+これらは通常変換そのものを禁止するものではありません。完成した表現は通常の変換候補として扱われるため、Space 変換やユーザー履歴による候補順位の調整も従来どおり有効です。
 
 たとえば:
 
@@ -394,9 +396,10 @@ daily local 辞書は主に以下を元に生成できます。
   - 人名・芸名・活動名などを含む人名辞書
   - 生成済み daily 辞書、nico/pixiv delta、Mozc 標準辞書に既に存在する key/value は除外
   - 短すぎる読み、長いカタカナ塊、グループ名風表記、ASCII 表記、記号を含む表記などは除外または弱める
-- Mozkey syntax guard 辞書
+- Mozkey syntax / expressive kana guard 辞書
   - 文節区切り崩れの影響が大きいケースだけを小さな生成辞書として補強
-  - 例: `と打ちたいのに`、`に分ける`、`にまで`、`までに`、`までも`、`肌身離さず` のような経路を保護
+  - 例: `と打ちたいのに`、`に分ける`、`にまで`、`までに`、`までも`、`肌身離さず`、`になってしまいます`、`になっちゃいます` のような経路を保護
+  - 例: `うっそ`、`くっそ`、`やっば`、`ちっす`、`ほえ～`、`ほぇ～` のような完成済み expressive kana を自然なかな候補として補強
 
 巨大な生成辞書ファイルは、このリポジトリには commit しません。`src/data/dictionary_koyasi/generated/` 以下にローカル生成します。
 
@@ -504,7 +507,7 @@ Windows MSI packages are available from [Releases](https://github.com/koyasi777/
 - Releases from this fork are published as personal experimental builds.
 - Zenz-bundled builds are larger than the traditional offline MSI because they include a local inference runtime and a GGUF model.
 - Windows release MSI packages may include the locally generated `daily` system dictionary profile.
-- The `daily` profile is generated from the Mozc base dictionaries, merge-ut-dictionaries, dic-nico-intersection-pixiv, mozcdic-ut-personal-names, and the Mozkey syntax guard dictionary.
+- The `daily` profile is generated from the Mozc base dictionaries, merge-ut-dictionaries, dic-nico-intersection-pixiv, mozcdic-ut-personal-names, and the Mozkey syntax / expressive kana guard dictionary.
 - See [Third-party notices](THIRD_PARTY_NOTICES.md) for source and license notes for bundled runtimes, model files, and generated dictionary data.
 
 > [!WARNING]
@@ -534,7 +537,7 @@ Main features added in this fork
 - Applies live conversion after a short debounce delay to avoid noisy intermediate conversions
 - Suppresses live conversion for one-character compositions to avoid over-converting particles
 - Suppresses live conversion for very short kana compositions with decorative trailing symbols such as `え~`, `えー`, or `ん？`
-- Suppresses over-eager live conversion for short expressive kana utterances, colloquial evaluative forms, and casual greetings such as `ふん`, `ふむ`, `うひょー`, `すっごい`, `なっがい`, `めっちゃ`, `ちーっす`, and `ちょりーっす`
+- Suppresses live-conversion flicker for unfinished expressive kana prefixes, while completed expressive forms such as `うっそ`, `くっそ`, `やっば`, `すっげぇ`, `めっちゃ`, `ちっす`, `ちょりっす`, `ほえ～`, `ほぇ～`, and `ほっほーん` are rescued as generated dictionary candidates
 - Uses committed left context, previous segments, and limited right context to reduce unnatural homophone results in cases such as `mainにマージしました`, `githubには`, `2名しかいない`, `追記したい`, `山梨県立美術館`, and `滋賀方面`
 - Allows assigning multiple commands to a single key binding as an ordered command sequence
 - Stores command sequences as `Commit|IMEOff` and shows them in the keymap editor as `Commit → IMEOff`
@@ -607,9 +610,11 @@ To reduce distracting intermediate conversions, this fork applies live conversio
 
 Live conversion is also suppressed for very short kana compositions followed only by decorative trailing symbols, such as `え~`, `えー`, or `ん？`. This avoids noisy intermediate conversions such as `え~` becoming `絵～` while the user is still typing.
 
-This fork also keeps many short expressive kana utterances, colloquial evaluative forms, and casual greetings as kana during live conversion. Examples include `ふん`, `ふむ`, `はて`, `うひょー`, `うっそん`, `すっごい`, `なっがい`, `あっちぃ`, `めっちゃ`, `ちーっす`, and `ちょりーっす`.
+For short expressive kana utterances, colloquial evaluative forms, and casual greetings, this fork suppresses live-conversion flicker only while the user is still typing an unfinished prefix or a pending roman suffix. Completed expressions are allowed to reach the normal converter.
 
-This does not disable normal conversion. Pressing Space still invokes ordinary conversion candidates. The suppression only prevents live conversion from prematurely showing unnatural kanji or katakana results while the user is still composing these short colloquial expressions.
+For completed expressive forms, the generated dictionary adds natural kana candidates such as `うっそ`, `くっそ`, `やっば`, `すっげぇ`, `めっちゃ`, `ちっす`, `ちょりっす`, `ほえ～`, `ほぇ～`, and `ほっほーん`. This avoids pathological kanji segmentation by default while still allowing explicit user selections, user history, and user dictionary entries such as `ウッソ`, `クッソ`, `ヤッバ`, `チッス`, or `ホェ～` to influence future ranking.
+
+This does not disable normal conversion. Pressing Space still invokes ordinary conversion candidates, and completed expressive words remain ordinary converter candidates.
 
 For example:
 
@@ -863,9 +868,10 @@ The daily local dictionary can be generated from:
   - personal names, stage names, and activity names
   - entries already covered by the generated daily dictionary, nico/pixiv delta dictionary, or base Mozc dictionaries are skipped
   - risky short readings, long katakana-like names, group-like names, ASCII values, and punctuation-heavy values are filtered or demoted
-- Mozkey syntax guard dictionary
+- Mozkey syntax / expressive kana guard dictionary
   - small generated guard entries for high-impact segmentation failures
-  - for example, protecting paths such as `と打ちたいのに`, `に分ける`, `にまで`, `までに`, `までも`, and `肌身離さず`
+  - for example, protecting paths such as `と打ちたいのに`, `に分ける`, `にまで`, `までに`, `までも`, `肌身離さず`, `になってしまいます`, and `になっちゃいます`
+  - also adds natural kana candidates for completed expressive forms such as `うっそ`, `くっそ`, `やっば`, `ちっす`, `ほえ～`, `ほぇ～`, and `ほっほーん`
 
 Large generated dictionary files are not committed to this repository.
 They are generated locally under `src/data/dictionary_koyasi/generated/`.

--- a/src/session/session.cc
+++ b/src/session/session.cc
@@ -1264,6 +1264,70 @@ bool ShouldHoldExpressiveKanaAtomForLiveConversion(
   return false;
 }
 
+bool FindEvaluativeSlangAdjectivePrefixSuffix(
+    absl::string_view text,
+    absl::string_view* suffix) {
+  size_t offset = 0;
+  for (absl::string_view c : Utf8AsChars(text)) {
+    const absl::string_view candidate = text.substr(offset);
+    if (IsEvaluativeSlangAdjectivePrefixAtom(candidate)) {
+      *suffix = candidate;
+      return true;
+    }
+    offset += c.size();
+  }
+
+  return false;
+}
+
+bool ShouldHoldEvaluativeSlangAdjectivePrefixForLiveConversion(
+    const LiveConversionAtom& atom,
+    absl::string_view lexical_core) {
+  if (IsEvaluativeSlangAdjectivePrefixAtom(atom.text)) {
+    return atom.is_entire_composition ||
+           atom.left_boundary == LiveConversionLeftBoundary::kKnownBoundary;
+  }
+
+  absl::string_view suffix;
+  if (!FindEvaluativeSlangAdjectivePrefixSuffix(lexical_core, &suffix)) {
+    return false;
+  }
+
+  // Protect short colloquial phrase prefixes such as 「これやっ」 or
+  // 「まじでなっ」, but let completed forms like 「これやっば」 reach the
+  // converter so user history and user dictionary preferences can apply.
+  return HasShortPrefixBeforeSuffix(
+      lexical_core, suffix, kMaxEvaluativeSlangPrefixChars);
+}
+
+bool ShouldHoldExpressiveKanaTypingPrefixForLiveConversion(
+    const LiveConversionAtom& atom,
+    absl::string_view expressive_core) {
+  if (atom.text.empty()) {
+    return false;
+  }
+
+  if (IsUhyoFamilyExpressiveProsodyPrefixAtom(atom.text) ||
+      IsUsoOrKusoFamilyExpressiveProsodyPrefixAtom(atom.text) ||
+      IsCasualSsuGreetingPrefixAtom(atom.text)) {
+    return CanHoldLowAmbiguityExpressiveAtom(atom);
+  }
+
+  const absl::string_view lexical_atom =
+      StripTrailingLiveConversionProlongationMarks(atom.text);
+  const absl::string_view lexical_core =
+      StripTrailingLiveConversionProlongationMarks(expressive_core);
+
+  if (!lexical_atom.empty() &&
+      Util::IsScriptType(lexical_atom, Util::HIRAGANA) &&
+      ShouldHoldEvaluativeSlangAdjectivePrefixForLiveConversion(
+          atom, lexical_core)) {
+    return true;
+  }
+
+  return false;
+}
+
 bool IsAsciiLetterForPendingRomanSuffix(char c) {
   return ('a' <= c && c <= 'z') || ('A' <= c && c <= 'Z');
 }
@@ -1320,18 +1384,18 @@ bool ShouldSkipLiveConversionForCompositionKey(
     return true;
   }
 
-  // First, protect short expressive utterance atoms before applying the legacy
-  // decorative-tail rule.  In particular, do not strip "ー" here; otherwise
-  // forms such as 「ほほー」 would collapse to 「ほほ」 and lose their expressive
-  // prosody.
+  // Keep only unfinished expressive typing prefixes out of live conversion.
+  // Completed expressive words should reach the converter so that normal
+  // dictionary ranking, user history, and user dictionary entries can decide
+  // between hiragana and katakana spellings.
   const absl::string_view expressive_core =
       StripTrailingLiveConversionSentenceTail(key);
   if (!expressive_core.empty()) {
     const LiveConversionAtom atom =
         ExtractTrailingLiveConversionAtom(expressive_core,
                                           committed_left_boundary);
-    if (ShouldHoldExpressiveKanaAtomForLiveConversion(atom,
-                                                      expressive_core)) {
+    if (ShouldHoldExpressiveKanaTypingPrefixForLiveConversion(
+            atom, expressive_core)) {
       return true;
     }
   }

--- a/src/session/session_test.cc
+++ b/src/session/session_test.cc
@@ -1533,258 +1533,135 @@ TEST_F(SessionTest,
   EXPECT_EQ(session.context().state(), ImeContext::COMPOSITION);
 }
 
-TEST_F(SessionTest, LiveConversionKeepsExpressiveKanaAtomsAsComposition) {
+TEST_F(SessionTest,
+       LiveConversionRunsConverterForDictionaryBackedExpressiveKanaAtoms) {
   constexpr absl::string_view kExpressiveAtoms[] = {
-      "ふん",
-      "ふんっ",
-      "ふんっっ",
-      "ふんっっっー",
-      "ふむっ",
-      "ほうっっ",
-      "ちっ",
-      "ちぇっ",
-      "くそ",
-      "よう",
-      "ふむ",
-      "はて",
-      "ほっ",
-      "ふう",
-      "いてっ",
-      "ぎゃっ",
-      "ひゃっ",
-      "ほう",
-      "はいはい",
-      "ほっほーん",
-
-      "ほい",
-      "ほいっ",
-      "ほいっっ",
-      "ほいほい",
-      "ほいほいっ",
-      "へい",
-      "へいっ",
-      "へいっっ",
-
-      "しゃっ",
-      "しゃっっ",
-      "しゃっー",
-
-      "てへ",
-      "てへっ",
-      "てへっっ",
-
-      "くちゃ",
-      "くちょ",
-      "ぐちょ",
-      "ぐちょっ",
-      "ぐちょっっ",
-      "ぐちょぐちょ",
-      "ぐちょぐちょっ",
-
-      "どろっ",
-      "どろっっ",
-      "どろっー",
-      "どろどろ",
-      "どろどろっ",
-      "とろっ",
-      "とろっっ",
-      "とろっー",
-      "さわっ",
-      "さわっっ",
-      "さわっー",
-      "つるっ",
-      "つるっっ",
-      "つるっー",
-      "つるつる",
-      "つるつるっ",
-
+      "うっそ",
+      "うっそー",
+      "うっそん",
+      "うっっそ",
+      "うっっっそーん",
+      "くっそ",
+      "くっそー",
+      "くっっそ",
+      "くっっっそー",
+      "やっば",
+      "やっっばい",
+      "やっべぇ",
+      "やっっべー",
+      "すっご",
+      "すっっごい",
+      "すっげぇ",
+      "すっっげー",
+      "すっくな",
+      "すっくねぇ",
+      "すっぱ",
+      "すっぺぇ",
+      "こっわ",
+      "こっっわい",
+      "つっよ",
+      "つっっよい",
+      "つっら",
+      "つっれぇ",
+      "でっか",
+      "でっっかい",
+      "なっが",
+      "なっっがい",
+      "たっか",
+      "たっけぇ",
+      "ちっさ",
+      "ちっちゃ",
+      "ちっせぇ",
+      "ひっく",
+      "ひっろ",
+      "さっむ",
+      "さっみぃ",
+      "さっみい",
+      "あっつ",
+      "あっちぃ",
+      "あっちい",
+      "あっっか",
+      "うっま",
+      "うっめぇ",
+      "うっざ",
+      "うっぜぇ",
+      "うっす",
+      "かっる",
+      "きっつ",
+      "きっちぃ",
+      "きっも",
+      "きっれい",
+      "だっる",
+      "だっりぃ",
+      "だっさ",
+      "だっせぇ",
+      "えっぐ",
+      "えっっぐ",
+      "えっぐい",
+      "えっっぐい",
+      "くっさ",
+      "くっせ",
+      "くっっせ",
+      "くっせぇ",
+      "くっろ",
+      "おっも",
+      "おっそ",
+      "はっや",
+      "めっちゃ",
+      "めっっちゃ",
+      "もっっと",
+      "もっっっと",
+      "ねっむ",
+      "ほっそ",
+      "せっま",
+      "みっじか",
+      "しっろ",
       "ちっす",
       "ちっっす",
       "ちーっす",
       "ちぃーっす",
-      "ちぃーーっす",
-      "ちーっすー",
       "ちょっす",
       "ちょーっす",
-      "ちょーっすー",
       "ちょりっす",
       "ちょりーっす",
-      "ちょりーっすー",
-
       "うひょ",
       "うひょー",
       "うひょーん",
       "うっひょ",
       "うっひょー",
       "うっひょーん",
-      "うっっひょ",
-      "うっっひょーん",
-
       "うひゃ",
       "うひゃー",
       "うひゃ～",
       "うひゃーん",
       "うっひゃ",
       "うっひゃー",
-      "うっひゃーん",
-      "うっっひゃ",
-      "うっっひゃーん",
-
-      "うっそん",
-      "うっっそ",
-      "うっっっそーん",
-      "くっそ",
-      "くっっそ",
-      "くっっっそー",
-
-      "やっば",
-      "やっっばい",
-      "やっべぇ",
-      "やっっべー",
-
-      "すっご",
-      "すっっごい",
-      "すっげぇ",
-      "すっっげー",
-      "すっくな",
-      "すっっくない",
-      "すっくね",
-      "すっっくねぇ",
-      "すっくねえ",
-      "すっくねー",
-      "すっぱ",
-      "すっっぱ",
-      "すっっっぱ",
-      "すっぱー",
-      "すっっぱー",
-      "すっぺぇ",
-      "すっっぺー",
-
-      "こっわ",
-      "こっっわい",
-
-      "つっよ",
-      "つっっよい",
-      "つっら",
-      "つっっらい",
-      "つっれぇ",
-      "つっっれー",
-
-      "でっか",
-      "でっっかい",
-
-      "なっが",
-      "なっっがい",
-
-      "たっか",
-      "たっっかい",
-      "たっけぇ",
-      "たっっけー",
-
-      "ちっさ",
-      "ちっっさい",
-      "ちっちゃ",
-      "ちっっちゃい",
-      "ちっせぇ",
-      "ちっっせー",
-
-      "ひっく",
-      "ひっっくい",
-      "ひっろ",
-      "ひっっろい",
-
-      "さっむ",
-      "さっっむい",
-      "さっみぃ",
-      "さっっみー",
-
-      "あっつ",
-      "あっっつい",
-      "あっちぃ",
-      "あっっちー",
-
-      "うっま",
-      "うっっまい",
-      "うっめぇ",
-      "うっっめー",
-      "うっざ",
-      "うっっざい",
-      "うっぜぇ",
-      "うっっぜー",
-      "うっす",
-      "うっっすい",
-
-      "かっる",
-      "かっっるい",
-
-      "きっつ",
-      "きっっつい",
-      "きっちぃ",
-      "きっっちー",
-      "きっも",
-      "きっっもい",
-      "きっれい",
-      "きっっれい",
-
-      "だっる",
-      "だっっるい",
-      "だっりぃ",
-      "だっっりー",
-      "だっさ",
-      "だっっさい",
-      "だっせぇ",
-      "だっっせー",
-
-      "えっぐ",
-      "えっっぐい",
-
-      "くっさ",
-      "くっっさい",
-      "くっせぇ",
-      "くっっせー",
-      "くっろ",
-      "くっっろい",
-
-      "まっぶし",
-      "まっっぶしい",
-
-      "おっも",
-      "おっっもい",
-      "おっそ",
-      "おっっそい",
-
-      "はっや",
-      "はっっやい",
-
-      "めっちゃ",
-      "めっっちゃ",
-
-      "もっと",
-      "もっっと",
-      "もっっっと",
-      "もっとー",
-      "もっっとー",
-
-      "ねっむ",
-      "ねっっむい",
-
-      "ほっそ",
-      "ほっっそい",
-
-      "せっま",
-      "せっっまい",
-
-      "みっじか",
-      "みっっじかい",
-
-      "しっろ",
-      "しっっろい",
-
-      "ええ",
-      "えぇ",
-      "ぇぇ",
-      "えぇぇ",
-      "えぇー",
+      "ほほう",
+      "ほっほーん",
+      "くちゃ",
+      "くちょ",
+      "ぐちょ",
+      "ぐちょっ",
+      "ぐちょぐちょ",
+      "ぐちょぐちょっ",
+      "ぐちょっと",
+      "どろっ",
+      "どろどろ",
+      "とろっ",
+      "さわっ",
+      "つるっ",
+      "つるつる",
+      "ほえー",
+      "ほえ～",
+      "ほぇ",
+      "ほぇー",
+      "ほぇ～",
+      "ほえぇ",
+      "ほえぇー",
+      "ほえぇ～",
+      "ほぇぇ",
+      "ほぇぇー",
+      "ほぇぇ～",
   };
 
   for (absl::string_view expressive_atom : kExpressiveAtoms) {
@@ -1801,22 +1678,22 @@ TEST_F(SessionTest, LiveConversionKeepsExpressiveKanaAtomsAsComposition) {
     config.set_live_conversion_delay_msec(0);
     session.SetConfig(config);
 
-    std::vector<std::string> chars;
+    std::vector<absl::string_view> chars;
     for (absl::string_view c : Utf8AsChars(expressive_atom)) {
-      chars.emplace_back(c);
+      chars.push_back(c);
     }
-    ASSERT_GE(chars.size(), 2);
+    ASSERT_FALSE(chars.empty());
 
     std::string prefix;
     std::string prefix_key_codes;
     for (size_t i = 0; i + 1 < chars.size(); ++i) {
-      prefix.append(chars[i]);
+      absl::StrAppend(&prefix, chars[i]);
       prefix_key_codes.push_back('a');
     }
 
-    // Some prefixes such as 「ちぇ」「いて」「はいは」 are intentionally not
-    // covered by the prefix test.  This test verifies that the completed
-    // expressive atom is held as kana during live conversion.
+    // Prefixes may be held as composition or may attempt live conversion.
+    // The assertion below is only about the completed dictionary-backed
+    // expressive word.
     EXPECT_CALL(*converter, StartConversion(_, _))
         .Times(::testing::AnyNumber())
         .WillRepeatedly(Return(false));
@@ -1826,15 +1703,25 @@ TEST_F(SessionTest, LiveConversionKeepsExpressiveKanaAtomsAsComposition) {
 
     Mock::VerifyAndClearExpectations(converter.get());
 
-    EXPECT_CALL(*converter, StartConversion(_, _)).Times(0);
+    Segments segments;
+    Segment* segment = segments.add_segment();
+    segment->set_key(std::string(expressive_atom));
+    converter::Candidate* candidate = segment->add_candidate();
+    candidate->key = std::string(expressive_atom);
+    candidate->content_key = std::string(expressive_atom);
+    candidate->value = std::string(expressive_atom);
+
+    EXPECT_CALL(*converter, StartConversion(_, _))
+        .Times(AtLeast(1))
+        .WillRepeatedly(DoAll(SetArgPointee<1>(segments), Return(true)));
 
     command.Clear();
     InsertCharacterString(chars.back(), "a", &session, &command);
 
     EXPECT_EQ(session.context().composer().GetQueryForConversion(),
               expressive_atom);
-    EXPECT_EQ(session.context().state(), ImeContext::COMPOSITION);
-    EXPECT_PREEDIT(expressive_atom, command);
+    EXPECT_EQ(session.context().state(), ImeContext::CONVERSION);
+    EXPECT_TRUE(command.output().live_conversion());
 
     Mock::VerifyAndClearExpectations(converter.get());
   }
@@ -1954,13 +1841,9 @@ TEST_F(SessionTest,
   };
 
   constexpr TestCase kTestCases[] = {
-      {"ち", "ssu", "ちっす"},
-      {"ちー", "ssu", "ちーっす"},
-      {"ちぃー", "ssu", "ちぃーっす"},
+      // Completed forms such as 「ちっす」 are now routed to the converter.
+      // This test keeps only a genuinely pending roman suffix.
       {"ちょ", "r", "ちょr"},
-      {"ちょー", "ssu", "ちょーっす"},
-      {"ちょり", "ssu", "ちょりっす"},
-      {"ちょりー", "ssu", "ちょりーっす"},
   };
 
   for (const TestCase& test_case : kTestCases) {
@@ -2189,7 +2072,7 @@ TEST_F(SessionTest,
   EXPECT_TRUE(SendKey("Escape", &session, &command));
 
   command.Clear();
-  InsertCharacterString("ふんっっ", "aaaa", &session, &command);
+  InsertCharacterString("やっっ", "aaa", &session, &command);
 
   command.Clear();
   command.mutable_input()->set_type(commands::Input::SEND_COMMAND);
@@ -2198,7 +2081,7 @@ TEST_F(SessionTest,
   EXPECT_TRUE(session.SendCommand(&command));
   EXPECT_FALSE(command.output().live_conversion());
   EXPECT_FALSE(command.output().live_conversion_pending());
-  EXPECT_TRUE(EnsurePreedit("ふんっっ", command));
+  EXPECT_TRUE(EnsurePreedit("やっっ", command));
 }
 
 TEST_F(SessionTest,
@@ -2249,21 +2132,22 @@ TEST_F(SessionTest,
 TEST_F(SessionTest,
        LiveConversionKeepsExpressiveKanaWithPendingRomanSuffixAsComposition) {
   struct TestCase {
-    absl::string_view key;
+    absl::string_view kana_prefix;
+    absl::string_view roman_suffix;
     absl::string_view expected_preedit;
   };
 
   constexpr TestCase kTestCases[] = {
-      {"ふんl", "ふんｌ"},
-      {"ふんlt", "ふんｌｔ"},
-      {"ふんっl", "ふんっｌ"},
-      {"ふんっlt", "ふんっｌｔ"},
-      {"ふんっっl", "ふんっっｌ"},
-      {"ふんっっlt", "ふんっっｌｔ"},
-      {"ふむl", "ふむｌ"},
-      {"ふむっlt", "ふむっｌｔ"},
-      {"ほうlt", "ほうｌｔ"},
-      {"ほうっlt", "ほうっｌｔ"},
+      {"ふん", "l", "ふんｌ"},
+      {"ふん", "lt", "ふんｌｔ"},
+      {"ふんっ", "l", "ふんっｌ"},
+      {"ふんっ", "lt", "ふんっｌｔ"},
+      {"ふんっっ", "l", "ふんっっｌ"},
+      {"ふんっっ", "lt", "ふんっっｌｔ"},
+      {"ふむ", "l", "ふむｌ"},
+      {"ふむっ", "lt", "ふむっｌｔ"},
+      {"ほう", "lt", "ほうｌｔ"},
+      {"ほうっ", "lt", "ほうっｌｔ"},
   };
 
   for (const TestCase& test_case : kTestCases) {
@@ -2280,11 +2164,25 @@ TEST_F(SessionTest,
     config.set_live_conversion_delay_msec(0);
     session.SetConfig(config);
 
-    EXPECT_CALL(*converter, StartConversion(_, _)).Times(0);
+    // A completed kana prefix may now reach the converter.  The pending roman
+    // suffix itself must still stay in composition and must not start another
+    // live conversion.
+    EXPECT_CALL(*converter, StartConversion(_, _))
+        .Times(::testing::AnyNumber())
+        .WillRepeatedly(Return(false));
 
     commands::Command command;
-    const std::string dummy_key_codes(Util::CharsLen(test_case.key), 'a');
-    InsertCharacterString(test_case.key, dummy_key_codes, &session, &command);
+    const std::string prefix_key_codes(
+        Util::CharsLen(test_case.kana_prefix), 'a');
+    InsertCharacterString(test_case.kana_prefix, prefix_key_codes,
+                          &session, &command);
+
+    Mock::VerifyAndClearExpectations(converter.get());
+
+    EXPECT_CALL(*converter, StartConversion(_, _)).Times(0);
+
+    command.Clear();
+    InsertCharacterChars(test_case.roman_suffix, &session, &command);
 
     EXPECT_EQ(session.context().state(), ImeContext::COMPOSITION);
     EXPECT_FALSE(command.output().live_conversion());

--- a/tools/dictionary/generate_syntax_guard_dictionary.py
+++ b/tools/dictionary/generate_syntax_guard_dictionary.py
@@ -74,6 +74,33 @@ SEEDED_PREFIX_GUARDS = (
     ("になったりします", "になったりします", "に", "なったりします"),
     ("になったりして", "になったりして", "に", "なったりして"),
     ("になったりした", "になったりした", "に", "なったりした"),
+
+    # Fix:
+    #   になってしまいます -> 担ってしまいます
+    # Keep the grammar boundary between the particle に and the auxiliary-like
+    # なってしま... sequence.  Do not add bare になって here; it can legitimately
+    # compete with 担って.  Guard only longer constructions where the functional
+    # phrase reading is much more likely.
+    ("になってしま", "になってしま", "に", "なってしま"),
+    ("になってしまう", "になってしまう", "に", "なってしまう"),
+    ("になってしまい", "になってしまい", "に", "なってしまい"),
+    ("になってしまいます", "になってしまいます", "に", "なってしまいます"),
+    ("になってしまいました", "になってしまいました", "に", "なってしまいました"),
+    ("になってしまっ", "になってしまっ", "に", "なってしまっ"),
+    ("になってしまった", "になってしまった", "に", "なってしまった"),
+    ("になってしまって", "になってしまって", "に", "なってしまって"),
+    ("になってしまえば", "になってしまえば", "に", "なってしまえば"),
+    ("になってしまわ", "になってしまわ", "に", "なってしまわ"),
+    ("になってしまわない", "になってしまわない", "に", "なってしまわない"),
+    ("になってしまわず", "になってしまわず", "に", "なってしまわず"),
+
+    # Colloquial contraction of になってしま...
+    ("になっちゃ", "になっちゃ", "に", "なっちゃ"),
+    ("になっちゃう", "になっちゃう", "に", "なっちゃう"),
+    ("になっちゃい", "になっちゃい", "に", "なっちゃい"),
+    ("になっちゃいます", "になっちゃいます", "に", "なっちゃいます"),
+    ("になっちゃった", "になっちゃった", "に", "なっちゃった"),
+    ("になっちゃって", "になっちゃって", "に", "なっちゃって"),
 )
 
 SEEDED_FIXED_GUARDS = (
@@ -108,17 +135,364 @@ DIRECT_FIXED_GUARDS = (
     ("はだみはなさ", 1851, 1851, 3600, "肌身離さ", "direct_idiom_guard"),
     ("はだみはなさず", 1851, 1851, 3600, "肌身離さず", "direct_idiom_guard"),
 
-    # Mimetic rescue:
-    # ぐちょぐちょ and ぐちょっと are natural hiragana mimetic expressions,
-    # but the base dictionary does not contain them, so conversion can fall
-    # back to unnatural segmentation such as 愚著具著 or 具ちょっと.
-    #
-    # Use ids/costs close to existing hiragana mimetic entries such as
-    # つるつる and どろどろ.
-    ("ぐちょぐちょ", 12, 12, 4300, "ぐちょぐちょ", "direct_mimetic_guard"),
-    ("ぐちょぐちょ", 1841, 1841, 6200, "ぐちょぐちょ", "direct_mimetic_guard"),
-    ("ぐちょっと", 12, 12, 4300, "ぐちょっと", "direct_mimetic_guard"),
-    ("ぐちょっと", 1841, 1841, 6200, "ぐちょっと", "direct_mimetic_guard"),
+)
+
+# Direct kana entries for completed expressive words.
+#
+# These entries are intentionally dictionary candidates, not session-level
+# live-conversion suppressors.  This lets the default output rescue natural
+# hiragana forms while still allowing user history / user dictionary entries
+# such as ウッソ, クッソ, ヤッバ, etc. to win after explicit selection.
+#
+# Use conservative costs close to the existing hiragana mimetic rescue entries:
+# cheap enough to beat pathological kanji segmentation, but not so cheap that
+# user-learned katakana spellings become unreachable.
+DEFAULT_EXPRESSIVE_KANA_GUARD_COSTS = (
+    (12, 12, 4300),
+    (1841, 1841, 6200),
+)
+
+# These forms strongly compete with common katakana loanword candidates such as
+# エッグ.  Keep them as dictionary candidates, not session suppressions, but make
+# the default hiragana rescue slightly stronger than the generic expressive
+# kana guards.
+STRONG_EXPRESSIVE_KANA_GUARD_COSTS = (
+    (12, 12, 3600),
+    (1841, 1841, 5600),
+)
+
+# Some expressive spellings compete with very strong ordinary dictionary
+# entries after the converter normalizes or approximates repeated small っ.
+# Keep these as dictionary candidates rather than session suppressions, but make
+# the kana rescue strong enough to beat the ordinary homophone path.
+EXTRA_STRONG_EXPRESSIVE_KANA_GUARD_COSTS = (
+    (12, 12, 2600),
+    (1841, 1841, 4600),
+)
+
+EXPRESSIVE_KANA_COST_OVERRIDES = {
+    "えっぐ": STRONG_EXPRESSIVE_KANA_GUARD_COSTS,
+    "えっっぐ": STRONG_EXPRESSIVE_KANA_GUARD_COSTS,
+    "えっぐい": STRONG_EXPRESSIVE_KANA_GUARD_COSTS,
+    "えっっぐい": STRONG_EXPRESSIVE_KANA_GUARD_COSTS,
+
+    # Do not add bare あっか because it strongly conflicts with 悪化.  Only the
+    # explicitly emphasized double-促音 spelling is rescued here.
+    "あっっか": EXTRA_STRONG_EXPRESSIVE_KANA_GUARD_COSTS,
+}
+
+
+def make_direct_expressive_kana_guards(*surface_groups):
+    surfaces = []
+    seen = set()
+    for group in surface_groups:
+        for surface in group:
+            if surface in seen:
+                continue
+            seen.add(surface)
+            surfaces.append(surface)
+
+    guards = []
+    for surface in surfaces:
+        for lid, rid, cost in EXPRESSIVE_KANA_COST_OVERRIDES.get(
+            surface, DEFAULT_EXPRESSIVE_KANA_GUARD_COSTS
+        ):
+            guards.append(
+                (surface, lid, rid, cost, surface, "direct_expressive_kana_guard")
+            )
+    return tuple(guards)
+
+
+# Short utterances and particles are intentionally kept as plain dictionary
+# candidates here, not as hard session-level suppressions.  Some of these are
+# short and ambiguous, but adding a kana candidate is still less invasive than
+# preventing the converter, user history, and user dictionary from participating.
+EXPRESSIVE_KANA_SHORT_UTTERANCE_SURFACES = (
+    "ふん",
+    "ふんっ",
+    "ふんっっ",
+    "ふんっっっー",
+    "ふむ",
+    "ふむっ",
+    "はて",
+    "ほう",
+    "ほうっっ",
+    "ちっ",
+    "ちぇっ",
+    "くそ",
+    "よう",
+    "ほっ",
+    "ふう",
+    "いてっ",
+    "ぎゃっ",
+    "ひゃっ",
+    "はいはい",
+    "ほい",
+    "ほいっ",
+    "ほいっっ",
+    "ほいほい",
+    "ほいほいっ",
+    "へい",
+    "へいっ",
+    "へいっっ",
+    "しゃっ",
+    "しゃっっ",
+    "しゃっー",
+    "てへ",
+    "てへっ",
+    "てへっっ",
+    "ええ",
+    "えぇ",
+    "ぇぇ",
+    "えぇぇ",
+    "えぇー",
+)
+
+
+EXPRESSIVE_KANA_MIMETIC_SURFACES = (
+    "くちゃ",
+    "くちょ",
+    "ぐちょ",
+    "ぐちょっ",
+    "ぐちょっっ",
+    "ぐちょぐちょ",
+    "ぐちょぐちょっ",
+    "ぐちょっと",
+    "どろっ",
+    "どろっっ",
+    "どろっー",
+    "どろどろ",
+    "どろどろっ",
+    "とろっ",
+    "とろっっ",
+    "とろっー",
+    "さわっ",
+    "さわっっ",
+    "さわっー",
+    "つるっ",
+    "つるっっ",
+    "つるっー",
+    "つるつる",
+    "つるつるっ",
+)
+
+
+EXPRESSIVE_KANA_CASUAL_GREETING_SURFACES = (
+    "ちっす",
+    "ちっっす",
+    "ちーっす",
+    "ちぃーっす",
+    "ちぃーーっす",
+    "ちーっすー",
+    "ちょっす",
+    "ちょーっす",
+    "ちょーっすー",
+    "ちょりっす",
+    "ちょりーっす",
+    "ちょりーっすー",
+)
+
+
+EXPRESSIVE_KANA_UHYO_UHYA_SURFACES = (
+    "うひょ",
+    "うひょー",
+    "うひょーん",
+    "うっひょ",
+    "うっひょー",
+    "うっひょーん",
+    "うっっひょ",
+    "うっっひょーん",
+    "うひゃ",
+    "うひゃー",
+    "うひゃ～",
+    "うひゃーん",
+    "うっひゃ",
+    "うっひゃー",
+    "うっひゃーん",
+    "うっっひゃ",
+    "うっっひゃーん",
+    "ほほう",
+    "ほっほーん",
+)
+
+
+EXPRESSIVE_KANA_USO_KUSO_SURFACES = (
+    "うっそ",
+    "うっそー",
+    "うっそん",
+    "うっっそ",
+    "うっっっそーん",
+    "くっそ",
+    "くっそー",
+    "くっっそ",
+    "くっっっそー",
+)
+
+
+EXPRESSIVE_KANA_EVALUATIVE_SLANG_SURFACES = (
+    "やっば",
+    "やっっばい",
+    "やっべぇ",
+    "やっっべー",
+    "すっご",
+    "すっっごい",
+    "すっげぇ",
+    "すっっげー",
+    "すっくな",
+    "すっっくない",
+    "すっくね",
+    "すっっくねぇ",
+    "すっくねえ",
+    "すっくねー",
+    "すっぱ",
+    "すっっぱ",
+    "すっっっぱ",
+    "すっぱー",
+    "すっっぱー",
+    "すっぺぇ",
+    "すっっぺー",
+    "こっわ",
+    "こっっわい",
+    "つっよ",
+    "つっっよい",
+    "つっら",
+    "つっっらい",
+    "つっれぇ",
+    "つっっれー",
+    "でっか",
+    "でっっかい",
+    "なっが",
+    "なっっがい",
+    "たっか",
+    "たっっかい",
+    "たっけぇ",
+    "たっっけー",
+    "ちっさ",
+    "ちっっさい",
+    "ちっちゃ",
+    "ちっっちゃい",
+    "ちっせぇ",
+    "ちっっせー",
+    "ひっく",
+    "ひっっくい",
+    "ひっろ",
+    "ひっっろい",
+    "さっむ",
+    "さっっむい",
+    "さっみぃ",
+    "さっみい",
+    "さっっみー",
+    "さっっみい",
+    "あっつ",
+    "あっっつい",
+    "あっちぃ",
+    "あっちい",
+    "あっっちー",
+    "あっっちい",
+    "あっっか",
+    "うっま",
+    "うっっまい",
+    "うっめぇ",
+    "うっっめー",
+    "うっざ",
+    "うっっざい",
+    "うっぜぇ",
+    "うっっぜー",
+    "うっす",
+    "うっっすい",
+    "かっる",
+    "かっっるい",
+    "きっつ",
+    "きっっつい",
+    "きっちぃ",
+    "きっっちー",
+    "きっも",
+    "きっっもい",
+    "きっれい",
+    "きっっれい",
+    "だっる",
+    "だっっるい",
+    "だっりぃ",
+    "だっっりー",
+    "だっさ",
+    "だっっさい",
+    "だっせぇ",
+    "だっっせー",
+    "えっぐ",
+    "えっっぐ",
+    "えっぐい",
+    "えっっぐい",
+    "くっさ",
+    "くっっさい",
+    "くっせ",
+    "くっっせ",
+    "くっせぇ",
+    "くっっせー",
+    "くっろ",
+    "くっっろい",
+    "まっぶし",
+    "まっっぶしい",
+    "おっも",
+    "おっっもい",
+    "おっそ",
+    "おっっそい",
+    "はっや",
+    "はっっやい",
+    "めっちゃ",
+    "めっっちゃ",
+    "もっと",
+    "もっっと",
+    "もっっっと",
+    "もっとー",
+    "もっっとー",
+    "ねっむ",
+    "ねっっむい",
+    "ほっそ",
+    "ほっっそい",
+    "せっま",
+    "せっっまい",
+    "みっじか",
+    "みっっじかい",
+    "しっろ",
+    "しっっろい",
+)
+
+
+# Surprise / wonder interjections such as ほえー and ほぇ～.
+#
+# Do not add bare ほえ here because it can compete with 吠え.  Add only clearly
+# expressive forms with vowel reduction, prolongation, or decorative tails.
+#
+# Keep both ～ U+FF5E and 〜 U+301C variants.  They are visually similar but can
+# appear through different input paths, and direct guards are written as literal
+# dictionary entries.
+EXPRESSIVE_KANA_HOE_SURFACES = (
+    "ほえー",
+    "ほえ～",
+    "ほぇ",
+    "ほぇー",
+    "ほぇ～",
+    "ほえぇ",
+    "ほえぇー",
+    "ほえぇ～",
+    "ほぇぇ",
+    "ほぇぇー",
+    "ほぇぇ～",
+    "ほえ〜",
+    "ほぇ〜",
+    "ほえぇ〜",
+    "ほぇぇ〜",
+)
+
+
+DIRECT_EXPRESSIVE_KANA_GUARDS = make_direct_expressive_kana_guards(
+    EXPRESSIVE_KANA_SHORT_UTTERANCE_SURFACES,
+    EXPRESSIVE_KANA_MIMETIC_SURFACES,
+    EXPRESSIVE_KANA_CASUAL_GREETING_SURFACES,
+    EXPRESSIVE_KANA_UHYO_UHYA_SURFACES,
+    EXPRESSIVE_KANA_USO_KUSO_SURFACES,
+    EXPRESSIVE_KANA_EVALUATIVE_SLANG_SURFACES,
+    EXPRESSIVE_KANA_HOE_SURFACES,
 )
 
 DANGEROUS_READING_SUFFIXES = (
@@ -476,6 +850,33 @@ def make_direct_fixed_guard(
     )
 
 
+SEEDED_PREFIX_GUARD_COST_OVERRIDES = {
+    # These guards compete with strong ordinary verb candidates such as
+    # 担ってしまいます. Keep the left id inherited from the particle に so the
+    # guard still prefers noun/adjectival contexts before に, but make the guard
+    # cost strong enough to beat the content-verb path in 名詞 + になってしま...
+    # constructions.
+    "になってしま": 2400,
+    "になってしまう": 2400,
+    "になってしまい": 2400,
+    "になってしまいます": 2400,
+    "になってしまいました": 2400,
+    "になってしまっ": 2400,
+    "になってしまった": 2400,
+    "になってしまって": 2400,
+    "になってしまえば": 2400,
+    "になってしまわ": 2400,
+    "になってしまわない": 2400,
+    "になってしまわず": 2400,
+    "になっちゃ": 2400,
+    "になっちゃう": 2400,
+    "になっちゃい": 2400,
+    "になっちゃいます": 2400,
+    "になっちゃった": 2400,
+    "になっちゃって": 2400,
+}
+
+
 def generate_guards(
     entries: list[Entry],
     max_source_cost: int,
@@ -595,7 +996,9 @@ def generate_guards(
             source_key=source_key,
             prefix_entry=prefix_entry,
             fallback_right_entry=fallback_right_entry,
-            guard_cost=prefix_guard_cost,
+            guard_cost=SEEDED_PREFIX_GUARD_COST_OVERRIDES.get(
+                key, prefix_guard_cost
+            ),
         )
 
         signature = (guard.key, guard.lid, guard.rid, guard.value)
@@ -632,7 +1035,9 @@ def generate_guards(
         guards.append(guard)
         stats["seeded_fixed_guards"] += 1
 
-    for key, lid, rid, cost, value, reason in DIRECT_FIXED_GUARDS:
+    for key, lid, rid, cost, value, reason in (
+        DIRECT_FIXED_GUARDS + DIRECT_EXPRESSIVE_KANA_GUARDS
+    ):
         guard = make_direct_fixed_guard(
             key=key,
             lid=lid,


### PR DESCRIPTION
## 概要

ライブ変換中の expressive kana 救出を、session 側で完成語を一律に握りつぶす方式から、生成辞書候補として救出する方式へ移します。

これにより、初期状態では `うっそ`、`くっそ`、`やっば`、`ちっす`、`ほえ～` などの自然なかな表記を出しやすくしつつ、ユーザーが `ウッソ`、`クッソ`、`ヤッバ`、`チッス`、`ホェ～` などのカタカナ表記を明示的に選んだ場合には、ユーザー履歴やユーザー辞書による表記選好が反映される余地を残します。

あわせて、`〇〇になってしまいます` が `〇〇担ってしまいます` に吸われる文節崩れを抑制する syntax guard も追加します。

## 変更内容

- 完成済み expressive kana を live conversion の hard suppress 対象から外し、converter に到達させるように変更
- 入力途中の expressive prefix / pending roman suffix は引き続き session 側で保護
- `DIRECT_EXPRESSIVE_KANA_GUARDS` を追加し、完成済み expressive kana を生成辞書候補として補強
- expressive kana guard をカテゴリ別 surface list + generator 方式に整理
  - 短い感嘆詞
  - 擬態語
  - くだけた挨拶
  - `うひょ` / `うひゃ` 系
  - `うっそ` / `くっそ` 系
  - 口語評価語
  - `ほえ` / `ほぇ` 系
- `えっぐ` 系が `エッグ` に寄りやすい問題に対して、該当 surface のみ少し強い cost を設定
- `あっっか` が `悪化` に寄りやすい問題に対して、裸の `あっか` は追加せず、明確な強調表記である `あっっか` のみ強めに救出
- `になってしま...` / `になっちゃ...` 系の seeded prefix guard を追加
- `担ってしま...` に吸われやすい `になってしま...` / `になっちゃ...` 系のみ cost override で強化
- README を「完成語は辞書側、入力途中は session 側」という設計に合わせて更新
- session test を、新しい責務分離に合わせて更新

## 意図

従来の session 側 hard suppress では、完成した感嘆詞・口語表現が converter に渡らないため、不自然な漢字化やカタカナ化は避けやすい一方で、ユーザーが意図的にカタカナ表記を選んだ場合の履歴学習やユーザー辞書の表記選好がライブ変換に反映されにくい問題がありました。

今回の変更では、完成した expressive kana は通常の converter / 辞書候補として扱います。初期状態では生成辞書側のかな候補で不自然な分割を抑えつつ、明示的なユーザー選択やユーザー辞書が候補順位へ影響できる構造にします。

一方で、入力途中の prefix や pending roman suffix は引き続き session 側で保護し、入力中のちらつきや中途半端なライブ変換を抑えます。

## 実機確認

確認済み:

- `えっぐ`
- `えっぐい`
- `あっちい`
- `さっみい`
- `くっせ`
- `あっっか`
- `問題になってしまいます`
- `対象になってしまいます`
- `原因になってしまいました`
- `問題になっちゃった`

壊していないことを確認:

- `役割を担ってしまいます`
- `責任を担ってしまいます`
- `彼が担ってしまいます`

## テスト

- `git diff --check origin/main...HEAD`
- `//session:session_test`
- `//server:mozc_server`
