### PR TITLE
fix(session): restore wave dash style in zenz live conversion

### DIFF
--- a/src/session/session.cc
+++ b/src/session/session.cc
@@ -2086,6 +2086,56 @@ void AddPreeditSegment(absl::string_view key,
   segment->set_value(std::string(value));
   segment->set_value_length(Util::CharsLen(value));
 }
+void RestorePreeditSegmentKeysForSymbolStyle(
+    absl::string_view symbol_style_source,
+    commands::Preedit* preedit) {
+  if (symbol_style_source.empty() || preedit == nullptr ||
+      preedit->segment_size() == 0) {
+    return;
+  }
+
+  // Restore only display keys.  The converter-owned internal key, candidate
+  // value, and feedback key remain unchanged.  Multi-segment preedit is handled
+  // by restoring the concatenated display key and then distributing it back by
+  // the original segment key character lengths.  This is safe for wave-dash
+  // restoration because ASCII '~', FULLWIDTH TILDE '～', and WAVE DASH '〜' are
+  // all single Unicode scalar values.
+  std::string full_key;
+  std::string full_value;
+  std::vector<size_t> segment_key_char_lengths;
+  segment_key_char_lengths.reserve(preedit->segment_size());
+
+  for (int i = 0; i < preedit->segment_size(); ++i) {
+    const commands::Preedit::Segment& segment = preedit->segment(i);
+    const absl::string_view segment_key =
+        segment.has_key() && !segment.key().empty()
+            ? absl::string_view(segment.key())
+            : absl::string_view(segment.value());
+
+    full_key.append(segment_key.data(), segment_key.size());
+    full_value.append(segment.value());
+    segment_key_char_lengths.push_back(Util::CharsLen(segment_key));
+  }
+
+  const std::string restored_key =
+      ZenzOutputValidator::RestoreUserVisibleSymbolStyle(
+          symbol_style_source, full_value, full_key);
+
+  if (restored_key == full_key ||
+      Util::CharsLen(restored_key) != Util::CharsLen(full_key)) {
+    return;
+  }
+
+  size_t offset = 0;
+  for (int i = 0; i < preedit->segment_size(); ++i) {
+    const size_t segment_chars = segment_key_char_lengths[i];
+    preedit->mutable_segment(i)->set_key(
+        std::string(Util::Utf8SubString(restored_key,
+                                        offset,
+                                        segment_chars)));
+    offset += segment_chars;
+  }
+}
 
 bool IsPlainBackspaceKey(const commands::KeyEvent& key) {
   return key.has_special_key() &&
@@ -4027,6 +4077,13 @@ bool Session::MaybeStartLiveConversion(commands::Command* command) {
   context_->mutable_converter()->SetCandidateListVisible(true);
 
   Output(command);
+
+  if (command->output().has_preedit()) {
+    RestorePreeditSegmentKeysForSymbolStyle(
+        live_conversion_preedit,
+        command->mutable_output()->mutable_preedit());
+  }
+
   command->mutable_output()->set_live_conversion(true);
   command->mutable_output()->set_live_conversion_pending(false);
 
@@ -4069,6 +4126,13 @@ bool Session::OutputPendingLiveConversion(commands::Command* command) const {
   // In that case, raw pending display is expected and should still be debounced.
   if (!has_stable_live_conversion) {
     OutputComposition(command);
+
+    if (command->output().has_preedit()) {
+      RestorePreeditSegmentKeysForSymbolStyle(
+          raw_preedit,
+          command->mutable_output()->mutable_preedit());
+    }
+
     commands::Output* output = command->mutable_output();
     output->clear_candidate_window();
     output->set_live_conversion(true);
@@ -4111,6 +4175,8 @@ bool Session::OutputPendingLiveConversion(commands::Command* command) const {
                       commands::Preedit::Segment::UNDERLINE,
                       preedit);
   }
+
+  RestorePreeditSegmentKeysForSymbolStyle(raw_preedit, preedit);
 
   preedit->set_cursor(Util::CharsLen(live_conversion_value_) +
                       Util::CharsLen(suffix_value));
@@ -4201,6 +4267,15 @@ bool Session::IgnoreStaleDelayedLiveConversion(commands::Command* command) {
 
   if (live_conversion_active_ && context_->state() == ImeContext::CONVERSION) {
     Output(command);
+
+    if (command->output().has_preedit()) {
+      RestorePreeditSegmentKeysForSymbolStyle(
+          live_conversion_preedit_.empty()
+              ? live_conversion_key_
+              : live_conversion_preedit_,
+          command->mutable_output()->mutable_preedit());
+    }
+
     command->mutable_output()->set_live_conversion(true);
     command->mutable_output()->set_live_conversion_pending(false);
     return true;
@@ -4795,6 +4870,7 @@ void Session::ClearZenzLiveCorrectionState() {
 
   zenz_live_visible_generation_ = 0;
   zenz_live_key_.clear();
+  zenz_live_display_key_.clear();
   zenz_live_value_.clear();
   zenz_live_mozc_value_.clear();
   zenz_live_context_class_.clear();
@@ -4949,6 +5025,9 @@ bool Session::MaybeApplyZenzFeedbackLiveCorrection(
 
     zenz_live_visible_generation_ = zenz_live_generation_;
     zenz_live_key_ = live_conversion_key_;
+    zenz_live_display_key_ = live_conversion_preedit_.empty()
+                                 ? live_conversion_key_
+                                 : live_conversion_preedit_;
     zenz_live_value_ = feedback_value;
     zenz_live_mozc_value_ = live_conversion_value_;
     zenz_live_context_class_ = context_class;
@@ -5070,6 +5149,9 @@ bool Session::MaybeScheduleZenzLiveCorrection(commands::Command* command) {
   pending_zenz_live_.right_context = right_context_for_prompt;
   pending_zenz_live_.context_class = context_result.context_class;
   pending_zenz_live_.mozc_value = live_conversion_value_;
+  pending_zenz_live_.symbol_style_source =
+      live_conversion_preedit_.empty() ? live_conversion_key_
+                                       : live_conversion_preedit_;
   pending_zenz_live_.prompt = prompt;
   pending_zenz_live_.issued_at = Clock::GetAbslTime();
   pending_zenz_live_.pending = true;
@@ -5265,6 +5347,15 @@ bool Session::OutputCurrentLiveConversionWithZenzPending(
 
   if (live_conversion_active_ && context_->state() == ImeContext::CONVERSION) {
     Output(command);
+
+    if (command->output().has_preedit()) {
+      RestorePreeditSegmentKeysForSymbolStyle(
+          live_conversion_preedit_.empty()
+              ? live_conversion_key_
+              : live_conversion_preedit_,
+          command->mutable_output()->mutable_preedit());
+    }
+
     commands::Output* output = command->mutable_output();
     output->set_live_conversion(true);
     output->set_live_conversion_pending(false);
@@ -5283,6 +5374,14 @@ bool Session::OutputCurrentLiveConversionAfterZenzStop(
 
   if (live_conversion_active_ && context_->state() == ImeContext::CONVERSION) {
     Output(command);
+
+    if (command->output().has_preedit()) {
+      RestorePreeditSegmentKeysForSymbolStyle(
+          live_conversion_preedit_.empty()
+              ? live_conversion_key_
+              : live_conversion_preedit_,
+          command->mutable_output()->mutable_preedit());
+    }
 
     commands::Output* output = command->mutable_output();
     output->set_live_conversion(true);
@@ -5441,6 +5540,15 @@ bool Session::ApplyZenzLiveCorrectionResult(
 
     CancelPendingZenzLiveCorrection();
     Output(command);
+
+    if (command->output().has_preedit()) {
+      RestorePreeditSegmentKeysForSymbolStyle(
+          live_conversion_preedit_.empty()
+              ? live_conversion_key_
+              : live_conversion_preedit_,
+          command->mutable_output()->mutable_preedit());
+    }
+
     command->mutable_output()->set_live_conversion(true);
     command->mutable_output()->set_live_conversion_pending(false);
     command->mutable_output()->set_zenz_live_correction_pending(false);
@@ -5459,6 +5567,30 @@ bool Session::ApplyZenzLiveCorrectionResult(
     ZenzDebugOutput(absl::StrCat(
         "[zenz] stripped left_context prefix ",
         ZenzRedactedTextStats("value", zenz_value),
+        " context_class=", pending_zenz_live_.context_class));
+  }
+
+  const absl::string_view zenz_symbol_style_source =
+      pending_zenz_live_.symbol_style_source.empty()
+          ? pending_zenz_live_.key
+          : pending_zenz_live_.symbol_style_source;
+
+  const std::string zenz_value_before_symbol_restore = zenz_value;
+  zenz_value = ZenzOutputValidator::RestoreUserVisibleSymbolStyle(
+      zenz_symbol_style_source, pending_zenz_live_.mozc_value, zenz_value);
+
+  const std::string zenz_display_key =
+      ZenzOutputValidator::RestoreUserVisibleSymbolStyle(
+          zenz_symbol_style_source,
+          pending_zenz_live_.mozc_value,
+          pending_zenz_live_.key);
+
+  if (zenz_value != zenz_value_before_symbol_restore) {
+    ZenzDebugOutput(absl::StrCat(
+        "[zenz] restored symbol style ",
+        ZenzRedactedTextStats("value", zenz_value),
+        " ", ZenzRedactedTextStats("raw_value",
+                                   zenz_value_before_symbol_restore),
         " context_class=", pending_zenz_live_.context_class));
   }
 
@@ -5489,6 +5621,15 @@ bool Session::ApplyZenzLiveCorrectionResult(
 
     CancelPendingZenzLiveCorrection();
     Output(command);
+
+    if (command->output().has_preedit()) {
+      RestorePreeditSegmentKeysForSymbolStyle(
+          live_conversion_preedit_.empty()
+              ? live_conversion_key_
+              : live_conversion_preedit_,
+          command->mutable_output()->mutable_preedit());
+    }
+
     command->mutable_output()->set_live_conversion(true);
     command->mutable_output()->set_live_conversion_pending(false);
     command->mutable_output()->set_zenz_live_correction_pending(false);
@@ -5512,6 +5653,15 @@ bool Session::ApplyZenzLiveCorrectionResult(
 
     CancelPendingZenzLiveCorrection();
     Output(command);
+
+    if (command->output().has_preedit()) {
+      RestorePreeditSegmentKeysForSymbolStyle(
+          live_conversion_preedit_.empty()
+              ? live_conversion_key_
+              : live_conversion_preedit_,
+          command->mutable_output()->mutable_preedit());
+    }
+
     command->mutable_output()->set_live_conversion(true);
     command->mutable_output()->set_live_conversion_pending(false);
     command->mutable_output()->set_zenz_live_correction_pending(false);
@@ -5535,6 +5685,15 @@ bool Session::ApplyZenzLiveCorrectionResult(
 
     CancelPendingZenzLiveCorrection();
     Output(command);
+
+    if (command->output().has_preedit()) {
+      RestorePreeditSegmentKeysForSymbolStyle(
+          live_conversion_preedit_.empty()
+              ? live_conversion_key_
+              : live_conversion_preedit_,
+          command->mutable_output()->mutable_preedit());
+    }
+
     command->mutable_output()->set_live_conversion(true);
     command->mutable_output()->set_live_conversion_pending(false);
     command->mutable_output()->set_zenz_live_correction_pending(false);
@@ -5581,6 +5740,7 @@ bool Session::ApplyZenzLiveCorrectionResult(
 
   zenz_live_visible_generation_ = pending_zenz_live_.generation;
   zenz_live_key_ = pending_zenz_live_.key;
+  zenz_live_display_key_ = zenz_display_key;
   zenz_live_value_ = zenz_value;
   zenz_live_mozc_value_ = pending_zenz_live_.mozc_value;
   zenz_live_context_class_ = context_class.empty() ? "empty" : context_class;
@@ -5605,8 +5765,11 @@ bool Session::OutputZenzLiveCorrection(
   commands::Preedit* preedit = output->mutable_preedit();
   preedit->Clear();
 
+  const absl::string_view display_key =
+      zenz_live_display_key_.empty() ? zenz_live_key_ : zenz_live_display_key_;
+
   AddPreeditSegment(
-      zenz_live_key_,
+      display_key,
       value,
       commands::Preedit::Segment::HIGHLIGHT,
       preedit);

--- a/src/session/session.h
+++ b/src/session/session.h
@@ -322,6 +322,7 @@ class Session {
     std::string right_context;
     std::string context_class;
     std::string mozc_value;
+    std::string symbol_style_source;
     std::string prompt;
     absl::Time issued_at;
     bool pending = false;
@@ -366,6 +367,7 @@ class Session {
 
   uint32_t zenz_live_visible_generation_ = 0;
   std::string zenz_live_key_;
+  std::string zenz_live_display_key_;
   std::string zenz_live_value_;
   std::string zenz_live_mozc_value_;
   std::string zenz_live_context_class_;

--- a/src/session/session_test.cc
+++ b/src/session/session_test.cc
@@ -615,6 +615,41 @@ TEST(ZenzPromptBuilderTest, SanitizesConditionFields) {
                 std::string("\xEE\xB8\x81"),
             builder.Build(reading, options));
 }
+
+TEST(ZenzOutputValidatorTest,
+     RestoresFullwidthWaveDashBeforeLiveCorrectionValidation) {
+  EXPECT_EQ(ZenzOutputValidator::RestoreUserVisibleSymbolStyle(
+                "う～ん", "う～ん", "う~ん"),
+            "う～ん");
+}
+
+TEST(ZenzOutputValidatorTest,
+     RestoresWaveDashWithoutDiscardingOtherZenzCorrection) {
+  EXPECT_EQ(ZenzOutputValidator::RestoreUserVisibleSymbolStyle(
+                "う～んむずかしい", "う～んむずかしい",
+                "う~ん難しい"),
+            "う～ん難しい");
+}
+
+TEST(ZenzOutputValidatorTest, PreservesIntentionalAsciiTilde) {
+  EXPECT_EQ(ZenzOutputValidator::RestoreUserVisibleSymbolStyle(
+                "う~ん", "う~ん", "う~ん"),
+            "う~ん");
+}
+
+TEST(ZenzOutputValidatorTest,
+     RestoresRawPreeditWaveDashEvenWhenMozcValueContainsAsciiTilde) {
+  EXPECT_EQ(ZenzOutputValidator::RestoreUserVisibleSymbolStyle(
+                "う～ん", "う~ん", "う~ん"),
+            "う～ん");
+}
+
+TEST(ZenzOutputValidatorTest, RestoresWaveDashCodePointStyle) {
+  EXPECT_EQ(ZenzOutputValidator::RestoreUserVisibleSymbolStyle(
+                "う〜ん", "う〜ん", "う~ん"),
+            "う〜ん");
+}
+
 class SessionTest : public testing::TestWithTempUserProfile {
  protected:
   void SetUp() override {

--- a/src/session/zenz_output_validator.cc
+++ b/src/session/zenz_output_validator.cc
@@ -1,9 +1,11 @@
 #include "session/zenz_output_validator.h"
 
+#include <algorithm>
 #include <cstddef>
 #include <cstdint>
 #include <string>
 #include <utility>
+#include <vector>
 
 #include "absl/strings/match.h"
 #include "base/util.h"
@@ -83,7 +85,146 @@ bool DecodeOneUtf8(absl::string_view input, size_t* index, char32_t* cp) {
   return false;
 }
 
+struct Utf8CharForSymbolRestore {
+  char32_t cp = 0;
+  std::string bytes;
+};
+
+bool IsAsciiTilde(char32_t cp) { return cp == 0x007E; }
+
+bool IsJapaneseWaveDash(char32_t cp) {
+  return cp == 0xFF5E ||  // FULLWIDTH TILDE: ～
+         cp == 0x301C;    // WAVE DASH: 〜
+}
+
+std::vector<Utf8CharForSymbolRestore> SplitUtf8ForSymbolRestore(
+    absl::string_view text) {
+  std::vector<Utf8CharForSymbolRestore> chars;
+  size_t index = 0;
+  while (index < text.size()) {
+    const size_t begin = index;
+    char32_t cp = 0;
+    if (!DecodeOneUtf8(text, &index, &cp)) {
+      return {};
+    }
+    chars.push_back({cp, std::string(text.substr(begin, index - begin))});
+  }
+  return chars;
+}
+
+int CountCodePoint(absl::string_view text, char32_t target) {
+  int count = 0;
+  size_t index = 0;
+  while (index < text.size()) {
+    char32_t cp = 0;
+    if (!DecodeOneUtf8(text, &index, &cp)) {
+      return 0;
+    }
+    if (cp == target) {
+      ++count;
+    }
+  }
+  return count;
+}
+
+int CountJapaneseWaveDashFamily(absl::string_view text) {
+  return CountCodePoint(text, 0xFF5E) + CountCodePoint(text, 0x301C);
+}
+
+int CountAsciiTilde(absl::string_view text) {
+  return CountCodePoint(text, 0x007E);
+}
+
+std::string FirstJapaneseWaveDashBytes(absl::string_view text) {
+  const std::vector<Utf8CharForSymbolRestore> chars =
+      SplitUtf8ForSymbolRestore(text);
+  for (const Utf8CharForSymbolRestore& ch : chars) {
+    if (IsJapaneseWaveDash(ch.cp)) {
+      return ch.bytes;
+    }
+  }
+  return {};
+}
+
 }  // namespace
+
+std::string ZenzOutputValidator::RestoreUserVisibleSymbolStyle(
+    absl::string_view key,
+    absl::string_view mozc_value,
+    absl::string_view zenz_value) {
+  const int key_wave_dash_count = CountJapaneseWaveDashFamily(key);
+  const int mozc_wave_dash_count = CountJapaneseWaveDashFamily(mozc_value);
+
+  // Prefer `key` because the caller passes raw-preedit-derived text here for
+  // live correction.  `mozc_value` may already contain an ASCII tilde due to
+  // converter or feedback influence, and must not cancel restoration of the
+  // user-entered Japanese wave dash style.
+  absl::string_view style_source;
+  if (key_wave_dash_count > 0) {
+    style_source = key;
+  } else if (mozc_wave_dash_count > 0) {
+    style_source = mozc_value;
+  } else {
+    return std::string(zenz_value);
+  }
+
+  const int source_wave_dash_count =
+      CountJapaneseWaveDashFamily(style_source);
+  const int zenz_wave_dash_count = CountJapaneseWaveDashFamily(zenz_value);
+  const int missing_wave_dash_count =
+      source_wave_dash_count - zenz_wave_dash_count;
+  if (missing_wave_dash_count <= 0) {
+    return std::string(zenz_value);
+  }
+
+  const int source_ascii_tilde_count = CountAsciiTilde(style_source);
+  const int zenz_ascii_tilde_count = CountAsciiTilde(zenz_value);
+  int replacement_budget = std::min(
+      missing_wave_dash_count, zenz_ascii_tilde_count - source_ascii_tilde_count);
+  if (replacement_budget <= 0) {
+    return std::string(zenz_value);
+  }
+
+  const std::vector<Utf8CharForSymbolRestore> source_chars =
+      SplitUtf8ForSymbolRestore(style_source);
+  const std::vector<Utf8CharForSymbolRestore> zenz_chars =
+      SplitUtf8ForSymbolRestore(zenz_value);
+  if (source_chars.empty() || zenz_chars.empty()) {
+    return std::string(zenz_value);
+  }
+
+  const std::string default_replacement =
+      FirstJapaneseWaveDashBytes(style_source);
+  if (default_replacement.empty()) {
+    return std::string(zenz_value);
+  }
+
+  std::string restored;
+  restored.reserve(zenz_value.size());
+  for (size_t i = 0; i < zenz_chars.size(); ++i) {
+    const Utf8CharForSymbolRestore& ch = zenz_chars[i];
+    const bool positional_restore =
+        i < source_chars.size() && IsJapaneseWaveDash(source_chars[i].cp);
+
+    // If the source did not contain ASCII tilde at all, any extra ASCII tilde
+    // returned by Zenz is highly likely to be a normalized Japanese wave dash.
+    // If the source did contain ASCII tilde, avoid broad fallback replacement
+    // and only restore exact character positions to preserve intentional ASCII.
+    const bool safe_fallback_restore = source_ascii_tilde_count == 0;
+
+    if (replacement_budget > 0 && IsAsciiTilde(ch.cp) &&
+        (positional_restore || safe_fallback_restore)) {
+      restored.append(positional_restore ? source_chars[i].bytes
+                                         : default_replacement);
+      --replacement_budget;
+      continue;
+    }
+
+    restored.append(ch.bytes);
+  }
+
+  return restored;
+}
 
 bool ZenzOutputValidator::ContainsSpecialToken(absl::string_view text) {
   if (absl::StrContains(text, "<s>") ||

--- a/src/session/zenz_output_validator.h
+++ b/src/session/zenz_output_validator.h
@@ -29,6 +29,16 @@ class ZenzOutputValidator {
  public:
   ZenzValidationResult Validate(const ZenzValidationInput& input) const;
 
+  // Restores user-visible Japanese symbol style that Zenz may normalize to
+  // ASCII.  This currently protects wave-dash-like Japanese tildes: when the
+  // key or the original Mozc value contains U+FF5E FULLWIDTH TILDE or U+301C
+  // WAVE DASH, and Zenz returns U+007E ASCII TILDE instead, the returned value
+  // is restored before validation, display, commit, and feedback recording.
+  static std::string RestoreUserVisibleSymbolStyle(
+      absl::string_view key,
+      absl::string_view mozc_value,
+      absl::string_view zenz_value);
+
  private:
   static bool ContainsSpecialToken(absl::string_view text);
   static bool LooksLikeUrlOrEmail(absl::string_view text);


### PR DESCRIPTION
## 概要

Zenzライブ補正およびライブ変換のルビ表示にて、ユーザーが入力した日本語の波ダッシュ系記号 `～` / `〜` が ASCII チルダ `~` として表示・採用される問題を修正します。

例:

- 修正前: `う～ん` が `う~ん` として表示されることがある
- 修正後: `う～ん` / `う〜ん` の表記スタイルを維持する

## 変更内容

- `ZenzOutputValidator::RestoreUserVisibleSymbolStyle()` を追加
  - 原文側に `～` / `〜` がある場合、Zenz返り値で `~` に正規化された箇所を復元
  - 原文側で意図的に ASCII `~` が使われている場合は保持
- Zenzライブ補正の pending state に `symbol_style_source` を追加
  - raw preedit 由来の文字列を保持し、復元元として使用
- Zenz補正結果の validation / display / commit / feedback recording 前に、表記スタイル復元を適用
- ルビウィンドウ表示用に `zenz_live_display_key_` を追加
  - 内部 key / feedback key は維持しつつ、preedit segment の表示用 key を復元
- 通常ライブ変換、ライブ変換 pending、Zenz pending、Zenz返答後、fallback 経路の preedit segment key を復元
  - 複数 segment の場合も、連結 key を復元して元の segment key 文字数に沿って再分配
- 回帰テストを追加

## 意図

Zenzの文脈補正は有用ですが、日本語入力中の `～` / `〜` は、口語的な伸ばし・余韻・範囲表現などに使われるユーザー可視の表記スタイルです。

これが ASCII `~` に落ちると、日本語文章として不自然になりやすく、ユーザーが入力した記号スタイルも失われます。

本修正では、Zenzの補正内容自体は維持しつつ、原文由来の波ダッシュ系記号だけを復元します。

## 設計メモ

- 既存の converter key / feedback key は変更しない
- 表示用の preedit segment key と Zenz表示値のみを復元する
- `zenz_feedback.tsv` に既に記録済みの accepted replay は今回の対象外
- ASCII `~` をユーザーが最初から入力している場合は尊重する

## 確認

- `git diff --check` 通過
- `//session:session_test` 通過
- `//server:mozc_server` ビルド通過
- 実機で以下を確認
  - `う～ん`
  - `え～っと`
  - `ん～どうかな`
  - `10～20個`
  - `う〜ん`

確認結果:

- 本文表示で `～` / `〜` が維持されること
- ルビウィンドウでも `～` / `〜` が維持されること
- Zenz返答前の pending 表示でも一瞬 `~` が見えないこと
- Zenz返答後も `~` に落ちないこと
