### PR TITLE
fix(dictionary): guard shita function expressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Windows 用のビルド済み MSI は [Releases](https://github.com/koyasi777/mo
 - merge-ut-dictionaries 由来の地名・SudachiDict 系語彙を system dictionary に取り込めるようにした
 - dic-nico-intersection-pixiv 由来のネット・サブカル系固有名詞を、既存辞書との差分として daily 辞書に追加可能
 - mozcdic-ut-personal-names 由来の人名辞書を、既存辞書や nico/pixiv delta との重複を除いた弱い daily 辞書として追加可能
-- 文節区切り崩れを抑えるための syntax guard 辞書を daily 辞書生成パイプラインに追加し、`と打ちたいのに`、`に分ける`、`にまで`、`までに`、`までも`、`肌身離さず` などの高影響な経路を保護
+- 文節区切り崩れを抑えるための syntax guard 辞書を daily 辞書生成パイプラインに追加し、`と打ちたいのに`、`に分ける`、`した方が`、`したにもかかわらず`、`にまで`、`までに`、`までも`、`肌身離さず` などの高影響な経路を保護
 - 大規模な生成辞書は Git に含めず、ローカルで再生成して Bazel の辞書入力へ切り替える運用に
 - `には` や `してたの` のような自然な機能語かな列が、`二は` や `して他の` のような 1 文字漢字候補に過剰変換される挙動を抑制
 - `にじ` のような 2 文字ひらがな入力で、`に|じ` のような短すぎる文節分割が全体候補を隠す挙動を抑制
@@ -398,7 +398,7 @@ daily local 辞書は主に以下を元に生成できます。
   - 短すぎる読み、長いカタカナ塊、グループ名風表記、ASCII 表記、記号を含む表記などは除外または弱める
 - Mozkey syntax / expressive kana guard 辞書
   - 文節区切り崩れの影響が大きいケースだけを小さな生成辞書として補強
-  - 例: `と打ちたいのに`、`に分ける`、`にまで`、`までに`、`までも`、`肌身離さず`、`になってしまいます`、`になっちゃいます` のような経路を保護
+  - 例: `と打ちたいのに`、`に分ける`、`した方が`、`したにもかかわらず`、`にまで`、`までに`、`までも`、`肌身離さず`、`になってしまいます`、`になっちゃいます` のような経路を保護
   - 例: `うっそ`、`くっそ`、`やっば`、`ちっす`、`ほえ～`、`ほぇ～` のような完成済み expressive kana を自然なかな候補として補強
 
 巨大な生成辞書ファイルは、このリポジトリには commit しません。`src/data/dictionary_koyasi/generated/` 以下にローカル生成します。
@@ -554,7 +554,7 @@ Main features added in this fork
 - Allows incorporating place names and SudachiDict-derived vocabulary from merge-ut-dictionaries into the system dictionary
 - Allows adding internet/subculture proper nouns from dic-nico-intersection-pixiv as daily-dictionary differences
 - Allows adding a weak personal-name dictionary from mozcdic-ut-personal-names after removing entries already covered by the generated daily dictionary, nico/pixiv delta dictionary, or base Mozc dictionaries
-- Adds a syntax guard dictionary generation pipeline to reduce high-impact segmentation failures, including guarded paths such as `と打ちたいのに`, `に分ける`, `にまで`, `までに`, `までも`, and `肌身離さず`
+- Adds a syntax guard dictionary generation pipeline to reduce high-impact segmentation failures, including guarded paths such as `と打ちたいのに`, `に分ける`, `した方が`, `したにもかかわらず`, `にまで`, `までに`, `までも`, and `肌身離さず`
 - Keeps large generated dictionary files out of Git and switches Bazel dictionary inputs to locally generated files
 - Reduces over-conversion of natural functional kana sequences such as `には` and `してたの`
 - Reduces cases where short two-character hiragana inputs such as `にじ` are split too aggressively
@@ -871,7 +871,7 @@ The daily local dictionary can be generated from:
   - risky short readings, long katakana-like names, group-like names, ASCII values, and punctuation-heavy values are filtered or demoted
 - Mozkey syntax / expressive kana guard dictionary
   - small generated guard entries for high-impact segmentation failures
-  - for example, protecting paths such as `と打ちたいのに`, `に分ける`, `にまで`, `までに`, `までも`, `肌身離さず`, `になってしまいます`, and `になっちゃいます`
+  - for example, protecting paths such as `と打ちたいのに`, `に分ける`, `した方が`, `したにもかかわらず`, `にまで`, `までに`, `までも`, `肌身離さず`, `になってしまいます`, and `になっちゃいます`
   - also adds natural kana candidates for completed expressive forms such as `うっそ`, `くっそ`, `やっば`, `ちっす`, `ほえ～`, `ほぇ～`, and `ほっほーん`
 
 Large generated dictionary files are not committed to this repository.

--- a/tools/dictionary/generate_syntax_guard_dictionary.py
+++ b/tools/dictionary/generate_syntax_guard_dictionary.py
@@ -125,6 +125,21 @@ SEEDED_FIXED_GUARDS = (
     # Fix:
     # とうちたいのに -> 統治体の二
     ("とうちたいのに", "と打ちたいのに", "と", "のに"),
+
+    # Fix:
+    # したほうが... -> 下ほうが... / 下方が...
+    # 方が is a formal-noun + case-particle construction following a verbal
+    # expression.  Guard this grammar boundary once, so it can connect to many
+    # following predicates such as いい, 悪い, 早い, 自然, 安全, and マシ.
+    # Do not make bare した too cheap; keep the rescue at the longer
+    # functional boundary.
+    ("したほうが", "した方が", "した", "が"),
+
+    # Fix:
+    # したにもかかわらず -> 下にもかかわらず
+    # にもかかわらず is a concessive functional expression.  In this full
+    # sequence, verbal した is overwhelmingly more natural than noun 下.
+    ("したにもかかわらず", "したにもかかわらず", "した", "ず"),
 )
 
 DIRECT_FIXED_GUARDS = (


### PR DESCRIPTION
## 概要

`した方が...` / `したにもかかわらず` などの `した` を含む機能表現が、`下ほうが...`、`下方が...`、`下にもかかわらず` のように `下` 側へ誤変換されやすい問題を抑制します。

## 変更内容

- syntax guard 辞書生成スクリプトに `したほうが` の固定ガードを追加
  - `したほうが` → `した方が`
- syntax guard 辞書生成スクリプトに `したにもかかわらず` の固定ガードを追加
  - `したにもかかわらず` → `したにもかかわらず`
- README の syntax guard 例に `した方が` / `したにもかかわらず` を追加

## 意図

`下` 自体のコストを直接変更すると、`下の方`、`下に戻す`、`下にもある`、`下方修正` などの正しい変換に副作用が出る可能性があります。

そのため、裸の `した` や `下` のコストを調整するのではなく、`したほうが` / `したにもかかわらず` のような、文法的に強いまとまりを syntax guard として保護します。

特に `したほうが` は、後続に `いい`、`悪い`、`早い`、`自然`、`安全`、`マシ` など多様な述語が続くため、`したほうがいい` のような終端までの固定句ではなく、`したほうが` → `した方が` の境界を保護する形にしています。

## 確認

以下で syntax guard 辞書を生成し、追加した guard が出力されることを確認しました。

```powershell
python .\tools\dictionary\generate_syntax_guard_dictionary.py

Select-String `
  -Path .\src\data\dictionary_koyasi\generated\profiled\koyasi-syntax-guard.txt `
  -Pattern "したほうが","したにもかかわらず"

Select-String `
  -Path .\dist\dictionary\koyasi-syntax-guard-debug.tsv `
  -Pattern "したほうが","したにもかかわらず"
```

生成結果として以下が出力されることを確認しました。

```text
したにもかかわらず    1851    218     200     したにもかかわらず
したほうが            1851    332     200     した方が
```

また、ローカル生成済み辞書を含めて `mozc_server.exe` を再ビルドし、実機差し替え後に以下の入力を確認しました。

```text
したほうがいい
したほうがよい
したほうがわるい
したほうがまし
したほうが自然
したほうが安全
したほうが早い
したほうが楽
したほうがよかった
したほうがいいと思う
したにもかかわらず
```

期待どおり `下ほうが...` / `下方が...` / `下にもかかわらず` へ寄らないことを確認しました。

回帰確認として、`下` を含む通常表現も確認しました。

```text
下の方がいい
下に戻す
下にもある
下にはある
下方修正
下方向
```

## 備考

`src/data/dictionary_koyasi/generated/` 以下の生成済み辞書は Git 管理対象外のため、この PR には含めていません。

