### PR TITLE
fix(session): preserve zenz commit result before IME off

### DIFF
--- a/src/session/session.cc
+++ b/src/session/session.cc
@@ -2360,6 +2360,42 @@ ImeContext::State GetEffectiveStateForTestSendKey(const commands::KeyEvent& key,
   return state;
 }
 
+void MergeCommandResult(const commands::Result& step_result,
+                        commands::Result* accumulated_result) {
+  if (!accumulated_result->has_key() && !accumulated_result->has_value()) {
+    *accumulated_result = step_result;
+    return;
+  }
+
+  if (step_result.has_key()) {
+    accumulated_result->set_key(
+        absl::StrCat(accumulated_result->key(), step_result.key()));
+  }
+  if (step_result.has_value()) {
+    accumulated_result->set_value(
+        absl::StrCat(accumulated_result->value(), step_result.value()));
+  }
+}
+
+void AccumulateCommandOutput(const commands::Output& step_output,
+                             bool* consumed,
+                             bool* has_accumulated_result,
+                             commands::Result* accumulated_result,
+                             commands::Output* final_output) {
+  *consumed = *consumed || step_output.consumed();
+  *final_output = step_output;
+
+  if (step_output.has_result()) {
+    MergeCommandResult(step_output.result(), accumulated_result);
+    *has_accumulated_result = true;
+  }
+
+  final_output->set_consumed(*consumed);
+  if (*has_accumulated_result) {
+    *final_output->mutable_result() = *accumulated_result;
+  }
+}
+
 }  // namespace
 
 Session::Session(const EngineInterface& engine)
@@ -2777,28 +2813,28 @@ bool Session::UpdateComposition(commands::Command* command) {
 bool Session::ExecuteCommandSequence(
     const keymap::CommandSequence& command_sequence,
     commands::Command* command) {
+  return ExecuteCommandSequenceWithInitialOutput(command_sequence, nullptr,
+                                                 command);
+}
+
+bool Session::ExecuteCommandSequenceWithInitialOutput(
+    const keymap::CommandSequence& command_sequence,
+    const commands::Output* initial_output,
+    commands::Command* command) {
   bool executed = false;
   bool consumed = false;
   bool has_accumulated_result = false;
   commands::Result accumulated_result;
   commands::Output final_output;
 
-  const auto merge_result = [](const commands::Result& step_result,
-                               commands::Result* accumulated_result) {
-    if (!accumulated_result->has_key() && !accumulated_result->has_value()) {
-      *accumulated_result = step_result;
-      return;
-    }
-
-    if (step_result.has_key()) {
-      accumulated_result->set_key(
-          absl::StrCat(accumulated_result->key(), step_result.key()));
-    }
-    if (step_result.has_value()) {
-      accumulated_result->set_value(
-          absl::StrCat(accumulated_result->value(), step_result.value()));
-    }
-  };
+  if (initial_output != nullptr) {
+    AccumulateCommandOutput(*initial_output,
+                            &consumed,
+                            &has_accumulated_result,
+                            &accumulated_result,
+                            &final_output);
+    executed = true;
+  }
 
   for (const std::string& command_name : command_sequence) {
     if (command_name.empty()) {
@@ -2823,19 +2859,11 @@ bool Session::ExecuteCommandSequence(
     executed = true;
 
     const commands::Output step_output = command->output();
-    consumed = consumed || step_output.consumed();
-
-    final_output = step_output;
-
-    if (step_output.has_result()) {
-      merge_result(step_output.result(), &accumulated_result);
-      has_accumulated_result = true;
-    }
-
-    final_output.set_consumed(consumed);
-    if (has_accumulated_result) {
-      *final_output.mutable_result() = accumulated_result;
-    }
+    AccumulateCommandOutput(step_output,
+                            &consumed,
+                            &has_accumulated_result,
+                            &accumulated_result,
+                            &final_output);
   }
 
   if (!executed) {
@@ -3419,9 +3447,12 @@ bool Session::SendKeyConversionState(commands::Command* command) {
         return true;
       }
 
+      const commands::Output zenz_commit_output = command->output();
+
       keymap::CommandSequence remaining_sequence(
           command_sequence.begin() + 1, command_sequence.end());
-      return ExecuteCommandSequence(remaining_sequence, command);
+      return ExecuteCommandSequenceWithInitialOutput(
+          remaining_sequence, &zenz_commit_output, command);
     }
 
     // While a zenz correction is visible, the first plain Space should peel off

--- a/src/session/session.h
+++ b/src/session/session.h
@@ -554,6 +554,11 @@ class Session {
       const mozc::keymap::CommandSequence& command_sequence,
       mozc::commands::Command* command);
 
+  bool ExecuteCommandSequenceWithInitialOutput(
+      const mozc::keymap::CommandSequence& command_sequence,
+      const mozc::commands::Output* initial_output,
+      mozc::commands::Command* command);
+
   bool ExecuteDirectInputCommand(
       mozc::keymap::DirectInputState::Commands key_command,
       mozc::commands::Command* command);

--- a/src/session/session_test.cc
+++ b/src/session/session_test.cc
@@ -1104,6 +1104,84 @@ TEST_F(SessionTest, KeymapCommandSequenceCommitAndImeOffFromConversion) {
   EXPECT_EQ(command.output().mode(), commands::DIRECT);
 }
 
+#if defined(_WIN32)
+
+TEST_F(SessionTest, KeymapCommandSequenceCommitZenzLiveCorrectionAndImeOff) {
+  MockEngine engine;
+  std::shared_ptr<MockConverter> converter = CreateEngineConverterMock(&engine);
+
+  ScopedUserProfileForZenzFeedbackSessionTest profile;
+  ASSERT_TRUE(profile.ok());
+
+  Session session(engine);
+  SessionTestPeer session_peer(session);
+  InitSessionToPrecomposition(&session);
+
+  constexpr absl::string_view kCustomKeymapTable =
+      "status\tkey\tcommand\n"
+      "Conversion\tCtrl Enter\tCommit|IMEOff\n";
+
+  config::Config config;
+  config::ConfigHandler::GetDefaultConfig(&config);
+  config.set_session_keymap(config::Config::CUSTOM);
+  config.set_custom_keymap_table(std::string(kCustomKeymapTable));
+  config.set_use_live_conversion(true);
+  config.set_use_zenz_live_correction(true);
+  config.set_use_zenz_feedback_learning(true);
+  config.set_use_zenz_synthetic_candidate(true);
+  config.set_zenz_live_correction_min_key_length(2);
+  session.SetConfig(config);
+
+  auto key_map_manager = std::make_shared<keymap::KeyMapManager>(config);
+  session.SetKeyMapManager(key_map_manager);
+
+  session_peer.zenz_feedback_store_().RecordAccepted(
+      "かれはてんてきです",
+      "empty",
+      "彼は天敵です");
+  ASSERT_FALSE(session_peer.zenz_feedback_store_().ListEntries().empty());
+
+  session_peer.context_()->set_state(ImeContext::CONVERSION);
+  session_peer.live_conversion_active_() = true;
+  session_peer.live_conversion_key_() = "かれはてんてきです";
+  session_peer.live_conversion_preedit_() = "かれはてんてきです";
+  session_peer.live_conversion_value_() = "彼は点滴です";
+
+  commands::Preedit& live_preedit =
+      session_peer.live_conversion_preedit_output_();
+  live_preedit.Clear();
+
+  commands::Preedit::Segment* segment = live_preedit.add_segment();
+  segment->set_key("かれは");
+  segment->set_value("彼は");
+  segment->set_value_length(Util::CharsLen("彼は"));
+
+  segment = live_preedit.add_segment();
+  segment->set_key("てんてきです");
+  segment->set_value("点滴です");
+  segment->set_value_length(Util::CharsLen("点滴です"));
+
+  commands::Command command;
+  ASSERT_TRUE(session_peer.MaybeApplyZenzFeedbackLiveCorrection(&command));
+  ASSERT_TRUE(command.output().zenz_live_correction_applied());
+  EXPECT_PREEDIT("彼は天敵です", command);
+
+  command.Clear();
+  EXPECT_TRUE(SendKey("Ctrl Enter", &session, &command));
+
+  EXPECT_TRUE(command.output().consumed());
+  EXPECT_RESULT_AND_KEY("彼は天敵です", "かれはてんてきです", command);
+  EXPECT_EQ(session.context().state(), ImeContext::DIRECT);
+  EXPECT_EQ(command.output().mode(), commands::DIRECT);
+  EXPECT_FALSE(session_peer.live_conversion_active_());
+  EXPECT_TRUE(session_peer.zenz_live_key_().empty());
+  EXPECT_TRUE(session_peer.zenz_live_value_().empty());
+  EXPECT_TRUE(session_peer.zenz_live_mozc_value_().empty());
+  EXPECT_TRUE(session_peer.zenz_live_context_class_().empty());
+}
+
+#endif  // defined(_WIN32)
+
 TEST_F(SessionTest, PendingZenzFeedbackIsConfirmedByNextTextInput) {
   MockEngine engine;
   std::shared_ptr<MockConverter> converter = CreateEngineConverterMock(&engine);


### PR DESCRIPTION
## Summary

- `Commit|IMEOff` 実行時に、表示中の zenz ライブ補正結果が消える問題を修正
- zenz 専用 commit の `output.result` を、後続 command sequence の accumulator に引き継ぐように変更
- zenz ライブ補正結果を確定しつつ IME を OFF にする回帰テストを追加

## Background

変換中のキーに `Commit|IMEOff` を割り当てている場合、通常の変換結果では問題なく確定と IME OFF が実行されます。

しかし zenz ライブ補正結果が表示されている状態では、`CommitZenzLiveCorrectionResult()` が一度 `output.result` を生成した後、残りの `IMEOff` が別の `ExecuteCommandSequence()` として実行されていました。

その結果、後続 command sequence の開始時に `command.output()` が clear され、zenz の確定結果が失われていました。

## Details

この変更では、`ExecuteCommandSequenceWithInitialOutput()` を追加し、既存の command sequence result accumulation を初期 output 付きで再利用できるようにしました。

zenz ライブ補正表示中の `Commit|IMEOff` では、`CommitZenzLiveCorrectionResult()` 後の output を保存し、それを後続 sequence の初期 output として渡します。

これにより、最終 output は以下のようになります。

- `IMEOff` による `DIRECT` mode を保持
- zenz commit による `result.key` / `result.value` を保持

通常の `ExecuteCommandSequence()` は `initial_output = nullptr` で新 helper に委譲するだけなので、既存の通常 command sequence の外部挙動は維持されます。

## Tests

Passed:

```powershell
bazelisk --output_user_root=C:/bzl test `
  --config oss_windows `
  --config release_build `
  //session:session_test `
  --test_filter=SessionTest.KeymapCommandSequenceCommitZenzLiveCorrectionAndImeOff `
  --verbose_failures
````

```powershell
bazelisk --output_user_root=C:/bzl test `
  --config oss_windows `
  --config release_build `
  //session:session_test `
  --test_filter=SessionTest.KeymapCommandSequence* `
  --verbose_failures
```

Manual test:

* Built `//server:mozc_server`
* Replaced installed `mozc_server.exe` with the locally built binary
* Confirmed that pressing a key assigned to `Commit|IMEOff` while a zenz live correction is visible:

  * commits the zenz result
  * disables IME
  * does not drop the committed text
