### PR TITLE
fix(session): start zenz live correction immediately

### DIFF
--- a/src/session/session.cc
+++ b/src/session/session.cc
@@ -5139,6 +5139,18 @@ bool Session::MaybeScheduleZenzLiveCorrection(commands::Command* command) {
       ZenzBool(right_context_result.allowed_for_prompt),
       " right_context_reason=", right_context_result.reason));
 
+  const uint32_t delay_msec = GetZenzLiveCorrectionDelayMsec(config);
+  if (delay_msec == 0) {
+    ZenzDebugOutput("[zenz] start immediately");
+    // The current command already contains the freshly generated live
+    // conversion output from MaybeStartLiveConversion().  Do not call
+    // Output() again in the same key-event path, because PopOutput() is
+    // destructive and a second output refresh can momentarily duplicate the
+    // composition text on some TSF clients.
+    return AdvancePendingZenzLiveCorrection(
+        command, /*refresh_output_on_submit=*/false);
+  }
+
   AttachZenzLiveCorrectionStartCallback(command);
   command->mutable_output()->set_zenz_live_correction_pending(true);
   return true;
@@ -5388,6 +5400,15 @@ bool Session::ApplyZenzLiveCorrection(commands::Command* command) {
     return IgnoreStaleDelayedLiveConversion(command);
   }
 
+  return AdvancePendingZenzLiveCorrection(
+      command, /*refresh_output_on_submit=*/true);
+}
+
+bool Session::AdvancePendingZenzLiveCorrection(
+    commands::Command* command,
+    const bool refresh_output_on_submit) {
+  command->mutable_output()->set_consumed(true);
+
   const config::Config& config = context_->GetConfig();
   const absl::Time now = Clock::GetAbslTime();
   const uint32_t timeout_msec = GetZenzLiveCorrectionTimeoutMsec(config);
@@ -5427,7 +5448,15 @@ bool Session::ApplyZenzLiveCorrection(commands::Command* command) {
 
     EnsureZenzLiveCorrector()->Submit(std::move(request));
 
-    const bool result = OutputCurrentLiveConversionWithZenzPending(command);
+    bool result = true;
+    if (refresh_output_on_submit) {
+      result = OutputCurrentLiveConversionWithZenzPending(command);
+    } else {
+      commands::Output* output = command->mutable_output();
+      output->set_live_conversion(true);
+      output->set_live_conversion_pending(false);
+      output->set_zenz_live_correction_pending(true);
+    }
     AttachZenzLiveCorrectionPollCallback(command);
     return result;
   }

--- a/src/session/session.h
+++ b/src/session/session.h
@@ -486,6 +486,9 @@ class Session {
   void AttachZenzLiveCorrectionPollCallback(
       mozc::commands::Command* command) const;
   bool ApplyZenzLiveCorrection(mozc::commands::Command* command);
+  bool AdvancePendingZenzLiveCorrection(
+      mozc::commands::Command* command,
+      bool refresh_output_on_submit);
   bool IsCurrentZenzLiveCorrectionCallback(
       const mozc::commands::Command& command) const;
   bool OutputCurrentLiveConversionWithZenzPending(

--- a/src/session/session_test.cc
+++ b/src/session/session_test.cc
@@ -1524,6 +1524,103 @@ TEST_F(SessionTest, LiveConversionAllowsSingleCharacterWhenMinKeyLengthIsOne) {
   EXPECT_TRUE(EnsurePreedit("亜", command));
 }
 
+TEST_F(SessionTest,
+       ZenzLiveCorrectionPositiveDelaySchedulesStartCallback) {
+  MockEngine engine;
+  std::shared_ptr<MockConverter> converter = CreateEngineConverterMock(&engine);
+
+  Session session(engine);
+  InitSessionToPrecomposition(&session);
+
+  config::Config config;
+  config::ConfigHandler::GetDefaultConfig(&config);
+  config.set_use_live_conversion(true);
+  config.set_live_conversion_delay_msec(0);
+  config.set_live_conversion_min_key_length(2);
+  config.set_use_zenz_live_correction(true);
+  config.set_zenz_live_correction_delay_msec(1);
+  config.set_zenz_live_correction_min_key_length(2);
+  session.SetConfig(config);
+
+  Segments segments;
+  Segment* segment = segments.add_segment();
+  segment->set_key("あい");
+  converter::Candidate* candidate = segment->add_candidate();
+  candidate->key = "あい";
+  candidate->content_key = "あい";
+  candidate->value = "愛";
+
+  EXPECT_CALL(*converter, StartConversion(_, _))
+      .Times(1)
+      .WillOnce(DoAll(SetArgPointee<1>(segments), Return(true)));
+
+  commands::Command command;
+  InsertCharacterString("あい", "ai", &session, &command);
+
+  EXPECT_EQ(session.context().state(), ImeContext::CONVERSION);
+  EXPECT_TRUE(command.output().live_conversion());
+  EXPECT_FALSE(command.output().live_conversion_pending());
+  EXPECT_TRUE(command.output().zenz_live_correction_pending());
+  EXPECT_TRUE(EnsurePreedit("愛", command));
+
+  ASSERT_TRUE(command.output().has_callback());
+  ASSERT_TRUE(command.output().callback().has_session_command());
+  EXPECT_EQ(command.output().callback().session_command().type(),
+            commands::SessionCommand::APPLY_ZENZ_LIVE_CORRECTION);
+  ASSERT_TRUE(command.output().callback().has_delay_millisec());
+  EXPECT_EQ(command.output().callback().delay_millisec(), 1);
+}
+
+TEST_F(SessionTest,
+       ZenzLiveCorrectionZeroDelayStartsImmediatelyAndKeepsLiveOutput) {
+  MockEngine engine;
+  std::shared_ptr<MockConverter> converter = CreateEngineConverterMock(&engine);
+
+  Session session(engine);
+  InitSessionToPrecomposition(&session);
+
+  config::Config config;
+  config::ConfigHandler::GetDefaultConfig(&config);
+  config.set_use_live_conversion(true);
+  config.set_live_conversion_delay_msec(0);
+  config.set_live_conversion_min_key_length(2);
+  config.set_use_zenz_live_correction(true);
+  config.set_zenz_live_correction_delay_msec(0);
+  config.set_zenz_live_correction_min_key_length(2);
+  config.set_zenz_live_correction_pipe_name("");
+  session.SetConfig(config);
+
+  Segments segments;
+  Segment* segment = segments.add_segment();
+  segment->set_key("あい");
+  converter::Candidate* candidate = segment->add_candidate();
+  candidate->key = "あい";
+  candidate->content_key = "あい";
+  candidate->value = "愛";
+
+  EXPECT_CALL(*converter, StartConversion(_, _))
+      .Times(1)
+      .WillOnce(DoAll(SetArgPointee<1>(segments), Return(true)));
+
+  commands::Command command;
+  InsertCharacterString("あい", "ai", &session, &command);
+
+  EXPECT_EQ(session.context().state(), ImeContext::CONVERSION);
+  EXPECT_TRUE(command.output().live_conversion());
+  EXPECT_FALSE(command.output().live_conversion_pending());
+  EXPECT_TRUE(command.output().zenz_live_correction_pending());
+  EXPECT_TRUE(EnsurePreedit("愛", command));
+
+  ASSERT_TRUE(command.output().has_callback());
+  ASSERT_TRUE(command.output().callback().has_session_command());
+  EXPECT_EQ(command.output().callback().session_command().type(),
+            commands::SessionCommand::APPLY_ZENZ_LIVE_CORRECTION);
+  ASSERT_TRUE(command.output().callback().has_delay_millisec());
+  // Zero-delay Zenz correction should not emit a rounded start callback.
+  // It starts the request immediately and emits the first poll callback.
+  EXPECT_EQ(command.output().callback().delay_millisec(), 24);
+}
+
 TEST_F(SessionTest, LiveConversionHonorsRaisedMinKeyLength) {
   MockEngine engine;
   std::shared_ptr<MockConverter> converter = CreateEngineConverterMock(&engine);


### PR DESCRIPTION
## Summary

Zenzライブ補正の開始遅延を 0ms に設定した場合に、補正開始 callback が Windows TIP 側で実行予約されず、Zenz補正が開始されない問題を修正しました。

## Changes

- Zenz補正開始遅延が 0ms の場合、`APPLY_ZENZ_LIVE_CORRECTION` の start callback を出さず、session 側で即時に pending Zenz request を開始するようにしました。
- 0ms 経路では、直前に生成済みのライブ変換 output を再利用し、`Output()` の二重呼び出しを避けるようにしました。
- 1ms 以上の遅延では、従来どおり callback 経由で Zenz補正を開始します。
- 0ms / 1ms それぞれの挙動を session test に追加しました。

## Testing

- `//session:session_test`
- 実機確認:
  - Zenz補正開始遅延 0ms で補正が動作する
  - 0ms 時に入力文字列が一瞬右側に複製される表示が出ない
  - Zenz結果表示後、SpaceでMozcライブ変換結果へ戻れる
  - 1ms 設定でも従来どおり動作する
  