### PR TITLE
Fix/config dialog apply state

### DIFF
--- a/src/composer/table.cc
+++ b/src/composer/table.cc
@@ -106,6 +106,16 @@ constexpr char k50KeysHiraganaTableFile[] = "system://50keys-hiragana.tsv";
 
 constexpr char kNewChunkPrefix[] = "\t";
 
+uint64_t GetCustomRomanTableFingerprint(
+    const commands::Request& request, const config::Config& config) {
+  if (request.special_romanji_table() != commands::Request::DEFAULT_TABLE ||
+      config.preedit_method() != config::Config::ROMAN ||
+      !config.has_custom_roman_table() || config.custom_roman_table().empty()) {
+    return 0;
+  }
+  return CityFingerprint(config.custom_roman_table());
+}
+
 }  // namespace
 
 // ========================================
@@ -577,37 +587,22 @@ std::shared_ptr<const Table> Table::GetSharedDefaultTable() {
 // ========================================
 // TableContainer
 // ========================================
-TableManager::TableManager()
-    : custom_roman_table_fingerprint_(CityFingerprint("")) {}
+TableManager::TableManager() = default;
 
 std::shared_ptr<const Table> TableManager::GetTable(
     const mozc::commands::Request& request,
     const mozc::config::Config& config) {
-  // calculate the hash depending on the request and the config
-  const size_t hash =
-      absl::HashOf(request.special_romanji_table(), config.preedit_method(),
-                   config.punctuation_method(), config.symbol_method());
-
-  // When custom_roman_table is set, force to create new table.
-  bool update_custom_roman_table = false;
-  if ((config.preedit_method() == config::Config::ROMAN) &&
-      config.has_custom_roman_table() && !config.custom_roman_table().empty()) {
-    const uint64_t custom_roman_table_fingerprint =
-        CityFingerprint(config.custom_roman_table());
-    if (custom_roman_table_fingerprint != custom_roman_table_fingerprint_) {
-      update_custom_roman_table = true;
-      custom_roman_table_fingerprint_ = custom_roman_table_fingerprint;
-    }
-  }
+  // calculate the hash depending on the request and the config.
+  // custom_roman_table must be part of the cache key.  Otherwise, clearing a
+  // previously saved custom table can keep returning the stale custom Table.
+  const size_t hash = absl::HashOf(
+      request.special_romanji_table(), config.preedit_method(),
+      config.punctuation_method(), config.symbol_method(),
+      GetCustomRomanTableFingerprint(request, config));
 
   if (const auto iterator = table_map_.find(hash);
       iterator != table_map_.end()) {
-    if (update_custom_roman_table) {
-      // Delete the previous table to update the table.
-      table_map_.erase(iterator);
-    } else {
-      return iterator->second;
-    }
+    return iterator->second;
   }
 
   auto table = std::make_shared<Table>();

--- a/src/composer/table.h
+++ b/src/composer/table.h
@@ -177,9 +177,8 @@ class TableManager {
   //  config::Config::PreeditMethod
   //  config::Config::PunctuationMethod
   //  config::Config::SymbolMethod
+  //  Config::custom_roman_table fingerprint
   absl::flat_hash_map<size_t, std::shared_ptr<const Table>> table_map_;
-  // Fingerprint for Config::custom_roman_table;
-  uint64_t custom_roman_table_fingerprint_;
 };
 
 }  // namespace composer

--- a/src/composer/table_test.cc
+++ b/src/composer/table_test.cc
@@ -1066,6 +1066,30 @@ TEST_F(TableTest, TableManager) {
     EXPECT_NE(table2->LookUp("a"), nullptr);
     EXPECT_NE(table2->LookUp("kk"), nullptr);
   }
+
+  {
+    commands::Request request;
+    request.set_special_romanji_table(Request::DEFAULT_TABLE);
+    config::Config config;
+    config.set_preedit_method(Config::ROMAN);
+    config.set_punctuation_method(Config::TOUTEN_KUTEN);
+    config.set_symbol_method(Config::CORNER_BRACKET_MIDDLE_DOT);
+
+    constexpr absl::string_view kRule = "mozctest\t[MOZC]\n";
+    config.set_custom_roman_table(kRule);
+    std::shared_ptr<const Table> custom_table =
+        table_manager.GetTable(request, config);
+    ASSERT_NE(custom_table, nullptr);
+    EXPECT_NE(custom_table->LookUp("mozctest"), nullptr);
+
+    config.clear_custom_roman_table();
+    std::shared_ptr<const Table> default_table =
+        table_manager.GetTable(request, config);
+    ASSERT_NE(default_table, nullptr);
+    EXPECT_NE(default_table, custom_table);
+    EXPECT_EQ(default_table->LookUp("mozctest"), nullptr);
+    EXPECT_EQ(table_manager.GetTable(request, config), default_table);
+  }
 }
 
 }  // namespace

--- a/src/gui/config_dialog/config_dialog.cc
+++ b/src/gui/config_dialog/config_dialog.cc
@@ -241,6 +241,9 @@ void NotifyDisplayAttributeUpdate();
 
 ConfigDialog::ConfigDialog()
     : client_(client::ClientFactory::NewClient()),
+      initial_ime_hot_key_disabled_(false),
+      initial_startup_enabled_(false),
+      suppress_apply_button_update_(true),
       initial_preedit_method_(0),
       initial_use_keyboard_to_change_preedit_method_(false),
       initial_use_mode_indicator_(true) {
@@ -496,14 +499,12 @@ ConfigDialog::ConfigDialog()
 
   InitializeCandidateRubyFontComboBox(candidateRubyFontComboBox);
 
-  // Event handlers to enable 'Apply' button.
-  Connect(findChildren<QPushButton *>(), SIGNAL(clicked()), this,
+  // Event handlers to update 'Apply' button state.
+  Connect(findChildren<QCheckBox *>(), SIGNAL(stateChanged(int)), this,
           SLOT(EnableApplyButton()));
-  Connect(findChildren<QCheckBox *>(), SIGNAL(clicked()), this,
+  Connect(findChildren<QComboBox *>(), SIGNAL(currentIndexChanged(int)), this,
           SLOT(EnableApplyButton()));
-  Connect(findChildren<QComboBox *>(), SIGNAL(activated(int)), this,
-          SLOT(EnableApplyButton()));
-  Connect(findChildren<QSpinBox *>(), SIGNAL(editingFinished()), this,
+  Connect(findChildren<QSpinBox *>(), SIGNAL(valueChanged(int)), this,
           SLOT(EnableApplyButton()));
   Connect(findChildren<QLineEdit *>(), SIGNAL(textEdited(QString)), this,
           SLOT(EnableApplyButton()));
@@ -550,6 +551,9 @@ ConfigDialog::ConfigDialog()
   IMEHotKeyDisabledCheckBox->setVisible(false);
 #endif  // _WIN32
 
+  RecordCurrentStateAsApplied();
+  suppress_apply_button_update_ = false;
+  EnableApplyButton();
 }
 
 bool ConfigDialog::SetConfig(const config::Config &config) {
@@ -586,12 +590,12 @@ void ConfigDialog::Reload() {
     QMessageBox::critical(this, windowTitle(),
                           tr("Failed to get current config values."));
   }
-  ConvertFromProto(config);
 
-  SelectLiveConversionSetting(
-      static_cast<int>(liveConversionCheckBox->isChecked()));
-  SelectAutoConversionSetting(static_cast<int>(useAutoConversion->isChecked()));
-  SelectDirectCommitSetting(static_cast<int>(useDirectCommit->isChecked()));
+  const bool was_suppressed = suppress_apply_button_update_;
+  suppress_apply_button_update_ = true;
+  ConvertFromProto(config);
+  UpdateDependentControls();
+  suppress_apply_button_update_ = was_suppressed;
   initial_preedit_method_ = static_cast<int>(config.preedit_method());
   initial_use_keyboard_to_change_preedit_method_ =
       config.use_keyboard_to_change_preedit_method();
@@ -731,6 +735,7 @@ bool ConfigDialog::Update() {
     // in almost all cases.
     // TODO(taku): better to show dialog?
     LOG(ERROR) << "Failed to update IME HotKey status";
+    return false;
   }
 #endif  // _WIN32
 
@@ -745,6 +750,10 @@ bool ConfigDialog::Update() {
     }
   }
 #endif  // __APPLE__
+
+  base_config_ = config;
+  RecordCurrentStateAsApplied();
+  EnableApplyButton();
 
   return true;
 }
@@ -1971,6 +1980,7 @@ void ConfigDialog::EditKeymap() {
     custom_keymap_table_ = output;
     // set keymapSettingComboBox to "Custom keymap"
     keymapSettingComboBox->setCurrentIndex(0);
+    EnableApplyButton();
   }
 }
 
@@ -1978,6 +1988,7 @@ void ConfigDialog::EditRomanTable() {
   std::string output;
   if (gui::RomanTableEditorDialog::Show(this, custom_roman_table_, &output)) {
     custom_roman_table_ = output;
+    EnableApplyButton();
   }
 }
 
@@ -2089,7 +2100,12 @@ void ConfigDialog::ResetToDefaults() {
                             QMessageBox::Cancel)) {
     // TODO(taku): remove the dependency to config::ConfigHandler
     // nice to have GET_DEFAULT_CONFIG command
+    const bool was_suppressed = suppress_apply_button_update_;
+    suppress_apply_button_update_ = true;
     ConvertFromProto(config::ConfigHandler::DefaultConfig());
+    UpdateDependentControls();
+    suppress_apply_button_update_ = was_suppressed;
+    EnableApplyButton();
   }
 }
 
@@ -2167,8 +2183,62 @@ void ConfigDialog::RestorePreviousDefaultImeSetting() {
 #endif  // _WIN32
 }
 
+void ConfigDialog::UpdateDependentControls() {
+  SelectInputModeSetting(inputModeComboBox->currentIndex());
+  SelectLiveConversionSetting(
+      static_cast<int>(liveConversionCheckBox->isChecked()));
+  SelectAutoConversionSetting(static_cast<int>(useAutoConversion->isChecked()));
+  SelectDirectCommitSetting(static_cast<int>(useDirectCommit->isChecked()));
+  SelectSuggestionSetting(
+      static_cast<int>(historySuggestCheckBox->isChecked() ||
+                       dictionarySuggestCheckBox->isChecked() ||
+                       realtimeConversionCheckBox->isChecked()));
+}
+
+void ConfigDialog::RecordCurrentStateAsApplied() {
+  ConvertToProto(&last_applied_config_);
+
+#ifdef _WIN32
+  initial_ime_hot_key_disabled_ = IMEHotKeyDisabledCheckBox->isChecked();
+#endif  // _WIN32
+
+#ifdef __APPLE__
+  initial_startup_enabled_ = startupCheckBox->isChecked();
+#endif  // __APPLE__
+}
+
+bool ConfigDialog::IsModified() const {
+  config::Config current_config;
+  ConvertToProto(&current_config);
+
+  if (current_config.SerializeAsString() !=
+      last_applied_config_.SerializeAsString()) {
+    return true;
+  }
+
+#ifdef _WIN32
+  if (IMEHotKeyDisabledCheckBox->isChecked() !=
+      initial_ime_hot_key_disabled_) {
+    return true;
+  }
+#endif  // _WIN32
+
+#ifdef __APPLE__
+  if (startupCheckBox->isChecked() != initial_startup_enabled_) {
+    return true;
+  }
+#endif  // __APPLE__
+
+  return false;
+}
+
 void ConfigDialog::EnableApplyButton() {
-  configDialogButtonBox->button(QDialogButtonBox::Apply)->setEnabled(true);
+  if (suppress_apply_button_update_) {
+    return;
+  }
+
+  configDialogButtonBox->button(QDialogButtonBox::Apply)
+      ->setEnabled(IsModified());
 }
 
 // Catch MouseButtonRelease event to toggle the CheckBoxes

--- a/src/gui/config_dialog/config_dialog.cc
+++ b/src/gui/config_dialog/config_dialog.cc
@@ -505,6 +505,8 @@ ConfigDialog::ConfigDialog()
           SLOT(EnableApplyButton()));
   Connect(findChildren<QSpinBox *>(), SIGNAL(editingFinished()), this,
           SLOT(EnableApplyButton()));
+  Connect(findChildren<QLineEdit *>(), SIGNAL(textEdited(QString)), this,
+          SLOT(EnableApplyButton()));
   // 'Apply' button is disabled on launching.
   configDialogButtonBox->button(QDialogButtonBox::Apply)->setEnabled(false);
 

--- a/src/gui/config_dialog/config_dialog.h
+++ b/src/gui/config_dialog/config_dialog.h
@@ -95,6 +95,9 @@ class ConfigDialog : public QDialog, private Ui::ConfigDialog {
   void ConvertFromProto(const config::Config &config);
   bool Update();
   void Reload();
+  void UpdateDependentControls();
+  void RecordCurrentStateAsApplied();
+  bool IsModified() const;
 
   std::unique_ptr<client::ClientInterface> client_;
   std::string custom_keymap_table_;
@@ -102,6 +105,10 @@ class ConfigDialog : public QDialog, private Ui::ConfigDialog {
   // base_config_ keeps the original config imported from the file including
   // unconfigurable options with the GUI (e.g. composing_timeout_threshold_msec)
   config::Config base_config_;
+  config::Config last_applied_config_;
+  bool initial_ime_hot_key_disabled_;
+  bool initial_startup_enabled_;
+  bool suppress_apply_button_update_;
   int initial_preedit_method_;
   bool initial_use_keyboard_to_change_preedit_method_;
   bool initial_use_mode_indicator_;

--- a/src/gui/config_dialog/roman_table_editor.cc
+++ b/src/gui/config_dialog/roman_table_editor.cc
@@ -34,6 +34,7 @@
 #include <QHeaderView>
 #include <QMenu>
 #include <QMessageBox>
+#include <QTableWidgetItem>
 #include <QToolTip>
 #include <QtGui>
 #include <istream>
@@ -112,7 +113,10 @@ QTableWidgetItem *CreateDisplayAmbiguousResultItem(
 }  // namespace
 
 RomanTableEditorDialog::RomanTableEditorDialog(QWidget *parent)
-    : GenericTableEditorDialog(parent, 4), actions_(MENU_SIZE) {
+    : GenericTableEditorDialog(parent, 4),
+      actions_(MENU_SIZE),
+      default_table_requested_(false),
+      loading_table_(false) {
   actions_[NEW_INDEX] = mutable_edit_menu()->addAction(tr("New entry"));
   actions_[REMOVE_INDEX] =
       mutable_edit_menu()->addAction(tr("Remove selected entries"));
@@ -134,6 +138,15 @@ RomanTableEditorDialog::RomanTableEditorDialog(QWidget *parent)
   headers << tr("Input") << tr("Output") << tr("Next input")
           << tr("途中一致でも表示");
   mutable_table_widget()->setHorizontalHeaderLabels(headers);
+
+  // Romaji table is an ordered list of conversion rules.  Sorting changes the
+  // serialized rule order and can change actual input behavior.
+  mutable_table_widget()->setSortingEnabled(false);
+  mutable_table_widget()->horizontalHeader()->setSortIndicatorShown(false);
+
+  QObject::connect(mutable_table_widget(), SIGNAL(itemChanged(QTableWidgetItem *)),
+                   this, SLOT(MarkRomanTableEdited(QTableWidgetItem *)));
+
   mutable_table_widget()->horizontalHeader()->viewport()->installEventFilter(this);
 
   resize(430, 350);
@@ -175,6 +188,9 @@ std::string RomanTableEditorDialog::GetDefaultRomanTable() {
 
 bool RomanTableEditorDialog::LoadFromStream(std::istream *is) {
   CHECK(is);
+  const bool was_loading_table = loading_table_;
+  loading_table_ = true;
+
   std::string line;
   mutable_table_widget()->setRowCount(0);
   mutable_table_widget()->verticalHeader()->hide();
@@ -225,6 +241,8 @@ bool RomanTableEditorDialog::LoadFromStream(std::istream *is) {
     }
   }
 
+  loading_table_ = was_loading_table;
+
   UpdateMenuStatus();
 
   return true;
@@ -235,6 +253,7 @@ bool RomanTableEditorDialog::LoadDefaultRomanTable() {
       ConfigFileStream::LegacyOpen(kRomanTableFile));
   CHECK(ifs);  // should never happen
   CHECK(LoadFromStream(ifs.get()));
+  default_table_requested_ = true;
   return true;
 }
 
@@ -313,6 +332,7 @@ void RomanTableEditorDialog::UpdateMenuStatus() {
 
 void RomanTableEditorDialog::OnEditMenuAction(QAction *action) {
   if (action == actions_[NEW_INDEX]) {
+    default_table_requested_ = false;
     AddNewItem();
     const int row = (mutable_table_widget()->currentRow() >= 0)
                         ? mutable_table_widget()->currentRow()
@@ -323,6 +343,7 @@ void RomanTableEditorDialog::OnEditMenuAction(QAction *action) {
           row, 3, CreateDisplayAmbiguousResultItem(false, std::string()));
     }
   } else if (action == actions_[REMOVE_INDEX]) {
+    default_table_requested_ = false;
     DeleteSelectedItems();
   } else if (action == actions_[IMPORT_FROM_FILE_INDEX] ||
              action == actions_[RESET_INDEX]) {  // import or reset
@@ -336,6 +357,7 @@ void RomanTableEditorDialog::OnEditMenuAction(QAction *action) {
     }
 
     if (action == actions_[IMPORT_FROM_FILE_INDEX]) {
+      default_table_requested_ = false;
       Import();
     } else if (action == actions_[RESET_INDEX]) {
       LoadDefaultRomanTable();
@@ -343,6 +365,15 @@ void RomanTableEditorDialog::OnEditMenuAction(QAction *action) {
   } else if (action == actions_[EXPORT_TO_FILE_INDEX]) {
     Export();
   }
+}
+
+
+void RomanTableEditorDialog::MarkRomanTableEdited(QTableWidgetItem *item) {
+  (void)item;
+  if (loading_table_) {
+    return;
+  }
+  default_table_requested_ = false;
 }
 
 bool RomanTableEditorDialog::eventFilter(QObject *obj, QEvent *event) {
@@ -381,7 +412,8 @@ bool RomanTableEditorDialog::Show(QWidget *parent,
   const bool result = (QDialog::Accepted == window.exec());
   new_roman_table->clear();
 
-  if (result && window.table() != window.GetDefaultRomanTable()) {
+  if (result && !window.default_table_requested_ &&
+      window.table() != window.GetDefaultRomanTable()) {
     *new_roman_table = window.table();
   }
 

--- a/src/gui/config_dialog/roman_table_editor.h
+++ b/src/gui/config_dialog/roman_table_editor.h
@@ -32,6 +32,7 @@
 
 #include <QAbstractButton>
 #include <QEvent>
+#include <QTableWidgetItem>
 #include <QWidget>
 #include <istream>
 #include <string>
@@ -56,6 +57,9 @@ class RomanTableEditorDialog : public GenericTableEditorDialog {
   void UpdateMenuStatus() override;
   void OnEditMenuAction(QAction *action) override;
 
+ private slots:
+  void MarkRomanTableEdited(QTableWidgetItem *item);
+
  protected:
   QLatin1String GetDefaultFilename() const override {
     return QLatin1String("romantable.txt");
@@ -71,6 +75,8 @@ class RomanTableEditorDialog : public GenericTableEditorDialog {
  private:
   absl::FixedArray<QAction *> actions_;
   QString dialog_title_;
+  bool default_table_requested_;
+  bool loading_table_;
 };
 
 }  // namespace gui


### PR DESCRIPTION
## Summary

- 設定画面のテキスト入力欄を編集しても Apply ボタンが有効にならない問題を修正
- Apply ボタンの dirty state 管理を改善し、保存成功後は未変更状態として Apply を無効化
- ローマ字テーブル編集画面の「初期値に戻す」で、保存済みカスタムローマ字テーブルを確実に解除するよう修正
- `mozc_server` 側のローマ字テーブルキャッシュキーに custom roman table fingerprint を含め、カスタム解除後も古いテーブルが使われる問題を修正

## Testing

- `//composer:table_test` 通過
- `//gui/tool:mozc_tool_win` ビルド成功
- `//server:mozc_server` ビルド成功
- 実機で以下を確認
  - Zenz条件フィールド編集で Apply が有効化される
  - Apply 後に Apply が無効へ戻る
  - ローマ字テーブルをカスタム状態にした後、実入力へ反映される
  - 「初期値に戻す」→ OK → Apply 後、実入力が組み込みデフォルト挙動へ戻る
  