### PR TITLE
fix(tip): turn on IME for empty reconversion

### DIFF
--- a/src/win32/tip/tip_edit_session.cc
+++ b/src/win32/tip/tip_edit_session.cc
@@ -359,10 +359,26 @@ bool TurnOnImeAndTryToReconvertFromIme(TipTextService* text_service,
     if (open) {
       return true;
     }
-    // Currently Mozc server will not turn on IME when |text_utf8| is empty but
-    // people expect IME will be turned on even when the reconversion does
-    // nothing.  b/4225148.
-    return OnUpdateOnOffModeAsync(text_service, context, true);
+    // When reconversion is requested without selected text in direct mode,
+    // behave as an IME-on key.  This must go through the normal session path;
+    // otherwise only TipInputModeManager is updated and the TSF open/close
+    // compartment stays OFF until the next focus update restores the effective
+    // state to OFF.
+    TipPrivateContext* private_context = text_service->GetPrivateContext(context);
+    if (!private_context) {
+      // This is an unmanaged context. Keep the historical local/UI update
+      // behavior, because there is no Mozc session to synchronize.
+      return OnUpdateOnOffModeAsync(text_service, context, true);
+    }
+
+    Output output;
+    SessionCommand command;
+    command.set_type(SessionCommand::TURN_ON_IME);
+    if (!private_context->GetClient()->SendCommand(command, &output)) {
+      return false;
+    }
+    return TipEditSession::OnOutputReceivedSync(text_service, context,
+                                                std::move(output));
   }
 
   TipPrivateContext* private_context = text_service->GetPrivateContext(context);


### PR DESCRIPTION
## 概要

MS-IME 風キー設定で、`無変換 -> IMEOff`、`変換 -> IMEOn` を設定した場合に、`無変換 -> 変換` の後、カーソル移動や focus/context 更新で IME が再び無効状態へ戻ることがある問題を修正しました。

## 原因

`MUHENKAN` で IME を OFF にした直後は Mozc server state が `DirectInput` になります。

この状態で `HENKAN` を押すと、`Precomposition Henkan IMEOn` ではなく、既存の `DirectInput Henkan Reconvert` が実行されます。

選択文字列がない場合、従来は `TipInputModeManager` の内部状態だけを ON にしており、Mozc server state と TSF の open/close compartment が OFF のまま残っていました。

そのため、次の focus/context 更新で TSF 側の OFF 状態が再読込され、IME が無効状態に戻っていました。

## 変更内容

選択文字列なしの再変換要求で IME が OFF の場合、`OnUpdateOnOffModeAsync()` で内部状態だけを更新するのではなく、`TURN_ON_IME` を通常の session path に送るようにしました。

これにより、Mozc server state と TSF open/close compartment が同期されます。

## 確認内容

- `bazelisk --output_user_root=C:/bzl build --config oss_windows --config release_build package --verbose_failures` 成功
- 修正版 MSI を実機インストール
- TIP 登録確認済み
- `Get-WinUserLanguageList` に Mozkey が存在することを確認
- Dynalist / Notion / Slack / UpNote 相当の再現手順で、`無変換 -> 変換` 後のカーソル移動で IME が無効状態へ戻らないことを確認
