### PR TITLE
fix(tip): fall back when reconversion text is unavailable

### DIFF
--- a/src/win32/tip/tip_edit_session.cc
+++ b/src/win32/tip/tip_edit_session.cc
@@ -333,6 +333,36 @@ bool OnSessionCommandAsync(TipTextService* text_service, ITfContext* context,
   return SUCCEEDED(hr) && SUCCEEDED(edit_session_result);
 }
 
+bool TurnOnImeForReconversionFallback(TipTextService* text_service,
+                                      ITfContext* context) {
+  if (context == nullptr) {
+    return false;
+  }
+
+  const bool open = text_service->GetThreadContext()
+                        ->GetInputModeManager()
+                        ->GetEffectiveOpenClose();
+  if (open) {
+    return true;
+  }
+
+  TipPrivateContext* private_context = text_service->GetPrivateContext(context);
+  if (!private_context) {
+    // This is an unmanaged context. Keep the historical local/UI update
+    // behavior, because there is no Mozc session to synchronize.
+    return OnUpdateOnOffModeAsync(text_service, context, true);
+  }
+
+  Output output;
+  SessionCommand command;
+  command.set_type(SessionCommand::TURN_ON_IME);
+  if (!private_context->GetClient()->SendCommand(command, &output)) {
+    return false;
+  }
+  return TipEditSession::OnOutputReceivedSync(text_service, context,
+                                              std::move(output));
+}
+
 bool TurnOnImeAndTryToReconvertFromIme(TipTextService* text_service,
                                        ITfContext* context) {
   if (context == nullptr) {
@@ -343,7 +373,10 @@ bool TurnOnImeAndTryToReconvertFromIme(TipTextService* text_service,
   bool need_async_edit_session = false;
   if (!TipSurroundingText::PrepareForReconversionFromIme(
           text_service, context, &info, &need_async_edit_session)) {
-    return false;
+    // Some TSF clients do not expose enough surrounding text for reconversion.
+    // In direct mode, Henkan should still behave as an IME-on key rather than
+    // doing nothing.
+    return TurnOnImeForReconversionFallback(text_service, context);
   }
 
   // Currently this is not supported.
@@ -353,32 +386,10 @@ bool TurnOnImeAndTryToReconvertFromIme(TipTextService* text_service,
 
   std::string text_utf8 = WideToUtf8(info.selected_text);
   if (text_utf8.empty()) {
-    const bool open = text_service->GetThreadContext()
-                          ->GetInputModeManager()
-                          ->GetEffectiveOpenClose();
-    if (open) {
-      return true;
-    }
     // When reconversion is requested without selected text in direct mode,
-    // behave as an IME-on key.  This must go through the normal session path;
-    // otherwise only TipInputModeManager is updated and the TSF open/close
-    // compartment stays OFF until the next focus update restores the effective
-    // state to OFF.
-    TipPrivateContext* private_context = text_service->GetPrivateContext(context);
-    if (!private_context) {
-      // This is an unmanaged context. Keep the historical local/UI update
-      // behavior, because there is no Mozc session to synchronize.
-      return OnUpdateOnOffModeAsync(text_service, context, true);
-    }
-
-    Output output;
-    SessionCommand command;
-    command.set_type(SessionCommand::TURN_ON_IME);
-    if (!private_context->GetClient()->SendCommand(command, &output)) {
-      return false;
-    }
-    return TipEditSession::OnOutputReceivedSync(text_service, context,
-                                                std::move(output));
+    // behave as an IME-on key. This must go through the normal session path so
+    // the Mozc server state and TSF open/close compartment stay synchronized.
+    return TurnOnImeForReconversionFallback(text_service, context);
   }
 
   TipPrivateContext* private_context = text_service->GetPrivateContext(context);
@@ -423,10 +434,11 @@ bool ReconvertSelectionOrKeepFallbackOutput(TipTextService* text_service,
   bool need_async_edit_session = false;
   if (!TipSurroundingText::PrepareForReconversionFromIme(
           text_service, context, &info, &need_async_edit_session)) {
-    // Do not apply the fallback output when the selected text state is
-    // unknown.  Otherwise selected application text may be replaced with a
-    // space in TSF-unfriendly applications.
-    return true;
+    // Some TSF clients do not expose enough surrounding text for reconversion.
+    // In that case, reconversion is unavailable, so keep the server-generated
+    // fallback InsertSpace output instead of consuming Space and doing nothing.
+    fallback_output->clear_callback();
+    return false;
   }
 
   if (info.in_composition) {


### PR DESCRIPTION
## 概要

一部の TSF クライアントで再変換用の surrounding text / selected text を取得できない場合に、変換キーや Space が何も起こさない問題を修正しました。

具体的には、Zed などで Mozkey 使用時に以下の問題が起きていました。

* IME OFF 状態で `Henkan` を押しても IME ON にならない
* IME ON 状態で `Space` を押してもスペース入力されない

## 変更内容

* `DirectInput Henkan -> Reconvert` で再変換用テキストを取得できない場合、何もせず失敗するのではなく `TURN_ON_IME` に fallback するようにしました。
* `ReconvertSelectionOrInsertSpace` で再変換用テキストを取得できない場合、`Space` を consume して何もしないのではなく、server-generated `InsertSpace` fallback を適用するようにしました。
* 選択文字列を取得できる通常の再変換経路は維持しています。

## 確認内容

Zed + Mozkey で確認:

* IME OFF → `Henkan` で IME ON になる
* IME ON → `Muhenkan` で IME OFF になる
* IME ON → `Muhenkan` → `Henkan` で IME ON に戻る
* IME ON → `Space` でスペース入力される
* 入力中 → `Space` で通常変換される

メモ帳 + Mozkey で確認:

* IME OFF + 選択文字列 → `Henkan` で再変換される
* IME ON + 選択文字列 → `Space` で再変換される
* IME ON + 選択なし → `Space` でスペース入力される
* IME ON + 入力中 → `Space` で通常変換される

## 補足

この修正では keymap や preserved key は変更していません。
Zed でも `VK_CONVERT` / `VK_NONCONVERT` は Mozkey に届いていたため、キー配送ではなく、再変換用テキストを取得できない場合の fallback 処理を修正しています。
