### PR TITLE
Protect user dictionary surfaces in Zenz live correction

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,9 @@ Windows 用のビルド済み MSI は [Releases](https://github.com/koyasi777/mo
 - 複数文節に分かれるライブ変換では、全文補正の学習を保つため、accepted Zenz feedback を session-level live correction fast path として再利用
 - sensitive-like context で得られた feedback は、通常文脈の候補 ranking / reuse には使わない
 - accepted として確定した Zenz 候補は、条件を満たす場合は Mozc の user history にも外部変換結果として学習
+- 通常 Mozc ライブ変換で現在の結果として現れているユーザー辞書由来候補や ASCII / mixed-script 表記を、Zenz live correction の採用時に保護
+- ASCII / mixed-script 表記は、読みを安全に特定できる場合に Zenz prompt 内で一時 placeholder 化し、応答後に元の表記へ復元。`もずきー -> Mozkey` のような表記が `モズキー` へ上書きされるのを避けつつ、前後の文は補正できるようにした
+- 日本語のみのユーザー辞書語は、自然な読みを Zenz prompt に残したまま、Zenz 応答後に表記の境界を検証し、余分なかな付着を安全に修復できる場合だけ採用するようにした
 - Zenz prompt に使う左文脈は sanitizer を通し、URL、email、file path、token、長い数字列など sensitive-like な文脈は prompt に含めない
 - Zenz feedback には raw left context を保存せず、非可逆な context class のみを保存
 - Zenz model / llama.cpp runtime の third-party license notice を MSI に同梱
@@ -226,6 +229,12 @@ Zenz request は `mozc_server` から Windows named pipe 経由で `mozc_zenz_sc
 Zenz 補正は設定可能なデバウンス時間の後に実行されます。デフォルトは 1000 ms です。また、Zenz 補正を開始する最小文字数も設定画面から変更できます。Zenz 結果が返る前に入力内容が変わった場合、古い結果は generation / key の検査により破棄されます。
 
 Zenz 出力は表示前に検証されます。空出力、短すぎる入力、Mozc 結果と同一の出力、長すぎる出力、不正な文字列、安全でない可能性のある文字列は拒否されます。拒否された場合は、通常の Mozc ライブ変換結果をそのまま表示します。
+
+通常 Mozc ライブ変換で現在の結果として現れているユーザー辞書由来候補や ASCII / mixed-script 表記は、Zenz 採用時に保護されます。ASCII / mixed-script 表記は、読みを安全に特定できる場合に Zenz prompt 内で一時 placeholder 化し、Zenz 応答後に元の表記へ復元します。これにより、`もずきー -> Mozkey` のような表記が `モズキー` のように上書きされることを避けつつ、対象語の前後にある文の補正は採用できるようにしています。
+
+日本語のみのユーザー辞書語は、自然な読みを Zenz prompt に残したまま、Zenz 応答後に表記の境界を検証します。たとえば保護対象の直後に余分なかなが付着した場合は、安全に修復できる場合だけ採用し、修復できない場合は通常の Mozc ライブ変換結果に戻します。
+
+Zenz が保護対象の表記を落としたり変更したりし、placeholder 復元や安全な repair でも必要な出現数を満たせない場合、その Zenz 結果は採用せず、通常の Mozc ライブ変換結果を表示します。保護対象はユーザー辞書に登録されている全候補ではなく、現在の通常ライブ変換結果に実際に現れた表記です。
 
 Zenz ライブ補正は password field では実行されません。また、入力途中の raw romaji のように日本語文字シグナルを含まない読みは補正対象外です。日本語文字を含む英字混じりの入力は、privacy gate を通る場合に限り補正対象になり得ます。
 
@@ -619,6 +628,9 @@ Main features added in this fork
 - Reuses accepted Zenz feedback via the session-level live-correction fast path for multi-segment live conversion to preserve learned full-phrase corrections
 - Does not reuse feedback obtained from `sensitive_like` context for ordinary-context candidate ranking
 - Learns accepted Zenz candidates into Mozc user history as external conversion results when the runtime conditions allow it
+- Protects user-dictionary candidates and ASCII / mixed-script surfaces that appear in the current normal Mozc live-conversion result before adopting Zenz live-correction output
+- For ASCII / mixed-script surfaces, temporarily replaces the reading with a placeholder in the Zenz prompt when it can be identified safely, then restores the selected surface after the response, so entries such as `もずきー -> Mozkey` are not silently overwritten as `モズキー` while surrounding text can still be corrected
+- For Japanese-only user-dictionary surfaces, keeps the natural reading in the Zenz prompt and validates the selected surface boundaries after the response, accepting the result only when any extra kana attachment can be repaired safely
 - Sanitizes left context before using it in Zenz prompts, and excludes sensitive-like context such as URLs, email addresses, file paths, tokens, and long digit sequences
 - Stores only non-reversible context classes in Zenz feedback and never stores raw left context
 - Bundles third-party license notices for the Zenz model and llama.cpp runtime in the MSI
@@ -698,6 +710,28 @@ Zenz output is validated before display. Outputs that are empty, too short,
 identical to the Mozc result, too long, malformed, or likely to contain unsafe
 text are rejected. If validation fails, the normal Mozc live conversion result
 remains visible.
+
+User-dictionary candidates and ASCII / mixed-script surfaces that appear in the
+current normal Mozc live-conversion result are protected before Zenz output is
+adopted. For ASCII / mixed-script surfaces, when the protected reading can be
+identified safely, such as in `もずきー -> Mozkey`, the reading is temporarily
+replaced with a placeholder in the Zenz prompt and restored to the selected
+surface after the response. This prevents Zenz from silently overwriting the
+protected word as `モズキー` while still allowing correction of the surrounding
+sentence.
+
+Japanese-only user-dictionary surfaces keep their natural reading in the Zenz
+prompt. After the Zenz response, Mozkey validates the selected surface
+boundaries. If extra kana is attached immediately after the protected surface,
+the result is accepted only when the attachment can be repaired safely; otherwise
+the normal Mozc live-conversion result remains visible.
+
+If a Zenz response drops or changes a protected surface and placeholder
+restoration or safe repair cannot preserve the required number of occurrences,
+the response is rejected and the normal Mozc live conversion result remains
+visible. This does not pin every candidate that merely exists in the user
+dictionary. Protection is based on surfaces that actually appear in the current
+normal live-conversion result.
 
 Zenz live correction is disabled for password fields and for composition text
 that has no Japanese-script signal, such as intermediate raw romaji input.

--- a/src/converter/converter.cc
+++ b/src/converter/converter.cc
@@ -60,6 +60,7 @@
 #include "converter/inner_segment.h"
 #include "converter/reverse_converter.h"
 #include "converter/segments.h"
+#include "dictionary/dictionary_interface.h"
 #include "dictionary/pos_matcher.h"
 #include "engine/modules.h"
 #include "prediction/predictor_interface.h"
@@ -421,6 +422,35 @@ bool Converter::LearnExternalConversionResult(
 
   FinishConversion(request, &learning_segments);
   return true;
+}
+
+void Converter::LookupUserDictionaryPrefixEntries(
+    absl::string_view key,
+    std::vector<UserDictionaryLookupResult>* results) const {
+  if (results == nullptr) {
+    return;
+  }
+  results->clear();
+  if (key.empty()) {
+    return;
+  }
+
+  using Callback = dictionary::DictionaryInterface::Callback;
+  dictionary::InlineCallback callback;
+  callback.OnToken([results](absl::string_view, absl::string_view,
+                             const dictionary::Token& token) {
+    if (token.key.empty() || token.value.empty()) {
+      return Callback::TRAVERSE_CONTINUE;
+    }
+
+    UserDictionaryLookupResult result;
+    result.key = std::string(token.key);
+    result.value = std::string(token.value);
+    results->push_back(std::move(result));
+    return Callback::TRAVERSE_CONTINUE;
+  });
+
+  user_dictionary_.LookupPrefix(key, &callback);
 }
 
 void Converter::CancelConversion(Segments* segments) const {

--- a/src/converter/converter.h
+++ b/src/converter/converter.h
@@ -195,6 +195,10 @@ class Converter final : public ConverterInterface {
   // Utility method to make history result passed to ConversionRequest.
   static prediction::Result MakeHistoryResult(const Segments& segments);
 
+  void LookupUserDictionaryPrefixEntries(
+      absl::string_view key,
+      std::vector<UserDictionaryLookupResult>* results) const override;
+
  private:
   friend class ConverterTestPeer;
 

--- a/src/converter/converter_interface.h
+++ b/src/converter/converter_interface.h
@@ -32,6 +32,8 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <string>
+#include <vector>
 
 #include "absl/strings/string_view.h"
 #include "absl/types/span.h"
@@ -43,6 +45,11 @@ namespace mozc {
 namespace composer {
 class Composer;
 }  // namespace composer
+
+struct UserDictionaryLookupResult {
+  std::string key;
+  std::string value;
+};
 
 class ConverterInterface {
  public:
@@ -95,6 +102,17 @@ class ConverterInterface {
       absl::string_view key,
       absl::string_view value) const {
     return false;
+  }
+
+  // Looks up user-dictionary entries whose key is a prefix of |key|.
+  // This narrow read-only API lets session code use the existing user
+  // dictionary index instead of loading UserDictionaryStorage directly.
+  virtual void LookupUserDictionaryPrefixEntries(
+      absl::string_view key,
+      std::vector<UserDictionaryLookupResult>* results) const {
+    if (results != nullptr) {
+      results->clear();
+    }
   }
 
   // Clear segments and keep the context

--- a/src/converter/converter_test.cc
+++ b/src/converter/converter_test.cc
@@ -1445,6 +1445,48 @@ TEST_F(ConverterTest, LimitCandidatesSize) {
             original_meta_candidates_size);
 }
 
+TEST_F(ConverterTest,
+       LookupUserDictionaryPrefixEntriesUsesExistingUserDictionaryIndex) {
+  using user_dictionary::UserDictionary;
+
+  std::vector<UserDefinedEntry> user_defined_entries;
+  user_defined_entries.push_back(
+      UserDefinedEntry("じしょご", "辞書語", UserDictionary::NOUN));
+  user_defined_entries.push_back(
+      UserDefinedEntry("もずきー", "Mozkey", UserDictionary::NOUN));
+
+  std::unique_ptr<Converter> converter = CreateConverterWithUserDefinedEntries(
+      user_defined_entries, STUB_PREDICTOR);
+
+  auto has_entry = [](const std::vector<UserDictionaryLookupResult>& results,
+                      absl::string_view key,
+                      absl::string_view value) {
+    for (const UserDictionaryLookupResult& result : results) {
+      if (result.key == key && result.value == value) {
+        return true;
+      }
+    }
+    return false;
+  };
+
+  std::vector<UserDictionaryLookupResult> results;
+  converter->LookupUserDictionaryPrefixEntries(
+      "じしょごのてんてきです", &results);
+  EXPECT_TRUE(has_entry(results, "じしょご", "辞書語"));
+
+  results.clear();
+  converter->LookupUserDictionaryPrefixEntries(
+      "もずきーをつかっています", &results);
+  EXPECT_TRUE(has_entry(results, "もずきー", "Mozkey"));
+
+  UserDictionaryLookupResult stale_result;
+  stale_result.key = "stale";
+  stale_result.value = "stale";
+  results.push_back(stale_result);
+  converter->LookupUserDictionaryPrefixEntries("", &results);
+  EXPECT_TRUE(results.empty());
+}
+
 TEST_F(ConverterTest, UserEntryShouldBePromoted) {
   using user_dictionary::UserDictionary;
   std::vector<UserDefinedEntry> user_defined_entries;

--- a/src/engine/BUILD.bazel
+++ b/src/engine/BUILD.bazel
@@ -396,6 +396,7 @@ mozc_cc_library(
     visibility = ["//session:__pkg__"],
     deps = [
         "//composer",
+        "//converter:converter_interface",
         "//protocol:commands_cc_proto",
         "//protocol:config_cc_proto",
         "//transliteration",

--- a/src/engine/engine_converter.cc
+++ b/src/engine/engine_converter.cc
@@ -841,6 +841,19 @@ bool EngineConverter::LearnExternalConversionResult(
       conversion_request, key, value);
 }
 
+void EngineConverter::LookupUserDictionaryPrefixEntries(
+    absl::string_view key,
+    std::vector<UserDictionaryLookupResult>* results) const {
+  if (results == nullptr) {
+    return;
+  }
+  results->clear();
+  if (!converter_) {
+    return;
+  }
+  converter_->LookupUserDictionaryPrefixEntries(key, results);
+}
+
 bool EngineConverter::CommitSuggestionInternal(
     const composer::Composer& composer, const commands::Context& context,
     size_t* consumed_key_size) {

--- a/src/engine/engine_converter.h
+++ b/src/engine/engine_converter.h
@@ -281,6 +281,10 @@ class EngineConverter : public EngineConverterInterface {
   static constexpr size_t kConsumedAllCharacters =
       std::numeric_limits<size_t>::max();
 
+  void LookupUserDictionaryPrefixEntries(
+      absl::string_view key,
+      std::vector<UserDictionaryLookupResult>* results) const override;
+
  private:
   // Uses default copy operator to simply copy all members.
   EngineConverter& operator=(const EngineConverter&) = default;

--- a/src/engine/engine_converter_interface.h
+++ b/src/engine/engine_converter_interface.h
@@ -40,6 +40,7 @@
 
 #include "absl/strings/string_view.h"
 #include "composer/composer.h"
+#include "converter/converter_interface.h"
 #include "protocol/commands.pb.h"
 #include "protocol/config.pb.h"
 #include "transliteration/transliteration.h"
@@ -290,6 +291,15 @@ class EngineConverterInterface {
       config::Config::SelectionShortcut selection_shortcut) = 0;
 
   virtual void set_use_cascading_window(bool use_cascading_window) = 0;
+
+  // Looks up user-dictionary entries whose key is a prefix of |key|.
+  virtual void LookupUserDictionaryPrefixEntries(
+      absl::string_view key,
+      std::vector<UserDictionaryLookupResult>* results) const {
+    if (results != nullptr) {
+      results->clear();
+    }
+  }
 };
 
 }  // namespace engine

--- a/src/session/BUILD.bazel
+++ b/src/session/BUILD.bazel
@@ -69,6 +69,15 @@ mozc_cc_test(
 )
 
 mozc_cc_library(
+    name = "zenz_adoption_policy",
+    srcs = ["zenz_adoption_policy.cc"],
+    hdrs = ["zenz_adoption_policy.h"],
+    deps = [
+        "@com_google_absl//absl/strings",
+    ],
+)
+
+mozc_cc_library(
     name = "session",
     srcs = [
         "session.cc",
@@ -93,12 +102,14 @@ mozc_cc_library(
         ":ime_context",
         ":key_event_transformer",
         ":keymap",
+        ":zenz_adoption_policy",
         ":zenz_feedback_store",
         "//base:clock",
         "//base:util",
         "//composer",
         "//composer:key_event_util",
         "//composer:table",
+        "//converter:converter_interface",
         "//engine:engine_converter_interface",
         "//engine:engine_interface",
         "//protocol:commands_cc_proto",
@@ -108,6 +119,16 @@ mozc_cc_library(
         "@com_google_absl//absl/log:check",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/time",
+    ],
+)
+
+mozc_cc_test(
+    name = "zenz_adoption_policy_test",
+    size = "small",
+    srcs = ["zenz_adoption_policy_test.cc"],
+    deps = [
+        ":zenz_adoption_policy",
+        "//testing:gunit_main",
     ],
 )
 

--- a/src/session/session.cc
+++ b/src/session/session.cc
@@ -43,6 +43,7 @@
 
 #include "absl/log/check.h"
 #include "absl/log/log.h"
+#include "absl/strings/match.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/string_view.h"
 #include "absl/time/time.h"
@@ -1392,6 +1393,386 @@ bool ShouldSkipLiveConversionForCompositionKey(
   }
 
   return Util::IsScriptType(core, Util::HIRAGANA);
+}
+
+
+bool CandidateWordHasAttribute(const commands::CandidateWord& candidate,
+                               commands::CandidateAttribute attribute) {
+  for (int i = 0; i < candidate.attributes_size(); ++i) {
+    if (candidate.attributes(i) == attribute) {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool IsAsciiIdentityChar(const unsigned char c) {
+  return (('0' <= c) && (c <= '9')) || (('A' <= c) && (c <= 'Z')) ||
+         (('a' <= c) && (c <= 'z')) || c == '_' || c == '-' || c == '.' ||
+         c == '+' || c == '#';
+}
+
+bool HasAsciiLetterOrDigit(absl::string_view value) {
+  for (const unsigned char c : value) {
+    if ((('0' <= c) && (c <= '9')) || (('A' <= c) && (c <= 'Z')) ||
+        (('a' <= c) && (c <= 'z'))) {
+      return true;
+    }
+  }
+  return false;
+}
+
+std::vector<std::string> ExtractAsciiIdentitySurfaces(
+    absl::string_view value) {
+  std::vector<std::string> surfaces;
+  size_t start = absl::string_view::npos;
+
+  auto flush = [&](size_t end) {
+    if (start == absl::string_view::npos || end <= start) {
+      start = absl::string_view::npos;
+      return;
+    }
+    const absl::string_view surface = value.substr(start, end - start);
+    if (HasAsciiLetterOrDigit(surface)) {
+      surfaces.emplace_back(surface);
+    }
+    start = absl::string_view::npos;
+  };
+
+  for (size_t i = 0; i < value.size(); ++i) {
+    const unsigned char c = static_cast<unsigned char>(value[i]);
+    if (IsAsciiIdentityChar(c)) {
+      if (start == absl::string_view::npos) {
+        start = i;
+      }
+    } else {
+      flush(i);
+    }
+  }
+  flush(value.size());
+
+  return surfaces;
+}
+
+std::string FindPreeditKeyForValue(const commands::Preedit& preedit,
+                                   absl::string_view value) {
+  for (int i = 0; i < preedit.segment_size(); ++i) {
+    const commands::Preedit::Segment& segment = preedit.segment(i);
+    if (segment.value() == value) {
+      return segment.key();
+    }
+  }
+  return std::string();
+}
+
+ProtectedConversionSpan* FindProtectedSurface(
+    std::vector<ProtectedConversionSpan>* protected_spans,
+    absl::string_view value) {
+  if (protected_spans == nullptr) {
+    return nullptr;
+  }
+  for (ProtectedConversionSpan& span : *protected_spans) {
+    if (span.value == value) {
+      return &span;
+    }
+  }
+  return nullptr;
+}
+
+size_t CountSurfaceOccurrences(absl::string_view value,
+                               absl::string_view surface) {
+  if (surface.empty()) {
+    return 0;
+  }
+
+  size_t count = 0;
+  size_t pos = 0;
+  while ((pos = value.find(surface, pos)) != absl::string_view::npos) {
+    ++count;
+    pos += surface.size();
+  }
+  return count;
+}
+
+
+std::string InferProtectedKeyForEmbeddedSurface(absl::string_view segment_key,
+                                                absl::string_view segment_value,
+                                                absl::string_view surface) {
+  if (segment_key.empty() || segment_value.empty() || surface.empty()) {
+    return std::string();
+  }
+
+  if (segment_value == surface) {
+    return std::string(segment_key);
+  }
+
+  // Keep this inference deliberately narrow.  It is safe to infer the protected
+  // reading when the protected surface starts the segment and the remaining
+  // value suffix appears literally at the end of the segment key, e.g.
+  //   key:   もずきーを
+  //   value: Mozkeyを
+  //   span:  もずきー -> Mozkey
+  // For converted suffixes such as "Mozkeyを使用しています" vs
+  // "もずきーをしようしています", this returns empty and leaves the span
+  // reject-only instead of guessing a boundary.
+  if (!absl::StartsWith(segment_value, surface)) {
+    return std::string();
+  }
+
+  const absl::string_view suffix = segment_value.substr(surface.size());
+  if (suffix.empty() || suffix.size() >= segment_key.size()) {
+    return std::string();
+  }
+  if (!absl::EndsWith(segment_key, suffix)) {
+    return std::string();
+  }
+
+  return std::string(segment_key.substr(0, segment_key.size() - suffix.size()));
+}
+
+std::string FindPreeditKeyForProtectedSurface(
+    const commands::Preedit& preedit, absl::string_view surface,
+    absl::string_view candidate_key) {
+  if (surface.empty()) {
+    return std::string();
+  }
+
+  for (int i = 0; i < preedit.segment_size(); ++i) {
+    const commands::Preedit::Segment& segment = preedit.segment(i);
+    if (segment.value().empty()) {
+      continue;
+    }
+
+    const std::string segment_key =
+        segment.has_key() ? segment.key() : std::string();
+    const std::string protected_key = InferProtectedKeyForEmbeddedSurface(
+        segment_key, segment.value(), surface);
+    if (!protected_key.empty()) {
+      return protected_key;
+    }
+
+    // Some live-conversion preedit segments can be larger than the protected
+    // word, e.g. "じしょごのてんてきです" -> "辞書語の点滴です".
+    // In that case the visible suffix is converted, so literal suffix matching
+    // cannot infer the boundary.  If the user-dictionary key and value both
+    // start the same preedit segment, use the candidate key as the protected
+    // reading.
+    if (!candidate_key.empty() && absl::StartsWith(segment.value(), surface) &&
+        absl::StartsWith(segment_key, candidate_key)) {
+      return std::string(candidate_key);
+    }
+  }
+  return std::string();
+}
+
+void AddOrUpdateProtectedSpan(
+    absl::string_view key, absl::string_view value,
+    ProtectedConversionSpan::Tier tier, bool repairable,
+    absl::string_view mozc_value,
+    std::vector<ProtectedConversionSpan>* protected_spans) {
+  if (protected_spans == nullptr || value.empty() ||
+      !absl::StrContains(mozc_value, value)) {
+    return;
+  }
+
+  size_t required_occurrences = CountSurfaceOccurrences(mozc_value, value);
+  if (required_occurrences == 0) {
+    required_occurrences = 1;
+  }
+
+  if (ProtectedConversionSpan* existing =
+          FindProtectedSurface(protected_spans, value)) {
+    if (existing->required_occurrences < required_occurrences) {
+      existing->required_occurrences = required_occurrences;
+    }
+    if (existing->key.empty() && !key.empty()) {
+      existing->key = std::string(key);
+    }
+    if (tier == ProtectedConversionSpan::Tier::kIdentityCritical) {
+      existing->tier = tier;
+    }
+    if (!existing->repairable && repairable && !key.empty()) {
+      existing->repairable = true;
+    }
+    return;
+  }
+
+  ProtectedConversionSpan span;
+  span.key = !key.empty() ? std::string(key) : std::string();
+  span.value = std::string(value);
+  span.tier = tier;
+  span.repairable = repairable && !span.key.empty();
+  span.required_occurrences = required_occurrences;
+  protected_spans->push_back(std::move(span));
+}
+
+void AddPreeditIdentityProtectedSpans(
+    const commands::Preedit& preedit, absl::string_view mozc_value,
+    std::vector<ProtectedConversionSpan>* protected_spans) {
+  for (int i = 0; i < preedit.segment_size(); ++i) {
+    const commands::Preedit::Segment& segment = preedit.segment(i);
+    if (segment.value().empty()) {
+      continue;
+    }
+
+    const std::string segment_key =
+        segment.has_key() ? segment.key() : std::string();
+    const std::vector<std::string> identity_surfaces =
+        ExtractAsciiIdentitySurfaces(segment.value());
+    for (const std::string& surface : identity_surfaces) {
+      const std::string surface_key = InferProtectedKeyForEmbeddedSurface(
+          segment_key, segment.value(), surface);
+      AddOrUpdateProtectedSpan(
+          surface_key, surface, ProtectedConversionSpan::Tier::kIdentityCritical,
+          !surface_key.empty(), mozc_value, protected_spans);
+    }
+  }
+}
+
+
+bool IsSafeDirectUserDictionaryProtectedEntry(absl::string_view key,
+                                              absl::string_view value) {
+  if (key.empty() || value.empty()) {
+    return false;
+  }
+
+  // Very short entries are too ambiguous for direct global matching. They can
+  // still be protected through candidate provenance when the converter exposes
+  // the selected user-dictionary candidate.
+  if (Util::CharsLen(key) < 2 || Util::CharsLen(value) < 2) {
+    return false;
+  }
+
+  return true;
+}
+
+std::vector<absl::string_view> GetUtf8SuffixesForUserDictionaryLookup(
+    absl::string_view key) {
+  std::vector<absl::string_view> suffixes;
+  if (key.empty()) {
+    return suffixes;
+  }
+
+  suffixes.reserve(Util::CharsLen(key));
+  for (size_t i = 0; i < key.size(); ++i) {
+    const unsigned char c = static_cast<unsigned char>(key[i]);
+    if (i != 0 && (c & 0xC0) == 0x80) {
+      continue;
+    }
+    suffixes.push_back(key.substr(i));
+  }
+  return suffixes;
+}
+
+void AddDirectUserDictionaryEntryProtectedSpans(
+    const engine::EngineConverterInterface& converter,
+    absl::string_view live_key, absl::string_view mozc_value,
+    std::vector<ProtectedConversionSpan>* protected_spans) {
+  if (protected_spans == nullptr || live_key.empty() || mozc_value.empty()) {
+    return;
+  }
+
+  for (const absl::string_view suffix :
+       GetUtf8SuffixesForUserDictionaryLookup(live_key)) {
+    std::vector<UserDictionaryLookupResult> entries;
+    converter.LookupUserDictionaryPrefixEntries(suffix, &entries);
+    for (const UserDictionaryLookupResult& entry : entries) {
+      const absl::string_view entry_key(entry.key);
+      const absl::string_view entry_value(entry.value);
+      if (!IsSafeDirectUserDictionaryProtectedEntry(entry_key, entry_value)) {
+        continue;
+      }
+      if (!absl::StartsWith(suffix, entry_key) ||
+          !absl::StrContains(mozc_value, entry_value)) {
+        continue;
+      }
+
+      AddOrUpdateProtectedSpan(
+          entry_key, entry_value, ProtectedConversionSpan::Tier::kUserPreferred,
+          false, mozc_value, protected_spans);
+    }
+  }
+}
+
+std::vector<ProtectedConversionSpan> BuildZenzProtectedConversionSpans(
+    const engine::EngineConverterInterface& converter,
+    const commands::Output& output, absl::string_view live_key,
+    absl::string_view mozc_value) {
+  std::vector<ProtectedConversionSpan> protected_spans;
+
+  if (output.has_all_candidate_words()) {
+    const commands::CandidateList& candidate_list = output.all_candidate_words();
+    const uint32_t focused_index = candidate_list.has_focused_index()
+                                     ? candidate_list.focused_index()
+                                     : 0;
+
+    for (int i = 0; i < candidate_list.candidates_size(); ++i) {
+      const commands::CandidateWord& candidate = candidate_list.candidates(i);
+      const bool focused_candidate = candidate.index() == focused_index;
+
+      if (!CandidateWordHasAttribute(candidate, commands::USER_DICTIONARY)) {
+        continue;
+      }
+
+      if (candidate.value().empty()) {
+        continue;
+      }
+
+      std::string candidate_key =
+          candidate.has_key() ? candidate.key() : std::string();
+      if (candidate_key.empty() && output.has_preedit()) {
+        candidate_key =
+            FindPreeditKeyForValue(output.preedit(), candidate.value());
+      }
+
+      std::string preedit_protected_key;
+      if (output.has_preedit()) {
+        preedit_protected_key = FindPreeditKeyForProtectedSurface(
+            output.preedit(), candidate.value(), candidate_key);
+      }
+
+      // For non-focused candidates, protect only when the same surface is
+      // actually visible in the current preedit.  This recovers embedded
+      // user-dictionary words such as "じしょごの" -> "辞書語の" without pinning
+      // unrelated user-dictionary candidates that merely exist in the candidate
+      // list.
+      if (!focused_candidate && preedit_protected_key.empty()) {
+        continue;
+      }
+
+      const std::string protected_key = !preedit_protected_key.empty()
+                                            ? preedit_protected_key
+                                            : candidate_key;
+
+      const std::vector<std::string> identity_surfaces =
+          ExtractAsciiIdentitySurfaces(candidate.value());
+      if (!identity_surfaces.empty()) {
+        for (const std::string& surface : identity_surfaces) {
+          const std::string surface_key = InferProtectedKeyForEmbeddedSurface(
+              protected_key, candidate.value(), surface);
+          AddOrUpdateProtectedSpan(
+              surface_key, surface, ProtectedConversionSpan::Tier::kIdentityCritical,
+              !surface_key.empty(), mozc_value, &protected_spans);
+        }
+        continue;
+      }
+
+      AddOrUpdateProtectedSpan(
+          protected_key, candidate.value(),
+          ProtectedConversionSpan::Tier::kUserPreferred, false, mozc_value,
+          &protected_spans);
+    }
+  }
+
+  if (output.has_preedit()) {
+    AddPreeditIdentityProtectedSpans(output.preedit(), mozc_value,
+                                     &protected_spans);
+  }
+
+  AddDirectUserDictionaryEntryProtectedSpans(converter, live_key, mozc_value,
+                                             &protected_spans);
+
+  return protected_spans;
 }
 
 uint32_t GetLiveConversionDelayMillisec(const config::Config& config) {
@@ -4095,6 +4476,7 @@ void Session::ClearLiveConversionState() {
   live_conversion_preedit_.clear();
   live_conversion_value_.clear();
   live_conversion_preedit_output_.Clear();
+  live_conversion_protected_spans_.clear();
   ClearZenzLiveCorrectionState();
 }
 
@@ -4205,6 +4587,13 @@ bool Session::MaybeStartLiveConversion(commands::Command* command) {
   } else {
     live_conversion_preedit_output_.Clear();
     live_conversion_value_ = context_->composer().GetStringForSubmission();
+  }
+
+  live_conversion_protected_spans_.clear();
+  if (context_->GetConfig().use_zenz_live_correction()) {
+    live_conversion_protected_spans_ = BuildZenzProtectedConversionSpans(
+        context_->converter(), command->output(), live_conversion_key_,
+        live_conversion_value_);
   }
 
   ClearZenzLiveCorrectionState();
@@ -5153,6 +5542,28 @@ bool Session::MaybeApplyZenzFeedbackLiveCorrection(
       continue;
     }
 
+    ZenzAdoptionInput adoption_input;
+    adoption_input.key = live_conversion_key_;
+    adoption_input.mozc_value = live_conversion_value_;
+    adoption_input.zenz_value = feedback_value;
+    adoption_input.protected_spans = live_conversion_protected_spans_;
+
+    const ZenzAdoptionResult adoption =
+        zenz_adoption_policy_.Decide(adoption_input);
+    if (adoption.action == ZenzAdoptionResult::Action::kReject) {
+      ZenzDebugOutput(absl::StrCat(
+          "[zenz-feedback] fast path candidate rejected reason=",
+          adoption.reason,
+          " ", ZenzRedactedTextStats("key", live_conversion_key_),
+          " ", ZenzRedactedTextStats("value", feedback_value),
+          " context_class=", context_class,
+          " accepted_count=", feedback_candidate.accepted_count,
+          " rejected_count=", feedback_candidate.rejected_count));
+      continue;
+    }
+
+    const std::string adopted_feedback_value = adoption.value;
+
     ++zenz_live_generation_;
     pending_zenz_live_ = PendingZenzLiveCorrection();
 
@@ -5161,7 +5572,7 @@ bool Session::MaybeApplyZenzFeedbackLiveCorrection(
     zenz_live_display_key_ = live_conversion_preedit_.empty()
                                  ? live_conversion_key_
                                  : live_conversion_preedit_;
-    zenz_live_value_ = feedback_value;
+    zenz_live_value_ = adopted_feedback_value;
     zenz_live_mozc_value_ = live_conversion_value_;
     zenz_live_context_class_ = context_class;
     zenz_live_left_context_ = left_context_for_validation;
@@ -5171,11 +5582,12 @@ bool Session::MaybeApplyZenzFeedbackLiveCorrection(
         ZenzRedactedTextStats("key", zenz_live_key_),
         " ", ZenzRedactedTextStats("value", zenz_live_value_),
         " ", ZenzRedactedTextStats("mozc_value", zenz_live_mozc_value_),
+        " adoption=", adoption.reason,
         " context_class=", zenz_live_context_class_,
         " accepted_count=", feedback_candidate.accepted_count,
         " rejected_count=", feedback_candidate.rejected_count));
 
-    return OutputZenzLiveCorrection(feedback_value, command);
+    return OutputZenzLiveCorrection(adopted_feedback_value, command);
   }
 
   return false;
@@ -5270,9 +5682,15 @@ bool Session::MaybeScheduleZenzLiveCorrection(commands::Command* command) {
   prompt_options.style = config.zenz_live_correction_style();
   prompt_options.settings = config.zenz_live_correction_settings();
 
+  ZenzProtectedPromptInput protected_prompt_input;
+  protected_prompt_input.key = live_conversion_key_;
+  protected_prompt_input.protected_spans = live_conversion_protected_spans_;
+  const ZenzProtectedPromptResult protected_prompt =
+      zenz_adoption_policy_.ProtectPromptKey(protected_prompt_input);
+
   ZenzPromptBuilder prompt_builder;
   const std::string prompt =
-      prompt_builder.Build(live_conversion_key_, prompt_options);
+      prompt_builder.Build(protected_prompt.key, prompt_options);
 
   ++zenz_live_generation_;
 
@@ -5286,6 +5704,7 @@ bool Session::MaybeScheduleZenzLiveCorrection(commands::Command* command) {
       live_conversion_preedit_.empty() ? live_conversion_key_
                                        : live_conversion_preedit_;
   pending_zenz_live_.prompt = prompt;
+  pending_zenz_live_.protected_spans = protected_prompt.protected_spans;
   pending_zenz_live_.issued_at = Clock::GetAbslTime();
   pending_zenz_live_.pending = true;
   pending_zenz_live_.submitted = false;
@@ -5300,7 +5719,9 @@ bool Session::MaybeScheduleZenzLiveCorrection(commands::Command* command) {
       " context_reason=", context_result.reason,
       " right_context_allowed=",
       ZenzBool(right_context_result.allowed_for_prompt),
-      " right_context_reason=", right_context_result.reason));
+      " right_context_reason=", right_context_result.reason,
+      " protected_prompt_replacements=",
+      protected_prompt.placeholder_count));
 
   const uint32_t delay_msec = GetZenzLiveCorrectionDelayMsec(config);
   if (delay_msec == 0) {
@@ -5735,6 +6156,18 @@ bool Session::ApplyZenzLiveCorrectionResult(
         " context_class=", pending_zenz_live_.context_class));
   }
 
+  const std::string zenz_value_before_placeholder_restore = zenz_value;
+  zenz_value = zenz_adoption_policy_.RestorePlaceholders(
+      zenz_value, pending_zenz_live_.protected_spans);
+  if (zenz_value != zenz_value_before_placeholder_restore) {
+    ZenzDebugOutput(absl::StrCat(
+        "[zenz] restored protected placeholders ",
+        ZenzRedactedTextStats("value", zenz_value),
+        " ", ZenzRedactedTextStats(
+                 "raw_value", zenz_value_before_placeholder_restore),
+        " context_class=", pending_zenz_live_.context_class));
+  }
+
   const absl::string_view zenz_symbol_style_source =
       pending_zenz_live_.symbol_style_source.empty()
           ? pending_zenz_live_.key
@@ -5867,6 +6300,62 @@ bool Session::ApplyZenzLiveCorrectionResult(
     return true;
   }
 
+  ZenzAdoptionInput adoption_input;
+  adoption_input.key = pending_zenz_live_.key;
+  adoption_input.mozc_value = pending_zenz_live_.mozc_value;
+  adoption_input.zenz_value = zenz_value;
+  adoption_input.protected_spans = pending_zenz_live_.protected_spans;
+
+  const ZenzAdoptionResult adoption =
+      zenz_adoption_policy_.Decide(adoption_input);
+  if (adoption.action == ZenzAdoptionResult::Action::kReject) {
+    ZenzDebugOutput(absl::StrCat(
+        "[zenz] adoption rejected reason=", adoption.reason,
+        " ", ZenzRedactedTextStats("value", zenz_value),
+        " ", ZenzRedactedTextStats("mozc_value",
+                                    pending_zenz_live_.mozc_value),
+        " context_class=", context_class));
+
+    CancelPendingZenzLiveCorrection();
+    Output(command);
+
+    if (command->output().has_preedit()) {
+      RestorePreeditSegmentKeysForSymbolStyle(
+          live_conversion_preedit_.empty()
+              ? live_conversion_key_
+              : live_conversion_preedit_,
+          command->mutable_output()->mutable_preedit());
+    }
+
+    command->mutable_output()->set_live_conversion(true);
+    command->mutable_output()->set_live_conversion_pending(false);
+    command->mutable_output()->set_zenz_live_correction_pending(false);
+    command->mutable_output()->set_zenz_live_correction_debug(adoption.reason);
+    return true;
+  }
+
+  zenz_value = adoption.value;
+
+  const ZenzTextPrivacyDecision adopted_value_privacy =
+      EvaluateZenzLiveValuePrivacy(zenz_value);
+  if (!adopted_value_privacy.allow) {
+    ZenzDebugOutput(absl::StrCat(
+        "[zenz] adoption rejected reason=adopted_value_privacy_",
+        adopted_value_privacy.reason,
+        " ", ZenzRedactedTextStats("value", zenz_value),
+        " context_class=", context_class));
+
+    CancelPendingZenzLiveCorrection();
+    Output(command);
+    command->mutable_output()->set_live_conversion(true);
+    command->mutable_output()->set_live_conversion_pending(false);
+    command->mutable_output()->set_zenz_live_correction_pending(false);
+    command->mutable_output()->set_zenz_live_correction_debug(
+        absl::StrCat("adopted_value_privacy_",
+                     adopted_value_privacy.reason));
+    return true;
+  }
+
   std::string feedback_reason = "feedback_learning_disabled";
 
   if (UseZenzFeedbackLearning(config)) {
@@ -5901,6 +6390,7 @@ bool Session::ApplyZenzLiveCorrectionResult(
       " ", ZenzRedactedTextStats("old_mozc_value",
                                   pending_zenz_live_.mozc_value),
       " context_class=", context_class,
+      " adoption=", adoption.reason,
       " feedback=", feedback_reason));
 
   zenz_live_visible_generation_ = pending_zenz_live_.generation;

--- a/src/session/session.h
+++ b/src/session/session.h
@@ -49,6 +49,7 @@
 #include "protocol/config.pb.h"
 #include "session/ime_context.h"
 #include "session/keymap.h"
+#include "session/zenz_adoption_policy.h"
 #include "session/zenz_context_sanitizer.h"
 #include "session/zenz_feedback_store.h"
 #include "session/zenz_live_corrector.h"
@@ -336,6 +337,11 @@ class Session {
   // to avoid display-attribute flicker.
   commands::Preedit live_conversion_preedit_output_;
 
+  // User-dictionary surfaces selected by the latest normal live conversion.
+  // Zenz live correction may improve the surrounding sentence, but these
+  // surfaces must be preserved or safely repaired before adoption.
+  std::vector<ProtectedConversionSpan> live_conversion_protected_spans_;
+
   // Set only after an explicit conversion Cancel command, such as Esc or Ctrl+Z
   // in the default keymap.  If the user commits the unchanged hiragana preedit
   // immediately after that cancel, the raw preedit should be learned like an
@@ -354,6 +360,7 @@ class Session {
     std::string mozc_value;
     std::string symbol_style_source;
     std::string prompt;
+    std::vector<ProtectedConversionSpan> protected_spans;
     absl::Time issued_at;
     bool pending = false;
     bool submitted = false;
@@ -406,6 +413,7 @@ class Session {
 
   ZenzContextSanitizer zenz_context_sanitizer_;
   ZenzOutputValidator zenz_output_validator_;
+  ZenzAdoptionPolicy zenz_adoption_policy_;
   ZenzFeedbackStore zenz_feedback_store_;
   std::unique_ptr<ZenzLiveCorrector> zenz_live_corrector_;
 

--- a/src/session/zenz_adoption_policy.cc
+++ b/src/session/zenz_adoption_policy.cc
@@ -1,0 +1,595 @@
+// Copyright 2010-2021, Google Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "session/zenz_adoption_policy.h"
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "absl/strings/match.h"
+#include "absl/strings/str_replace.h"
+
+namespace mozc::session {
+namespace {
+
+bool DecodeUtf8Char(absl::string_view s, size_t* index, char32_t* out) {
+  if (index == nullptr || out == nullptr || *index >= s.size()) {
+    return false;
+  }
+
+  const unsigned char c0 = static_cast<unsigned char>(s[*index]);
+  if (c0 < 0x80) {
+    *out = c0;
+    ++*index;
+    return true;
+  }
+
+  size_t length = 0;
+  char32_t code = 0;
+  if ((c0 & 0xE0) == 0xC0) {
+    length = 2;
+    code = c0 & 0x1F;
+  } else if ((c0 & 0xF0) == 0xE0) {
+    length = 3;
+    code = c0 & 0x0F;
+  } else if ((c0 & 0xF8) == 0xF0) {
+    length = 4;
+    code = c0 & 0x07;
+  } else {
+    return false;
+  }
+
+  if (*index + length > s.size()) {
+    return false;
+  }
+
+  for (size_t i = 1; i < length; ++i) {
+    const unsigned char cx = static_cast<unsigned char>(s[*index + i]);
+    if ((cx & 0xC0) != 0x80) {
+      return false;
+    }
+    code = (code << 6) | (cx & 0x3F);
+  }
+
+  *index += length;
+  *out = code;
+  return true;
+}
+
+void AppendUtf8Char(char32_t c, std::string* out) {
+  if (out == nullptr) {
+    return;
+  }
+
+  if (c <= 0x7F) {
+    out->push_back(static_cast<char>(c));
+  } else if (c <= 0x7FF) {
+    out->push_back(static_cast<char>(0xC0 | (c >> 6)));
+    out->push_back(static_cast<char>(0x80 | (c & 0x3F)));
+  } else if (c <= 0xFFFF) {
+    out->push_back(static_cast<char>(0xE0 | (c >> 12)));
+    out->push_back(static_cast<char>(0x80 | ((c >> 6) & 0x3F)));
+    out->push_back(static_cast<char>(0x80 | (c & 0x3F)));
+  } else {
+    out->push_back(static_cast<char>(0xF0 | (c >> 18)));
+    out->push_back(static_cast<char>(0x80 | ((c >> 12) & 0x3F)));
+    out->push_back(static_cast<char>(0x80 | ((c >> 6) & 0x3F)));
+    out->push_back(static_cast<char>(0x80 | (c & 0x3F)));
+  }
+}
+
+std::string HiraganaToKatakana(absl::string_view s) {
+  std::string result;
+  for (size_t i = 0; i < s.size();) {
+    const size_t old_index = i;
+    char32_t c = 0;
+    if (!DecodeUtf8Char(s, &i, &c)) {
+      result.append(s.substr(old_index, 1));
+      i = old_index + 1;
+      continue;
+    }
+
+    // Hiragana letters map to Katakana by adding 0x60.  Keep marks and the
+    // prolonged sound mark as-is when they are outside this contiguous range.
+    if (0x3041 <= c && c <= 0x3096) {
+      c += 0x60;
+    } else if (c == 0x309D) {
+      c = 0x30FD;
+    } else if (c == 0x309E) {
+      c = 0x30FE;
+    }
+    AppendUtf8Char(c, &result);
+  }
+  return result;
+}
+
+size_t CountOccurrences(absl::string_view haystack, absl::string_view needle) {
+  if (needle.empty()) {
+    return 0;
+  }
+
+  size_t count = 0;
+  size_t pos = 0;
+  while ((pos = haystack.find(needle, pos)) != absl::string_view::npos) {
+    ++count;
+    pos += needle.size();
+  }
+  return count;
+}
+
+bool DecodeUtf8CharAt(absl::string_view s, size_t index, char32_t* out,
+                      size_t* length) {
+  if (out == nullptr || length == nullptr || index >= s.size()) {
+    return false;
+  }
+  size_t cursor = index;
+  if (!DecodeUtf8Char(s, &cursor, out)) {
+    return false;
+  }
+  *length = cursor - index;
+  return true;
+}
+
+bool DecodePreviousUtf8Char(absl::string_view s, size_t index,
+                            char32_t* out, size_t* begin,
+                            size_t* length) {
+  if (out == nullptr || begin == nullptr || length == nullptr || index == 0 ||
+      index > s.size()) {
+    return false;
+  }
+
+  size_t start = index - 1;
+  while (start > 0 &&
+         (static_cast<unsigned char>(s[start]) & 0xC0) == 0x80) {
+    --start;
+  }
+
+  size_t cursor = start;
+  if (!DecodeUtf8Char(s, &cursor, out) || cursor != index) {
+    return false;
+  }
+  *begin = start;
+  *length = index - start;
+  return true;
+}
+
+bool IsAsciiWordLike(char32_t c) {
+  return (U'0' <= c && c <= U'9') || (U'A' <= c && c <= U'Z') ||
+         (U'a' <= c && c <= U'z') || c == U'_' || c == U'-' ||
+         c == U'.' || c == U'+' || c == U'#';
+}
+
+bool IsJapaneseLetterLike(char32_t c) {
+  return (0x3040 <= c && c <= 0x309F) ||  // Hiragana
+         (0x30A0 <= c && c <= 0x30FF) ||  // Katakana
+         (0x3400 <= c && c <= 0x9FFF) ||  // CJK Unified Ideographs
+         (0xF900 <= c && c <= 0xFAFF) ||  // CJK Compatibility Ideographs
+         (0xFF66 <= c && c <= 0xFF9D);    // Halfwidth Katakana
+}
+
+bool IsJapaneseParticleBoundary(char32_t c) {
+  switch (c) {
+    case U'の':
+    case U'は':
+    case U'を':
+    case U'に':
+    case U'で':
+    case U'へ':
+    case U'と':
+    case U'が':
+    case U'も':
+    case U'や':
+    case U'か':
+      return true;
+    default:
+      return false;
+  }
+}
+
+bool IsPunctuationOrSpaceBoundary(char32_t c) {
+  if (c <= 0x20) {
+    return true;
+  }
+  switch (c) {
+    case U'、':
+    case U'。':
+    case U'，':
+    case U'．':
+    case U'・':
+    case U'「':
+    case U'」':
+    case U'『':
+    case U'』':
+    case U'（':
+    case U'）':
+    case U'(':
+    case U')':
+    case U'[':
+    case U']':
+    case U'{':
+    case U'}':
+    case U' ':
+    case U'\t':
+    case U'\n':
+      return true;
+    default:
+      return false;
+  }
+}
+
+bool IsProtectedSurfaceBoundaryChar(char32_t c) {
+  if (IsPunctuationOrSpaceBoundary(c) || IsJapaneseParticleBoundary(c)) {
+    return true;
+  }
+  return !IsJapaneseLetterLike(c) && !IsAsciiWordLike(c);
+}
+
+bool HasProtectedSurfaceBoundaries(absl::string_view value, size_t pos,
+                                   absl::string_view surface) {
+  if (surface.empty() || pos > value.size() ||
+      pos + surface.size() > value.size()) {
+    return false;
+  }
+
+  if (pos > 0) {
+    char32_t left = 0;
+    size_t left_begin = 0;
+    size_t left_len = 0;
+    if (!DecodePreviousUtf8Char(value, pos, &left, &left_begin, &left_len) ||
+        !IsProtectedSurfaceBoundaryChar(left)) {
+      return false;
+    }
+  }
+
+  const size_t right_pos = pos + surface.size();
+  if (right_pos < value.size()) {
+    char32_t right = 0;
+    size_t right_len = 0;
+    if (!DecodeUtf8CharAt(value, right_pos, &right, &right_len) ||
+        !IsProtectedSurfaceBoundaryChar(right)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+std::string FindUniqueRightBoundaryAfterSurface(absl::string_view value,
+                                                absl::string_view surface) {
+  if (surface.empty()) {
+    return std::string();
+  }
+
+  std::string boundary;
+  bool seen_boundary = false;
+  size_t pos = 0;
+  while ((pos = value.find(surface, pos)) != absl::string_view::npos) {
+    const size_t right_pos = pos + surface.size();
+    if (right_pos >= value.size()) {
+      pos = right_pos;
+      continue;
+    }
+
+    char32_t right = 0;
+    size_t right_len = 0;
+    if (!DecodeUtf8CharAt(value, right_pos, &right, &right_len) ||
+        !IsProtectedSurfaceBoundaryChar(right)) {
+      pos = right_pos;
+      continue;
+    }
+
+    const std::string candidate(value.substr(right_pos, right_len));
+    if (!seen_boundary) {
+      boundary = candidate;
+      seen_boundary = true;
+    } else if (boundary != candidate) {
+      return std::string();
+    }
+    pos = right_pos;
+  }
+  return seen_boundary ? boundary : std::string();
+}
+
+bool IsAllJapaneseAttachedContent(absl::string_view value) {
+  if (value.empty()) {
+    return false;
+  }
+
+  for (size_t i = 0; i < value.size();) {
+    const size_t old_i = i;
+    char32_t c = 0;
+    if (!DecodeUtf8Char(value, &i, &c) || i == old_i) {
+      return false;
+    }
+    if (!IsJapaneseLetterLike(c) || IsJapaneseParticleBoundary(c)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool TryRepairAttachedProtectedSpan(absl::string_view mozc_value,
+                                    const ProtectedConversionSpan& span,
+                                    std::string* value) {
+  if (value == nullptr || span.value.empty()) {
+    return false;
+  }
+
+  const std::string expected_boundary =
+      FindUniqueRightBoundaryAfterSurface(mozc_value, span.value);
+  if (expected_boundary.empty()) {
+    return false;
+  }
+
+  size_t pos = 0;
+  while ((pos = value->find(span.value, pos)) != std::string::npos) {
+    if (HasProtectedSurfaceBoundaries(*value, pos, span.value)) {
+      pos += span.value.size();
+      continue;
+    }
+
+    const size_t attached_begin = pos + span.value.size();
+    const size_t boundary_pos = value->find(expected_boundary, attached_begin);
+    if (boundary_pos == std::string::npos || boundary_pos == attached_begin ||
+        boundary_pos - attached_begin > 12) {
+      pos = attached_begin;
+      continue;
+    }
+
+    const absl::string_view attached(value->data() + attached_begin,
+                                     boundary_pos - attached_begin);
+    if (!IsAllJapaneseAttachedContent(attached)) {
+      pos = attached_begin;
+      continue;
+    }
+
+    value->erase(attached_begin, boundary_pos - attached_begin);
+    return true;
+  }
+  return false;
+}
+size_t CountBoundaryPreservedOccurrences(absl::string_view value,
+                                         absl::string_view surface) {
+  if (surface.empty()) {
+    return 0;
+  }
+
+  size_t count = 0;
+  size_t pos = 0;
+  while ((pos = value.find(surface, pos)) != absl::string_view::npos) {
+    if (HasProtectedSurfaceBoundaries(value, pos, surface)) {
+      ++count;
+    }
+    pos += surface.size();
+  }
+  return count;
+}
+
+std::string BuildProtectedPlaceholder(size_t index) {
+  return std::string("__MOZC_ZENZ_PROTECTED_") + std::to_string(index) +
+         "__";
+}
+
+std::string BuildUniqueProtectedPlaceholder(size_t index,
+                                            absl::string_view key) {
+  std::string placeholder = BuildProtectedPlaceholder(index);
+  size_t suffix = 0;
+  while (absl::StrContains(key, placeholder)) {
+    placeholder = std::string("__MOZC_ZENZ_PROTECTED_") +
+                  std::to_string(index) + "_" + std::to_string(++suffix) +
+                  "__";
+  }
+  return placeholder;
+}
+
+size_t ReplaceAllLiteral(absl::string_view from, absl::string_view to,
+                         std::string* value) {
+  if (value == nullptr || from.empty()) {
+    return 0;
+  }
+
+  size_t count = 0;
+  size_t pos = 0;
+  while ((pos = value->find(from.data(), pos, from.size())) !=
+         std::string::npos) {
+    value->replace(pos, from.size(), to.data(), to.size());
+    pos += to.size();
+    ++count;
+  }
+  return count;
+}
+
+bool IsRepairCandidateSafe(absl::string_view from,
+                           const ProtectedConversionSpan& span) {
+  if (from.empty() || from == span.value) {
+    return false;
+  }
+  if (!span.repairable ||
+      span.tier != ProtectedConversionSpan::Tier::kIdentityCritical) {
+    return false;
+  }
+
+  // Very short replacements such as "AI" or "Go" are too collision-prone.
+  size_t ascii_alnum_count = 0;
+  for (const unsigned char c : span.value) {
+    if ((('0' <= c) && (c <= '9')) || (('A' <= c) && (c <= 'Z')) ||
+        (('a' <= c) && (c <= 'z'))) {
+      ++ascii_alnum_count;
+    }
+  }
+  return ascii_alnum_count >= 3;
+}
+
+bool TryRepairProtectedSpan(const ProtectedConversionSpan& span,
+                            std::string* value) {
+  if (value == nullptr) {
+    return false;
+  }
+
+  const std::array<std::string, 2> candidates = {
+      HiraganaToKatakana(span.key),
+      span.key,
+  };
+
+  for (const std::string& candidate : candidates) {
+    if (!IsRepairCandidateSafe(candidate, span)) {
+      continue;
+    }
+    if (CountOccurrences(*value, candidate) != 1) {
+      continue;
+    }
+
+    *value = absl::StrReplaceAll(*value, {{candidate, span.value}});
+    return absl::StrContains(*value, span.value);
+  }
+
+  return false;
+}
+
+}  // namespace
+
+ZenzProtectedPromptResult ZenzAdoptionPolicy::ProtectPromptKey(
+    const ZenzProtectedPromptInput& input) const {
+  ZenzProtectedPromptResult result;
+  result.key = std::string(input.key);
+  result.protected_spans = input.protected_spans;
+
+  std::vector<size_t> order;
+  order.reserve(result.protected_spans.size());
+  for (size_t i = 0; i < result.protected_spans.size(); ++i) {
+    const ProtectedConversionSpan& span = result.protected_spans[i];
+    // Prompt-side placeholders are intentionally limited to identity-critical
+    // surfaces such as ASCII / mixed-script product names.  Japanese
+    // user-dictionary entries are protected on the output side instead: keeping
+    // their natural reading in the prompt preserves Zenz's ability to improve
+    // the surrounding Japanese text, while Decide() still repairs or rejects
+    // boundary changes such as an extra kana attached to the protected surface.
+    if (!span.key.empty() && !span.value.empty() &&
+        span.tier == ProtectedConversionSpan::Tier::kIdentityCritical) {
+      order.push_back(i);
+    }
+  }
+
+  std::stable_sort(order.begin(), order.end(),
+                   [&](size_t lhs, size_t rhs) {
+                     return result.protected_spans[lhs].key.size() >
+                            result.protected_spans[rhs].key.size();
+                   });
+
+  size_t placeholder_index = 0;
+  for (const size_t span_index : order) {
+    ProtectedConversionSpan& span = result.protected_spans[span_index];
+    if (CountOccurrences(result.key, span.key) == 0) {
+      continue;
+    }
+
+    const std::string placeholder =
+        BuildUniqueProtectedPlaceholder(placeholder_index++, result.key);
+    const size_t replaced =
+        ReplaceAllLiteral(span.key, placeholder, &result.key);
+    if (replaced == 0) {
+      continue;
+    }
+
+    span.placeholder = placeholder;
+    if (span.required_occurrences < replaced) {
+      span.required_occurrences = replaced;
+    }
+    result.placeholder_count += replaced;
+  }
+
+  return result;
+}
+
+std::string ZenzAdoptionPolicy::RestorePlaceholders(
+    absl::string_view value,
+    const std::vector<ProtectedConversionSpan>& protected_spans) const {
+  std::string restored(value);
+  for (const ProtectedConversionSpan& span : protected_spans) {
+    if (span.placeholder.empty() || span.value.empty()) {
+      continue;
+    }
+    ReplaceAllLiteral(span.placeholder, span.value, &restored);
+  }
+  return restored;
+}
+
+ZenzAdoptionResult ZenzAdoptionPolicy::Decide(
+    const ZenzAdoptionInput& input) const {
+  std::string adopted_value(input.zenz_value);
+  bool repaired = false;
+
+  for (const ProtectedConversionSpan& span : input.protected_spans) {
+    if (span.value.empty()) {
+      continue;
+    }
+
+    const size_t required_occurrences =
+        span.required_occurrences == 0 ? 1 : span.required_occurrences;
+
+    while (CountBoundaryPreservedOccurrences(adopted_value, span.value) <
+           required_occurrences) {
+      if (TryRepairAttachedProtectedSpan(input.mozc_value, span,
+                                         &adopted_value)) {
+        repaired = true;
+        continue;
+      }
+
+      if (CountOccurrences(adopted_value, span.value) < required_occurrences &&
+          TryRepairProtectedSpan(span, &adopted_value)) {
+        repaired = true;
+        continue;
+      }
+
+      ZenzAdoptionResult result;
+      result.action = ZenzAdoptionResult::Action::kReject;
+      result.value = std::string(input.mozc_value);
+      result.reason = CountOccurrences(adopted_value, span.value) >=
+                              required_occurrences
+                          ? "protected_user_dictionary_surface_boundary_changed"
+                          : "protected_user_dictionary_surface_not_preserved";
+      return result;
+    }
+  }
+
+  ZenzAdoptionResult result;
+  result.action = repaired ? ZenzAdoptionResult::Action::kAcceptWithRepair
+                           : ZenzAdoptionResult::Action::kAcceptAsIs;
+  result.value = std::move(adopted_value);
+  result.reason = repaired ? "protected_user_dictionary_surface_repaired"
+                           : "accepted";
+  return result;
+}
+
+}  // namespace mozc::session

--- a/src/session/zenz_adoption_policy.h
+++ b/src/session/zenz_adoption_policy.h
@@ -1,0 +1,120 @@
+// Copyright 2010-2021, Google Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#ifndef MOZC_SESSION_ZENZ_ADOPTION_POLICY_H_
+#define MOZC_SESSION_ZENZ_ADOPTION_POLICY_H_
+
+#include <cstddef>
+#include <string>
+#include <vector>
+
+#include "absl/strings/string_view.h"
+
+namespace mozc::session {
+
+// A surface that normal Mozc live conversion has already selected from a
+// user-dictionary candidate.  Zenz live correction is allowed to improve the
+// surrounding sentence, but must not silently destroy these surfaces.
+struct ProtectedConversionSpan {
+  enum class Tier {
+    // Product names, handles, ASCII/mixed-script spellings, and other surfaces
+    // where the exact spelling is part of the user's intent.
+    kIdentityCritical,
+
+    // Other user-dictionary surfaces selected by normal Mozc live conversion.
+    // They are protected from silent overwrite.  They are not eligible for
+    // reading-derived kana replacement, but boundary/attachment repair may be
+    // applied when it is locally safe.
+    kUserPreferred,
+  };
+
+  std::string key;
+  std::string value;
+  Tier tier = Tier::kUserPreferred;
+
+  // Bounded repair is permitted only for identity-critical surfaces whose
+  // reading-derived kana spelling can be found unambiguously in the Zenz output.
+  bool repairable = false;
+
+  // Number of occurrences of this surface in the normal Mozc live-conversion
+  // value.  Zenz adoption must preserve at least this many occurrences, or
+  // repair the missing occurrence when it is safe.
+  size_t required_occurrences = 1;
+
+  // Placeholder used only in the Zenz prompt.  When non-empty, the prompt key
+  // contains this token instead of key, and the Zenz output is restored to
+  // value before validation and adoption.
+  std::string placeholder;
+};
+
+struct ZenzProtectedPromptInput {
+  absl::string_view key;
+  std::vector<ProtectedConversionSpan> protected_spans;
+};
+
+struct ZenzProtectedPromptResult {
+  std::string key;
+  std::vector<ProtectedConversionSpan> protected_spans;
+  size_t placeholder_count = 0;
+};
+
+struct ZenzAdoptionInput {
+  absl::string_view key;
+  absl::string_view mozc_value;
+  absl::string_view zenz_value;
+  std::vector<ProtectedConversionSpan> protected_spans;
+};
+
+struct ZenzAdoptionResult {
+  enum class Action {
+    kAcceptAsIs,
+    kAcceptWithRepair,
+    kReject,
+  };
+
+  Action action = Action::kReject;
+  std::string value;
+  std::string reason;
+};
+
+class ZenzAdoptionPolicy {
+ public:
+  ZenzProtectedPromptResult ProtectPromptKey(
+      const ZenzProtectedPromptInput& input) const;
+
+  std::string RestorePlaceholders(
+      absl::string_view value,
+      const std::vector<ProtectedConversionSpan>& protected_spans) const;
+
+  ZenzAdoptionResult Decide(const ZenzAdoptionInput& input) const;
+};
+
+}  // namespace mozc::session
+
+#endif  // MOZC_SESSION_ZENZ_ADOPTION_POLICY_H_

--- a/src/session/zenz_adoption_policy_test.cc
+++ b/src/session/zenz_adoption_policy_test.cc
@@ -1,0 +1,328 @@
+// Copyright 2010-2021, Google Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "session/zenz_adoption_policy.h"
+
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "testing/gunit.h"
+
+namespace mozc::session {
+namespace {
+
+ProtectedConversionSpan BuildSpan(
+    std::string key, std::string value, ProtectedConversionSpan::Tier tier,
+    bool repairable) {
+  ProtectedConversionSpan span;
+  span.key = std::move(key);
+  span.value = std::move(value);
+  span.tier = tier;
+  span.repairable = repairable;
+  return span;
+}
+
+TEST(ZenzAdoptionPolicyTest, ProtectPromptKeyAndRestorePlaceholder) {
+  ZenzAdoptionPolicy policy;
+  ZenzProtectedPromptInput input;
+  input.key = "てんてきのかれはもずきーをつかっています";
+  input.protected_spans = {
+      BuildSpan("もずきー", "Mozkey",
+                ProtectedConversionSpan::Tier::kIdentityCritical, true),
+  };
+
+  const ZenzProtectedPromptResult prompt = policy.ProtectPromptKey(input);
+  ASSERT_EQ(prompt.protected_spans.size(), 1);
+  EXPECT_EQ(prompt.placeholder_count, 1);
+  EXPECT_EQ(prompt.key,
+            "てんてきのかれは__MOZC_ZENZ_PROTECTED_0__をつかっています");
+
+  const std::string restored = policy.RestorePlaceholders(
+      "点滴の彼は__MOZC_ZENZ_PROTECTED_0__を使用しています",
+      prompt.protected_spans);
+  EXPECT_EQ(restored, "点滴の彼はMozkeyを使用しています");
+}
+
+TEST(ZenzAdoptionPolicyTest, DoesNotPlaceholderUserPreferredJapaneseSurface) {
+  ZenzAdoptionPolicy policy;
+  ZenzProtectedPromptInput prompt_input;
+  prompt_input.key = "かれはじしょごのてんてきです";
+  prompt_input.protected_spans = {
+      BuildSpan("じしょご", "辞書語",
+                ProtectedConversionSpan::Tier::kUserPreferred, false),
+  };
+
+  const ZenzProtectedPromptResult prompt = policy.ProtectPromptKey(prompt_input);
+  ASSERT_EQ(prompt.protected_spans.size(), 1);
+  EXPECT_EQ(prompt.placeholder_count, 0);
+  EXPECT_EQ(prompt.key, "かれはじしょごのてんてきです");
+  EXPECT_TRUE(prompt.protected_spans[0].placeholder.empty());
+
+  ZenzAdoptionInput adoption_input;
+  adoption_input.key = prompt.key;
+  adoption_input.mozc_value = "彼は辞書語の点滴です";
+  adoption_input.zenz_value = "彼は辞書語けの天敵です";
+  adoption_input.protected_spans = prompt.protected_spans;
+
+  const ZenzAdoptionResult result = policy.Decide(adoption_input);
+  EXPECT_EQ(result.action, ZenzAdoptionResult::Action::kAcceptWithRepair);
+  EXPECT_EQ(result.value, "彼は辞書語の天敵です");
+}
+
+TEST(ZenzAdoptionPolicyTest, UserPreferredJapaneseSurfaceIsGuardedOnOutputSide) {
+  ZenzAdoptionPolicy policy;
+
+  ProtectedConversionSpan span;
+  span.key = "じしょご";
+  span.value = "辞書語";
+  span.tier = ProtectedConversionSpan::Tier::kUserPreferred;
+  span.repairable = false;
+  span.required_occurrences = 1;
+
+  ZenzProtectedPromptInput prompt_input;
+  prompt_input.key = "かれはじしょごのてんてきです";
+  prompt_input.protected_spans = {span};
+
+  const ZenzProtectedPromptResult prompt =
+      policy.ProtectPromptKey(prompt_input);
+  EXPECT_EQ(prompt.placeholder_count, 0);
+  EXPECT_EQ(prompt.key, "かれはじしょごのてんてきです");
+
+  ZenzAdoptionInput adoption_input;
+  adoption_input.key = "かれはじしょごのてんてきです";
+  adoption_input.mozc_value = "彼は辞書語の点滴です";
+  adoption_input.zenz_value = "彼は辞書語けの天敵です";
+  adoption_input.protected_spans = {span};
+
+  const ZenzAdoptionResult result = policy.Decide(adoption_input);
+  EXPECT_EQ(result.action, ZenzAdoptionResult::Action::kAcceptWithRepair);
+  EXPECT_EQ(result.value, "彼は辞書語の天敵です");
+}
+
+
+TEST(ZenzAdoptionPolicyTest, ProtectPromptKeyHandlesRepeatedSurface) {
+  ZenzAdoptionPolicy policy;
+  ZenzProtectedPromptInput input;
+  input.key = "もずきーともずきーをくらべます";
+  ProtectedConversionSpan span = BuildSpan(
+      "もずきー", "Mozkey",
+      ProtectedConversionSpan::Tier::kIdentityCritical, true);
+  span.required_occurrences = 2;
+  input.protected_spans = {span};
+
+  const ZenzProtectedPromptResult prompt = policy.ProtectPromptKey(input);
+  ASSERT_EQ(prompt.protected_spans.size(), 1);
+  EXPECT_EQ(prompt.placeholder_count, 2);
+  EXPECT_EQ(prompt.key,
+            "__MOZC_ZENZ_PROTECTED_0__と"
+            "__MOZC_ZENZ_PROTECTED_0__をくらべます");
+
+  const std::string restored = policy.RestorePlaceholders(
+      "__MOZC_ZENZ_PROTECTED_0__と"
+      "__MOZC_ZENZ_PROTECTED_0__を比較します",
+      prompt.protected_spans);
+  EXPECT_EQ(restored, "MozkeyとMozkeyを比較します");
+}
+
+TEST(ZenzAdoptionPolicyTest, AcceptsWhenProtectedSurfaceIsPreserved) {
+  ZenzAdoptionPolicy policy;
+  ZenzAdoptionInput input;
+  input.key = "もずきーをつかっています";
+  input.mozc_value = "Mozkeyを使っています";
+  input.zenz_value = "Mozkeyを使用しています";
+  input.protected_spans = {
+      BuildSpan("もずきー", "Mozkey", ProtectedConversionSpan::Tier::kIdentityCritical, true),
+  };
+
+  const ZenzAdoptionResult result = policy.Decide(input);
+  EXPECT_EQ(result.action, ZenzAdoptionResult::Action::kAcceptAsIs);
+  EXPECT_EQ(result.value, "Mozkeyを使用しています");
+}
+
+TEST(ZenzAdoptionPolicyTest, RepairsIdentityCriticalKanaSurface) {
+  ZenzAdoptionPolicy policy;
+  ZenzAdoptionInput input;
+  input.key = "もずきーをつかっています";
+  input.mozc_value = "Mozkeyを使っています";
+  input.zenz_value = "モズキーを使用しています";
+  input.protected_spans = {
+      BuildSpan("もずきー", "Mozkey", ProtectedConversionSpan::Tier::kIdentityCritical, true),
+  };
+
+  const ZenzAdoptionResult result = policy.Decide(input);
+  EXPECT_EQ(result.action, ZenzAdoptionResult::Action::kAcceptWithRepair);
+  EXPECT_EQ(result.value, "Mozkeyを使用しています");
+}
+
+
+TEST(ZenzAdoptionPolicyTest, AcceptsJapaneseUserDictionarySurfaceWithParticle) {
+  ZenzAdoptionPolicy policy;
+  ZenzAdoptionInput input;
+  input.key = "かれはじしょごのてんてきです";
+  input.mozc_value = "彼は辞書語の点滴です";
+  input.zenz_value = "彼は辞書語の天敵です";
+  input.protected_spans = {
+      BuildSpan("じしょご", "辞書語",
+                ProtectedConversionSpan::Tier::kUserPreferred, false),
+  };
+
+  const ZenzAdoptionResult result = policy.Decide(input);
+  EXPECT_EQ(result.action, ZenzAdoptionResult::Action::kAcceptAsIs);
+  EXPECT_EQ(result.value, "彼は辞書語の天敵です");
+}
+
+TEST(ZenzAdoptionPolicyTest, RepairsAttachedKanaAfterProtectedSurface) {
+  ZenzAdoptionPolicy policy;
+  ZenzAdoptionInput input;
+  input.key = "かれはじしょごのてんてきです";
+  input.mozc_value = "彼は辞書語の点滴です";
+  input.zenz_value = "彼は辞書語けの天敵です";
+  input.protected_spans = {
+      BuildSpan("じしょご", "辞書語",
+                ProtectedConversionSpan::Tier::kUserPreferred, false),
+  };
+
+  const ZenzAdoptionResult result = policy.Decide(input);
+  EXPECT_EQ(result.action, ZenzAdoptionResult::Action::kAcceptWithRepair);
+  EXPECT_EQ(result.value, "彼は辞書語の天敵です");
+}
+
+TEST(ZenzAdoptionPolicyTest, RejectsAttachedKanaWithoutSafeBoundaryRepair) {
+  ZenzAdoptionPolicy policy;
+  ZenzAdoptionInput input;
+  input.key = "かれはじしょご";
+  input.mozc_value = "彼は辞書語";
+  input.zenz_value = "彼は辞書語け";
+  input.protected_spans = {
+      BuildSpan("じしょご", "辞書語",
+                ProtectedConversionSpan::Tier::kUserPreferred, false),
+  };
+
+  const ZenzAdoptionResult result = policy.Decide(input);
+  EXPECT_EQ(result.action, ZenzAdoptionResult::Action::kReject);
+  EXPECT_EQ(result.value, "彼は辞書語");
+}
+
+TEST(ZenzAdoptionPolicyTest, RejectsAsciiIdentitySurfaceAttachment) {
+  ZenzAdoptionPolicy policy;
+  ZenzAdoptionInput input;
+  input.key = "もずきーをつかっています";
+  input.mozc_value = "Mozkeyを使っています";
+  input.zenz_value = "MozkeyXを使用しています";
+  input.protected_spans = {
+      BuildSpan("もずきー", "Mozkey",
+                ProtectedConversionSpan::Tier::kIdentityCritical, true),
+  };
+
+  const ZenzAdoptionResult result = policy.Decide(input);
+  EXPECT_EQ(result.action, ZenzAdoptionResult::Action::kReject);
+  EXPECT_EQ(result.value, "Mozkeyを使っています");
+}
+
+TEST(ZenzAdoptionPolicyTest, RejectsAmbiguousRepair) {
+  ZenzAdoptionPolicy policy;
+  ZenzAdoptionInput input;
+  input.key = "もずきー";
+  input.mozc_value = "MozkeyとMozkey";
+  input.zenz_value = "モズキーとモズキー";
+  input.protected_spans = {
+      BuildSpan("もずきー", "Mozkey", ProtectedConversionSpan::Tier::kIdentityCritical, true),
+  };
+
+  const ZenzAdoptionResult result = policy.Decide(input);
+  EXPECT_EQ(result.action, ZenzAdoptionResult::Action::kReject);
+  EXPECT_EQ(result.reason, "protected_user_dictionary_surface_not_preserved");
+}
+
+TEST(ZenzAdoptionPolicyTest, RepairsOneMissingRepeatedSurface) {
+  ZenzAdoptionPolicy policy;
+  ZenzAdoptionInput input;
+  input.key = "もずきーともずきー";
+  input.mozc_value = "MozkeyとMozkey";
+  input.zenz_value = "Mozkeyとモズキー";
+
+  ProtectedConversionSpan span = BuildSpan(
+      "もずきー", "Mozkey",
+      ProtectedConversionSpan::Tier::kIdentityCritical, true);
+  span.required_occurrences = 2;
+  input.protected_spans = {span};
+
+  const ZenzAdoptionResult result = policy.Decide(input);
+  EXPECT_EQ(result.action, ZenzAdoptionResult::Action::kAcceptWithRepair);
+  EXPECT_EQ(result.value, "MozkeyとMozkey");
+}
+
+TEST(ZenzAdoptionPolicyTest, RejectsWhenRequiredOccurrenceIsMissing) {
+  ZenzAdoptionPolicy policy;
+  ZenzAdoptionInput input;
+  input.key = "もずきーともずきー";
+  input.mozc_value = "MozkeyとMozkey";
+  input.zenz_value = "Mozkeyだけ";
+
+  ProtectedConversionSpan span = BuildSpan(
+      "もずきー", "Mozkey",
+      ProtectedConversionSpan::Tier::kIdentityCritical, true);
+  span.required_occurrences = 2;
+  input.protected_spans = {span};
+
+  const ZenzAdoptionResult result = policy.Decide(input);
+  EXPECT_EQ(result.action, ZenzAdoptionResult::Action::kReject);
+}
+
+TEST(ZenzAdoptionPolicyTest, DoesNotRepairUserPreferredSurface) {
+  ZenzAdoptionPolicy policy;
+  ZenzAdoptionInput input;
+  input.key = "わたなべ";
+  input.mozc_value = "渡邊さんに送る";
+  input.zenz_value = "渡辺さんへ送ります";
+  input.protected_spans = {
+      BuildSpan("わたなべ", "渡邊", ProtectedConversionSpan::Tier::kUserPreferred, false),
+  };
+
+  const ZenzAdoptionResult result = policy.Decide(input);
+  EXPECT_EQ(result.action, ZenzAdoptionResult::Action::kReject);
+}
+
+TEST(ZenzAdoptionPolicyTest, DoesNotRepairShortAsciiSurface) {
+  ZenzAdoptionPolicy policy;
+  ZenzAdoptionInput input;
+  input.key = "えーあい";
+  input.mozc_value = "AIを使う";
+  input.zenz_value = "エーアイを使います";
+  input.protected_spans = {
+      BuildSpan("えーあい", "AI", ProtectedConversionSpan::Tier::kIdentityCritical, true),
+  };
+
+  const ZenzAdoptionResult result = policy.Decide(input);
+  EXPECT_EQ(result.action, ZenzAdoptionResult::Action::kReject);
+}
+
+}  // namespace
+}  // namespace mozc::session


### PR DESCRIPTION
## 概要 #123

この PR では、通常 Mozc ライブ変換で現在の結果として現れているユーザー辞書由来候補や ASCII / mixed-script 表記を、Zenz live correction の採用時に保護するようにしました。

Zenz は汎用的な日本語補正には強い一方で、通常辞書や学習データに載りにくいマイナーな語、ローカルな語、個人・組織固有の表記、ユーザーが意図して登録した表記までは必ずしも知りません。

一方、Mozc にはそのような語を扱うためのユーザー辞書があります。通常 Mozc ライブ変換ではユーザー辞書に基づいて正しい表記が出ていても、その後に Zenz live correction を採用すると、Zenz 側がそのローカルな表記知識を持たないため、表記を一般的な形へ戻したり、読み由来の別表記へ変えてしまうことがありました。

今回の変更では、ユーザー辞書そのものを Zenz に丸ごと渡すのではなく、通常 Mozc ライブ変換が現在選んでいるユーザー辞書由来の表記を、Zenz 採用時の保護対象として扱うようにしました。これにより、Zenz による文全体の補正を活かしつつ、ユーザー辞書で明示的に選ばれた表記を意図せず上書きしないようにしています。

例:

* `もずきー -> Mozkey` が通常ライブ変換で `Mozkey` と出ている場合、Zenz によって `モズキー` へ戻されないようにする
* 日本語のみのユーザー辞書語が通常ライブ変換で選ばれている場合、Zenz によって表記が崩れたり、余分なかなが付着したりしないようにする
* 一方で、保護対象の前後にある文の補正は引き続き採用できるようにする

## 変更内容

### ユーザー辞書候補の保護

通常 Mozc ライブ変換の現在結果に実際に現れているユーザー辞書由来候補を、Zenz 採用時の保護対象として扱うようにしました。

保護対象は「ユーザー辞書に存在する全候補」ではなく、「現在の通常ライブ変換結果に実際に現れた表記」に限定しています。これにより、無関係なユーザー辞書語を過剰に固定しないようにしています。

この設計により、Mozc 側のユーザー辞書によって得られたローカルな表記知識を、Zenz の採用判定へ安全に反映できます。

### 既存 user dictionary index 経由の lookup

Session から `UserDictionaryStorage` を直接読み込むのではなく、`ConverterInterface` / `EngineConverterInterface` に読み取り専用の narrow API を追加し、既存の user dictionary index 経由で prefix lookup するようにしました。

これにより、ユーザー辞書の再読み込み・index 管理・lookup 経路を既存の Mozc 側の責務に寄せています。

### ASCII / mixed-script 表記の placeholder 保護

`Mozkey` のような ASCII / mixed-script 表記は、読みを安全に特定できる場合に Zenz prompt 内で一時 placeholder 化し、Zenz 応答後に元の表記へ復元するようにしました。

これにより、Zenz が読みをカタカナ表記などに戻してしまうケースを避けつつ、対象語の前後にある文の補正は維持します。

### 日本語のみのユーザー辞書語は output-side guard

日本語のみのユーザー辞書語は、Zenz prompt では自然な読みを残したままにしています。

そのうえで、Zenz 応答後に保護対象の表記境界を検証し、余分なかな付着などが安全に修復できる場合だけ採用します。修復できない場合は Zenz 結果を採用せず、通常の Mozc ライブ変換結果に戻します。

例:

* 保護対象の直後に余分なかなが付着した場合、安全に境界を復元できるときだけ採用する
* 人名・固有名詞・異体字など、表記そのものがユーザー意図を持つ候補が別表記へ変わった場合は採用しない

### Zenz feedback fast path への適用

accepted Zenz feedback を session-level live correction fast path として再利用する場合にも、同じ adoption policy を通すようにしました。

これにより、通常の Zenz 応答だけでなく、過去 feedback の再利用時にも保護対象が崩れないようにしています。

### Zenz 無効時の追加コスト回避

Zenz live correction が無効な場合は、protected span の構築および user dictionary lookup を行わないようにしました。

## テスト

以下を確認しました。

* `//converter:converter_test`
* `//session:zenz_adoption_policy_test`
* `//session:session_test`
* `//session:session_handler_stress_test`
* 実機確認

実機確認では、以下のようなケースが意図どおり動作することを確認しました。

* ASCII / mixed-script のユーザー辞書表記が維持され、読み由来の別表記へ戻されないこと
* 日本語のみのユーザー辞書表記が維持され、余分なかな付着や別表記化が起きないこと
* 保護対象の前後にある文の補正は引き続き採用できること

## 備考

この PR は、ユーザー辞書の全内容を Zenz prompt に渡すものではありません。保護対象は、通常 Mozc ライブ変換が現在の結果として実際に選んでいる表記に限定しています。

日本語のみのユーザー辞書語は prompt placeholder 化せず、出力側で境界検証する設計にしています。

これは、日本語語彙では助詞・接尾辞・活用的な付着との境界が曖昧になりやすく、prompt 段階で読みを隠すと Zenz が周辺文脈を自然に補正しにくくなるためです。ASCII / mixed-script 表記と日本語のみ表記で保護方法を分けることで、表記保護と文全体の補正を両立させています。
