### PR TITLE
Preserve user-visible symbol style in Zenz live correction

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Windows 用のビルド済み MSI は [Releases](https://github.com/koyasi777/mo
 - accepted として確定した Zenz 候補は、条件を満たす場合は Mozc の user history にも外部変換結果として学習
 - 通常 Mozc ライブ変換で現在の結果として現れているユーザー辞書由来候補や ASCII / mixed-script 表記を、Zenz live correction の採用時に保護
 - ASCII / mixed-script 表記は、読みを安全に特定できる場合に Zenz prompt 内で一時 placeholder 化し、応答後に元の表記へ復元。`もずきー -> Mozkey` のような表記が `モズキー` へ上書きされるのを避けつつ、前後の文は補正できるようにした
+- Zenz が `（ ）` / `( )`、`？` / `?`、`！` / `!`、`：` / `:` などの記号幅・記号スタイルを正規化して返した場合でも、元の未確定文字列または通常 Mozc ライブ変換結果でユーザーが使っていた表記へ復元
 - 日本語のみのユーザー辞書語は、自然な読みを Zenz prompt に残したまま、Zenz 応答後に表記の境界を検証し、余分なかな付着を安全に修復できる場合だけ採用するようにした
 - Zenz prompt に使う左文脈は sanitizer を通し、URL、email、file path、token、長い数字列など sensitive-like な文脈は prompt に含めない
 - Zenz feedback には raw left context を保存せず、非可逆な context class のみを保存
@@ -231,6 +232,8 @@ Zenz 補正は設定可能なデバウンス時間の後に実行されます。
 Zenz 出力は表示前に検証されます。空出力、短すぎる入力、Mozc 結果と同一の出力、長すぎる出力、不正な文字列、安全でない可能性のある文字列は拒否されます。拒否された場合は、通常の Mozc ライブ変換結果をそのまま表示します。
 
 通常 Mozc ライブ変換で現在の結果として現れているユーザー辞書由来候補や ASCII / mixed-script 表記は、Zenz 採用時に保護されます。ASCII / mixed-script 表記は、読みを安全に特定できる場合に Zenz prompt 内で一時 placeholder 化し、Zenz 応答後に元の表記へ復元します。これにより、`もずきー -> Mozkey` のような表記が `モズキー` のように上書きされることを避けつつ、対象語の前後にある文の補正は採用できるようにしています。
+
+また、Zenz が括弧、疑問符、感嘆符、一部の全角 ASCII 記号 などを正規化して返した場合でも、採用前にユーザー可視の記号スタイルを復元します。これは全角化ではなく、現在の未確定文字列または通常 Mozc ライブ変換結果に現れていた表記の保存です。たとえば `（テスト）` は `（ ）` のまま、`(test)` は `( )` のまま維持します。URL、path、ASCII token 風の文脈では、ASCII 記号を不用意に全角化しないよう保守的に扱います。
 
 日本語のみのユーザー辞書語は、自然な読みを Zenz prompt に残したまま、Zenz 応答後に表記の境界を検証します。たとえば保護対象の直後に余分なかなが付着した場合は、安全に修復できる場合だけ採用し、修復できない場合は通常の Mozc ライブ変換結果に戻します。
 
@@ -630,6 +633,7 @@ Main features added in this fork
 - Learns accepted Zenz candidates into Mozc user history as external conversion results when the runtime conditions allow it
 - Protects user-dictionary candidates and ASCII / mixed-script surfaces that appear in the current normal Mozc live-conversion result before adopting Zenz live-correction output
 - For ASCII / mixed-script surfaces, temporarily replaces the reading with a placeholder in the Zenz prompt when it can be identified safely, then restores the selected surface after the response, so entries such as `もずきー -> Mozkey` are not silently overwritten as `モズキー` while surrounding text can still be corrected
+- Preserves user-visible punctuation style when adopting Zenz live-correction output, so brackets and symbols such as `（ ）` / `( )`, `？` / `?`, and `！` / `!` stay in the style chosen by the current composition or Mozc live-conversion result
 - For Japanese-only user-dictionary surfaces, keeps the natural reading in the Zenz prompt and validates the selected surface boundaries after the response, accepting the result only when any extra kana attachment can be repaired safely
 - Sanitizes left context before using it in Zenz prompts, and excludes sensitive-like context such as URLs, email addresses, file paths, tokens, and long digit sequences
 - Stores only non-reversible context classes in Zenz feedback and never stores raw left context
@@ -719,6 +723,13 @@ replaced with a placeholder in the Zenz prompt and restored to the selected
 surface after the response. This prevents Zenz from silently overwriting the
 protected word as `モズキー` while still allowing correction of the surrounding
 sentence.
+
+Zenz output may also normalize visible punctuation style. Before adoption,
+Mozkey restores the symbol style from the current composition or normal Mozc
+live-conversion result. This is preservation rather than fullwidth
+normalization: `（test）` stays fullwidth when that was the source style, while
+`(test)` stays ASCII. ASCII-token-like contexts such as code-like words, paths,
+and URLs are handled conservatively to avoid unwanted widening.
 
 Japanese-only user-dictionary surfaces keep their natural reading in the Zenz
 prompt. After the Zenz response, Mozkey validates the selected surface

--- a/src/session/BUILD.bazel
+++ b/src/session/BUILD.bazel
@@ -133,6 +133,21 @@ mozc_cc_test(
 )
 
 mozc_cc_test(
+    name = "zenz_output_validator_test",
+    size = "small",
+    srcs = [
+        "zenz_output_validator.cc",
+        "zenz_output_validator.h",
+        "zenz_output_validator_test.cc",
+    ],
+    deps = [
+        "//base:util",
+        "//testing:gunit_main",
+        "@com_google_absl//absl/strings",
+    ],
+)
+
+mozc_cc_test(
     name = "session_test",
     size = "small",
     timeout = "moderate",

--- a/src/session/zenz_output_validator.cc
+++ b/src/session/zenz_output_validator.cc
@@ -90,13 +90,6 @@ struct Utf8CharForSymbolRestore {
   std::string bytes;
 };
 
-bool IsAsciiTilde(char32_t cp) { return cp == 0x007E; }
-
-bool IsJapaneseWaveDash(char32_t cp) {
-  return cp == 0xFF5E ||  // FULLWIDTH TILDE: ～
-         cp == 0x301C;    // WAVE DASH: 〜
-}
-
 std::vector<Utf8CharForSymbolRestore> SplitUtf8ForSymbolRestore(
     absl::string_view text) {
   std::vector<Utf8CharForSymbolRestore> chars;
@@ -112,76 +105,71 @@ std::vector<Utf8CharForSymbolRestore> SplitUtf8ForSymbolRestore(
   return chars;
 }
 
-int CountCodePoint(absl::string_view text, char32_t target) {
-  int count = 0;
-  size_t index = 0;
-  while (index < text.size()) {
-    char32_t cp = 0;
-    if (!DecodeOneUtf8(text, &index, &cp)) {
-      return 0;
-    }
-    if (cp == target) {
-      ++count;
+int FindSymbolStyleVariantIndex(char32_t cp,
+                                const std::vector<char32_t>& variants) {
+  for (size_t i = 0; i < variants.size(); ++i) {
+    if (variants[i] == cp) {
+      return static_cast<int>(i);
     }
   }
-  return count;
+  return -1;
 }
 
-int CountJapaneseWaveDashFamily(absl::string_view text) {
-  return CountCodePoint(text, 0xFF5E) + CountCodePoint(text, 0x301C);
+bool IsAsciiTokenCharForSymbolRestore(char32_t cp) {
+  if (cp > 0x7F) {
+    return false;
+  }
+
+  return (U'0' <= cp && cp <= U'9') ||
+         (U'A' <= cp && cp <= U'Z') ||
+         (U'a' <= cp && cp <= U'z') ||
+         cp == U'_' || cp == U'-' || cp == U'.' || cp == U'+' ||
+         cp == U'#' || cp == U'/' || cp == U'\\';
 }
 
-int CountAsciiTilde(absl::string_view text) {
-  return CountCodePoint(text, 0x007E);
+bool HasAsciiTokenNeighborForSymbolRestore(
+    const std::vector<Utf8CharForSymbolRestore>& chars, size_t index) {
+  if (index > 0 && IsAsciiTokenCharForSymbolRestore(chars[index - 1].cp)) {
+    return true;
+  }
+  if (index + 1 < chars.size() &&
+      IsAsciiTokenCharForSymbolRestore(chars[index + 1].cp)) {
+    return true;
+  }
+  return false;
 }
 
-std::string FirstJapaneseWaveDashBytes(absl::string_view text) {
-  const std::vector<Utf8CharForSymbolRestore> chars =
-      SplitUtf8ForSymbolRestore(text);
+std::string FirstSymbolVariantBytes(
+    const std::vector<Utf8CharForSymbolRestore>& chars, char32_t target) {
   for (const Utf8CharForSymbolRestore& ch : chars) {
-    if (IsJapaneseWaveDash(ch.cp)) {
+    if (ch.cp == target) {
       return ch.bytes;
     }
   }
   return {};
 }
 
-}  // namespace
-
-std::string ZenzOutputValidator::RestoreUserVisibleSymbolStyle(
-    absl::string_view key,
-    absl::string_view mozc_value,
-    absl::string_view zenz_value) {
-  const int key_wave_dash_count = CountJapaneseWaveDashFamily(key);
-  const int mozc_wave_dash_count = CountJapaneseWaveDashFamily(mozc_value);
-
-  // Prefer `key` because the caller passes raw-preedit-derived text here for
-  // live correction.  `mozc_value` may already contain an ASCII tilde due to
-  // converter or feedback influence, and must not cancel restoration of the
-  // user-entered Japanese wave dash style.
-  absl::string_view style_source;
-  if (key_wave_dash_count > 0) {
-    style_source = key;
-  } else if (mozc_wave_dash_count > 0) {
-    style_source = mozc_value;
-  } else {
-    return std::string(zenz_value);
+bool ContainsAnySymbolStyleVariant(absl::string_view text,
+                                   const std::vector<char32_t>& variants) {
+  size_t index = 0;
+  while (index < text.size()) {
+    char32_t cp = 0;
+    if (!DecodeOneUtf8(text, &index, &cp)) {
+      return false;
+    }
+    if (FindSymbolStyleVariantIndex(cp, variants) >= 0) {
+      return true;
+    }
   }
+  return false;
+}
 
-  const int source_wave_dash_count =
-      CountJapaneseWaveDashFamily(style_source);
-  const int zenz_wave_dash_count = CountJapaneseWaveDashFamily(zenz_value);
-  const int missing_wave_dash_count =
-      source_wave_dash_count - zenz_wave_dash_count;
-  if (missing_wave_dash_count <= 0) {
-    return std::string(zenz_value);
-  }
-
-  const int source_ascii_tilde_count = CountAsciiTilde(style_source);
-  const int zenz_ascii_tilde_count = CountAsciiTilde(zenz_value);
-  int replacement_budget = std::min(
-      missing_wave_dash_count, zenz_ascii_tilde_count - source_ascii_tilde_count);
-  if (replacement_budget <= 0) {
+std::string RestoreSymbolGroupStyle(
+    absl::string_view style_source,
+    absl::string_view zenz_value,
+    const std::vector<char32_t>& variants,
+    bool avoid_ascii_token_fallback_when_widening) {
+  if (style_source.empty() || zenz_value.empty() || variants.empty()) {
     return std::string(zenz_value);
   }
 
@@ -193,35 +181,183 @@ std::string ZenzOutputValidator::RestoreUserVisibleSymbolStyle(
     return std::string(zenz_value);
   }
 
-  const std::string default_replacement =
-      FirstJapaneseWaveDashBytes(style_source);
-  if (default_replacement.empty()) {
+  std::vector<int> source_counts(variants.size(), 0);
+  std::vector<int> zenz_counts(variants.size(), 0);
+
+  for (const Utf8CharForSymbolRestore& ch : source_chars) {
+    const int index = FindSymbolStyleVariantIndex(ch.cp, variants);
+    if (index >= 0) {
+      ++source_counts[index];
+    }
+  }
+  for (const Utf8CharForSymbolRestore& ch : zenz_chars) {
+    const int index = FindSymbolStyleVariantIndex(ch.cp, variants);
+    if (index >= 0) {
+      ++zenz_counts[index];
+    }
+  }
+
+  int active_source_variant_count = 0;
+  for (const int count : source_counts) {
+    if (count > 0) {
+      ++active_source_variant_count;
+    }
+  }
+  if (active_source_variant_count == 0) {
     return std::string(zenz_value);
+  }
+
+  std::vector<int> missing_counts(variants.size(), 0);
+  std::vector<int> excess_counts(variants.size(), 0);
+  bool needs_restore = false;
+  for (size_t i = 0; i < variants.size(); ++i) {
+    missing_counts[i] = std::max(0, source_counts[i] - zenz_counts[i]);
+    excess_counts[i] = std::max(0, zenz_counts[i] - source_counts[i]);
+    needs_restore = needs_restore || missing_counts[i] > 0;
+  }
+  if (!needs_restore) {
+    return std::string(zenz_value);
+  }
+
+  std::vector<std::string> default_replacements(variants.size());
+  for (size_t i = 0; i < variants.size(); ++i) {
+    if (missing_counts[i] > 0) {
+      default_replacements[i] =
+          FirstSymbolVariantBytes(source_chars, variants[i]);
+      if (default_replacements[i].empty()) {
+        missing_counts[i] = 0;
+      }
+    }
   }
 
   std::string restored;
   restored.reserve(zenz_value.size());
   for (size_t i = 0; i < zenz_chars.size(); ++i) {
     const Utf8CharForSymbolRestore& ch = zenz_chars[i];
-    const bool positional_restore =
-        i < source_chars.size() && IsJapaneseWaveDash(source_chars[i].cp);
+    const int current_index =
+        FindSymbolStyleVariantIndex(ch.cp, variants);
 
-    // If the source did not contain ASCII tilde at all, any extra ASCII tilde
-    // returned by Zenz is highly likely to be a normalized Japanese wave dash.
-    // If the source did contain ASCII tilde, avoid broad fallback replacement
-    // and only restore exact character positions to preserve intentional ASCII.
-    const bool safe_fallback_restore = source_ascii_tilde_count == 0;
+    int target_index = -1;
+    bool positional_restore = false;
+    if (current_index >= 0 && i < source_chars.size()) {
+      const int source_index =
+          FindSymbolStyleVariantIndex(source_chars[i].cp, variants);
+      if (source_index >= 0 && source_index != current_index &&
+          missing_counts[source_index] > 0) {
+        target_index = source_index;
+        positional_restore = true;
+      }
+    }
 
-    if (replacement_budget > 0 && IsAsciiTilde(ch.cp) &&
-        (positional_restore || safe_fallback_restore)) {
-      restored.append(positional_restore ? source_chars[i].bytes
-                                         : default_replacement);
-      --replacement_budget;
+    if (target_index < 0 && current_index >= 0 &&
+        excess_counts[current_index] > 0 && active_source_variant_count == 1) {
+      for (size_t j = 0; j < variants.size(); ++j) {
+        if (missing_counts[j] <= 0) {
+          continue;
+        }
+
+        const bool widening_from_ascii =
+            ch.cp <= 0x7F && variants[j] > 0x7F;
+        if (avoid_ascii_token_fallback_when_widening && widening_from_ascii &&
+            HasAsciiTokenNeighborForSymbolRestore(zenz_chars, i)) {
+          continue;
+        }
+
+        target_index = static_cast<int>(j);
+        break;
+      }
+    }
+
+    if (target_index >= 0) {
+      if (positional_restore) {
+        restored.append(source_chars[i].bytes);
+      } else {
+        restored.append(default_replacements[target_index]);
+      }
+      --missing_counts[target_index];
+      if (current_index >= 0 && excess_counts[current_index] > 0) {
+        --excess_counts[current_index];
+      }
       continue;
     }
 
     restored.append(ch.bytes);
   }
+
+  return restored;
+}
+
+std::string RestoreSymbolGroupStyleFromKeyOrMozc(
+    absl::string_view key,
+    absl::string_view mozc_value,
+    absl::string_view zenz_value,
+    const std::vector<char32_t>& variants,
+    bool avoid_ascii_token_fallback_when_widening) {
+  absl::string_view style_source;
+  if (ContainsAnySymbolStyleVariant(key, variants)) {
+    style_source = key;
+  } else if (ContainsAnySymbolStyleVariant(mozc_value, variants)) {
+    style_source = mozc_value;
+  } else {
+    return std::string(zenz_value);
+  }
+
+  return RestoreSymbolGroupStyle(style_source, zenz_value, variants,
+                                 avoid_ascii_token_fallback_when_widening);
+}
+
+}  // namespace
+
+std::string ZenzOutputValidator::RestoreUserVisibleSymbolStyle(
+    absl::string_view key,
+    absl::string_view mozc_value,
+    absl::string_view zenz_value) {
+  std::string restored(zenz_value);
+
+  // Preserve the user's visible orthographic choice.  This is not fullwidth
+  // normalization: if the source text used ASCII punctuation, a fullwidth Zenz
+  // response is repaired back to ASCII; if the source text used Japanese-width
+  // punctuation, an ASCII-normalized Zenz response is repaired back to that
+  // source style.
+  restored = RestoreSymbolGroupStyleFromKeyOrMozc(
+      key, mozc_value, restored, {U'~', U'～', U'〜'},
+      /*avoid_ascii_token_fallback_when_widening=*/false);
+  restored = RestoreSymbolGroupStyleFromKeyOrMozc(
+      key, mozc_value, restored, {U'(', U'（'},
+      /*avoid_ascii_token_fallback_when_widening=*/true);
+  restored = RestoreSymbolGroupStyleFromKeyOrMozc(
+      key, mozc_value, restored, {U')', U'）'},
+      /*avoid_ascii_token_fallback_when_widening=*/true);
+  restored = RestoreSymbolGroupStyleFromKeyOrMozc(
+      key, mozc_value, restored, {U'[', U'［'},
+      /*avoid_ascii_token_fallback_when_widening=*/true);
+  restored = RestoreSymbolGroupStyleFromKeyOrMozc(
+      key, mozc_value, restored, {U']', U'］'},
+      /*avoid_ascii_token_fallback_when_widening=*/true);
+  restored = RestoreSymbolGroupStyleFromKeyOrMozc(
+      key, mozc_value, restored, {U'{', U'｛'},
+      /*avoid_ascii_token_fallback_when_widening=*/true);
+  restored = RestoreSymbolGroupStyleFromKeyOrMozc(
+      key, mozc_value, restored, {U'}', U'｝'},
+      /*avoid_ascii_token_fallback_when_widening=*/true);
+  restored = RestoreSymbolGroupStyleFromKeyOrMozc(
+      key, mozc_value, restored, {U'!', U'！'},
+      /*avoid_ascii_token_fallback_when_widening=*/false);
+  restored = RestoreSymbolGroupStyleFromKeyOrMozc(
+      key, mozc_value, restored, {U'?', U'？'},
+      /*avoid_ascii_token_fallback_when_widening=*/false);
+  restored = RestoreSymbolGroupStyleFromKeyOrMozc(
+      key, mozc_value, restored, {U':', U'：'},
+      /*avoid_ascii_token_fallback_when_widening=*/true);
+  restored = RestoreSymbolGroupStyleFromKeyOrMozc(
+      key, mozc_value, restored, {U';', U'；'},
+      /*avoid_ascii_token_fallback_when_widening=*/true);
+  restored = RestoreSymbolGroupStyleFromKeyOrMozc(
+      key, mozc_value, restored, {U',', U'，'},
+      /*avoid_ascii_token_fallback_when_widening=*/true);
+  restored = RestoreSymbolGroupStyleFromKeyOrMozc(
+      key, mozc_value, restored, {U'.', U'．'},
+      /*avoid_ascii_token_fallback_when_widening=*/true);
 
   return restored;
 }

--- a/src/session/zenz_output_validator.h
+++ b/src/session/zenz_output_validator.h
@@ -29,11 +29,13 @@ class ZenzOutputValidator {
  public:
   ZenzValidationResult Validate(const ZenzValidationInput& input) const;
 
-  // Restores user-visible Japanese symbol style that Zenz may normalize to
-  // ASCII.  This currently protects wave-dash-like Japanese tildes: when the
-  // key or the original Mozc value contains U+FF5E FULLWIDTH TILDE or U+301C
-  // WAVE DASH, and Zenz returns U+007E ASCII TILDE instead, the returned value
-  // is restored before validation, display, commit, and feedback recording.
+  // Restores user-visible symbol style that Zenz may normalize. This preserves
+  // the user's current composition style instead of normalizing to either
+  // fullwidth or ASCII: if the key or original Mozc value used Japanese-width
+  // punctuation, ASCII-normalized Zenz punctuation is restored; if the source
+  // used ASCII punctuation, fullwidth Zenz punctuation is restored to ASCII.
+  // The returned value is used before validation, display, commit, and
+  // feedback recording.
   static std::string RestoreUserVisibleSymbolStyle(
       absl::string_view key,
       absl::string_view mozc_value,

--- a/src/session/zenz_output_validator_test.cc
+++ b/src/session/zenz_output_validator_test.cc
@@ -1,0 +1,88 @@
+// Copyright 2010-2021, Google Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "session/zenz_output_validator.h"
+
+#include "testing/gunit.h"
+
+namespace mozc::session {
+namespace {
+
+TEST(ZenzOutputValidatorTest, RestoreUserVisibleSymbolStyleFullwidthBrackets) {
+  EXPECT_EQ(ZenzOutputValidator::RestoreUserVisibleSymbolStyle(
+                "これは（てすと）です", "これは（テスト）です",
+                "これは(テスト)だと思います"),
+            "これは（テスト）だと思います");
+}
+
+TEST(ZenzOutputValidatorTest, RestoreUserVisibleSymbolStyleAsciiBrackets) {
+  EXPECT_EQ(ZenzOutputValidator::RestoreUserVisibleSymbolStyle(
+                "これは(test)です", "これは(test)です",
+                "これは（test）です"),
+            "これは(test)です");
+}
+
+TEST(ZenzOutputValidatorTest, RestoreUserVisibleSymbolStyleMixedBrackets) {
+  EXPECT_EQ(ZenzOutputValidator::RestoreUserVisibleSymbolStyle(
+                "（A）と(B)", "（A）と(B)", "(A)と(B)"),
+            "（A）と(B)");
+}
+
+TEST(ZenzOutputValidatorTest, RestoreUserVisibleSymbolStyleQuestionAndBang) {
+  EXPECT_EQ(ZenzOutputValidator::RestoreUserVisibleSymbolStyle(
+                "本当ですか？！", "本当ですか？！", "本当ですか?!"),
+            "本当ですか？！");
+
+  EXPECT_EQ(ZenzOutputValidator::RestoreUserVisibleSymbolStyle(
+                "OK?!", "OK?!", "OK？！"),
+            "OK?!");
+}
+
+TEST(ZenzOutputValidatorTest, RestoreUserVisibleSymbolStyleKeepsWaveDash) {
+  EXPECT_EQ(ZenzOutputValidator::RestoreUserVisibleSymbolStyle(
+                "ほ〜", "ほ〜", "ほ~"),
+            "ほ〜");
+
+  EXPECT_EQ(ZenzOutputValidator::RestoreUserVisibleSymbolStyle(
+                "ほ~", "ほ~", "ほ〜"),
+            "ほ~");
+}
+
+TEST(ZenzOutputValidatorTest, RestoreUserVisibleSymbolStyleFullwidthAsciiPunct) {
+  EXPECT_EQ(ZenzOutputValidator::RestoreUserVisibleSymbolStyle(
+                "注：A；B，C．", "注：A；B，C．", "注:A;B,C."),
+            "注：A；B，C．");
+
+  EXPECT_EQ(ZenzOutputValidator::RestoreUserVisibleSymbolStyle(
+                "note:A;B,C.", "note:A;B,C.", "note：A；B，C．"),
+            "note:A;B,C.");
+}
+
+}  // namespace
+}  // namespace mozc::session


### PR DESCRIPTION
## 概要

Zenz live correction の採用時に、ユーザーが現在の未確定文字列または通常 Mozc ライブ変換結果で使っていた記号幅・記号スタイルを保持するようにしました。

これにより、Zenz が `（ ）` / `( )`、`？` / `?`、`！` / `!`、`：` / `:` などを正規化して返した場合でも、採用前に元のユーザー可視スタイルへ復元します。

この処理は全角化ではなく、source style preservation です。半角で入力されていた記号は半角のまま、全角で入力されていた記号は全角のまま維持します。

## 変更内容

- `RestoreUserVisibleSymbolStyle` を波ダッシュ系専用から、括弧・疑問符・感嘆符・一部の全角 ASCII 記号にも対応する処理へ拡張
- `key` を優先し、なければ通常 Mozc ライブ変換結果を style source として使用
- mixed style では位置対応による復元を優先
- URL / path / ASCII token 風の文脈では、不用意な ASCII 記号の全角化を抑制
- `zenz_output_validator_test` を追加
- README に Zenz 採用時の記号スタイル保存について追記

## 確認

- `//session:zenz_output_validator_test`
- `//session:session_test`