### PR TITLE
Avoid ruby window overlap with passive suggestions

### DIFF
--- a/src/renderer/win32/ruby_window.cc
+++ b/src/renderer/win32/ruby_window.cc
@@ -22,7 +22,9 @@ namespace {
 // Theme-aware translucent pill UI.
 constexpr int kPaddingX = 14;
 constexpr int kPaddingY = 6;
-constexpr int kGapFromComposition = 0;
+// Keep a real gap from the host application text. A zero gap makes a
+// topmost overlay visually merge with, or cover, editor glyphs.
+constexpr int kGapFromComposition = 4;
 constexpr int kFontPointSize = 13;
 constexpr uint32_t kDefaultDpi = 96;
 
@@ -135,6 +137,25 @@ int GetPreeditWidth(const commands::RendererCommand& command) {
   const commands::RendererCommand::Rectangle& rect =
       command.preedit_rectangle();
   return std::max(0, rect.right() - rect.left());
+}
+
+bool Intersects(const RECT& lhs, const RECT& rhs) {
+  return lhs.left < rhs.right && rhs.left < lhs.right &&
+         lhs.top < rhs.bottom && rhs.top < lhs.bottom;
+}
+
+bool IsUsableRubyRect(const RECT& rect, const RECT& work_area,
+                      const RECT* avoid_rect) {
+  if (rect.left >= rect.right || rect.top >= rect.bottom) {
+    return false;
+  }
+  if (rect.top < work_area.top || rect.bottom > work_area.bottom) {
+    return false;
+  }
+  if (avoid_rect != nullptr && Intersects(rect, *avoid_rect)) {
+    return false;
+  }
+  return true;
 }
 
 }  // namespace
@@ -342,7 +363,8 @@ SIZE RubyWindow::MeasureText() const {
   return size;
 }
 
-void RubyWindow::OnUpdate(const commands::RendererCommand& command) {
+void RubyWindow::OnUpdate(const commands::RendererCommand& command,
+                          const RECT* avoid_rect) {
   if (!command.visible()) {
     Hide();
     return;
@@ -377,27 +399,47 @@ void RubyWindow::OnUpdate(const commands::RendererCommand& command) {
     return;
   }
 
+  const RendererStyleHandler::RubyWindowStyle theme = GetRubyWindowTheme();
+  const int gap = ScaleByPercent(kGapFromComposition, theme.size_percent);
+
   const RECT work_area = GetWorkAreaForPoint(base_point);
 
-  // Horizontally center over the preedit rectangle when possible.
-  // If preedit width is unavailable, align to the preedit/caret x position.
+  // Keep the left edge stable while the reading text grows. Centering a ruby
+  // chip that is wider than the preedit makes the window expand both left and
+  // right on every keystroke, which is visually noisy in live conversion.
   const int preedit_width = GetPreeditWidth(command);
 
   int left = base_point.x;
-  if (preedit_width > 0) {
+  if (preedit_width > window_size_.cx) {
     left = base_point.x + (preedit_width - window_size_.cx) / 2;
   }
-
-  // Attach tightly above the preedit.
-  int top = base_point.y - window_size_.cy - kGapFromComposition;
-
-  // If there is no room above, place below the composition line.
-  if (top < work_area.top) {
-    top = base_point.y + line_height + kGapFromComposition;
-  }
-
   left = ClampInt(left, work_area.left, work_area.right - window_size_.cx);
-  top = ClampInt(top, work_area.top, work_area.bottom - window_size_.cy);
+
+  const int above_top = base_point.y - window_size_.cy - gap;
+  const int below_top = base_point.y + line_height + gap;
+
+  const auto ruby_rect_at = [&](int top) {
+    return RECT{left, top, left + window_size_.cx, top + window_size_.cy};
+  };
+
+  const auto try_place = [&](int top, int* chosen_top) {
+    const RECT rect = ruby_rect_at(top);
+    if (!IsUsableRubyRect(rect, work_area, avoid_rect)) {
+      return false;
+    }
+    *chosen_top = top;
+    return true;
+  };
+
+  int top = 0;
+  // Prefer the conventional ruby-like placement above the preedit.  Use below
+  // only when the above side is unavailable or occupied by candidate/suggestion
+  // UI.  If neither side is usable, hide the ruby window rather than overlapping
+  // other renderer UI.
+  if (!try_place(above_top, &top) && !try_place(below_top, &top)) {
+    Hide();
+    return;
+  }
 
   const int radius = ScaleCornerRadius(
       RendererStyleHandler::GetRubyWindowStyle().corner_radius,

--- a/src/renderer/win32/ruby_window.h
+++ b/src/renderer/win32/ruby_window.h
@@ -39,7 +39,8 @@ class RubyWindow
   void Initialize();
   void Destroy();
   void Hide();
-  void OnUpdate(const commands::RendererCommand& command);
+  void OnUpdate(const commands::RendererCommand& command,
+                const RECT* avoid_rect = nullptr);
 
  private:
   LRESULT OnEraseBkgnd(UINT msg_id, WPARAM wparam, LPARAM lparam,

--- a/src/renderer/win32/window_manager.cc
+++ b/src/renderer/win32/window_manager.cc
@@ -69,6 +69,8 @@ WindowManager::WindowManager()
       send_command_interface_(nullptr),
       last_position_(kInvalidMousePosition),
       last_live_conversion_passive_suggestion_visible_(false),
+      last_live_conversion_passive_suggestion_rect_(),
+      has_last_live_conversion_passive_suggestion_rect_(false),
       candidates_finger_print_(0),
       thread_id_(0) {}
 
@@ -91,6 +93,7 @@ void WindowManager::Initialize() {
 
 void WindowManager::AsyncHideAllWindows() {
   last_live_conversion_passive_suggestion_visible_ = false;
+  has_last_live_conversion_passive_suggestion_rect_ = false;
   cascading_window_->ShowWindowAsync(SW_HIDE);
   main_window_->ShowWindowAsync(SW_HIDE);
   infolist_window_->ShowWindowAsync(SW_HIDE);
@@ -99,6 +102,7 @@ void WindowManager::AsyncHideAllWindows() {
 
 void WindowManager::AsyncQuitAllWindows() {
   last_live_conversion_passive_suggestion_visible_ = false;
+  has_last_live_conversion_passive_suggestion_rect_ = false;
   cascading_window_->PostMessage(WM_CLOSE, 0, 0);
   main_window_->PostMessage(WM_CLOSE, 0, 0);
   infolist_window_->PostMessage(WM_CLOSE, 0, 0);
@@ -107,6 +111,7 @@ void WindowManager::AsyncQuitAllWindows() {
 
 void WindowManager::DestroyAllWindows() {
   last_live_conversion_passive_suggestion_visible_ = false;
+  has_last_live_conversion_passive_suggestion_rect_ = false;
   if (main_window_->IsWindow()) {
     main_window_->DestroyWindow();
   }
@@ -122,6 +127,7 @@ void WindowManager::DestroyAllWindows() {
 
 void WindowManager::HideAllWindows() {
   last_live_conversion_passive_suggestion_visible_ = false;
+  has_last_live_conversion_passive_suggestion_rect_ = false;
   main_window_->ShowWindow(SW_HIDE);
   cascading_window_->ShowWindow(SW_HIDE);
   indicator_window_->Hide();
@@ -138,6 +144,7 @@ void WindowManager::UpdateLayout(const commands::RendererCommand& command) {
   // Hide all UI elements if |command.visible()| is false.
   if (!command.visible()) {
     last_live_conversion_passive_suggestion_visible_ = false;
+    has_last_live_conversion_passive_suggestion_rect_ = false;
     cascading_window_->ShowWindow(SW_HIDE);
     main_window_->ShowWindow(SW_HIDE);
     indicator_window_->Hide();
@@ -150,8 +157,6 @@ void WindowManager::UpdateLayout(const commands::RendererCommand& command) {
   // for all |RendererCommand::UPDATE| renderer messages.
   DCHECK(command.has_output());
   const commands::Output& output = command.output();
-
-  ruby_window_->OnUpdate(command);
 
   // Live conversion normally uses only the ruby overlay and should keep the
   // ordinary candidate windows hidden.  However, Mozkey may attach a passive
@@ -172,11 +177,24 @@ void WindowManager::UpdateLayout(const commands::RendererCommand& command) {
       (output.zenz_live_correction_pending() ||
        output.zenz_live_correction_applied() ||
        output.has_zenz_live_correction_debug());
+
+  const bool should_defer_ruby_update =
+      is_live_conversion_passive_suggestion;
+  const RECT* ruby_avoid_rect = nullptr;
+  if (should_keep_previous_live_conversion_passive_suggestion &&
+      has_last_live_conversion_passive_suggestion_rect_) {
+    ruby_avoid_rect = &last_live_conversion_passive_suggestion_rect_;
+  }
+  if (!should_defer_ruby_update) {
+    ruby_window_->OnUpdate(command, ruby_avoid_rect);
+  }
+
   if (output.live_conversion() && !is_live_conversion_passive_suggestion) {
     cascading_window_->ShowWindow(SW_HIDE);
     if (!should_keep_previous_live_conversion_passive_suggestion) {
       main_window_->ShowWindow(SW_HIDE);
       last_live_conversion_passive_suggestion_visible_ = false;
+      has_last_live_conversion_passive_suggestion_rect_ = false;
     }
     indicator_window_->Hide();
     infolist_window_->DelayHide(0);
@@ -184,6 +202,7 @@ void WindowManager::UpdateLayout(const commands::RendererCommand& command) {
   }
   if (!output.live_conversion()) {
     last_live_conversion_passive_suggestion_visible_ = false;
+    has_last_live_conversion_passive_suggestion_rect_ = false;
   }
 
   // We assume |application_info| exists in the renderer command
@@ -272,6 +291,9 @@ void WindowManager::UpdateLayout(const commands::RendererCommand& command) {
     cascading_window_->ShowWindow(SW_HIDE);
     main_window_->ShowWindow(SW_HIDE);
     infolist_window_->DelayHide(0);
+    if (should_defer_ruby_update) {
+      ruby_window_->OnUpdate(command);
+    }
     return;
   }
 
@@ -334,6 +356,15 @@ void WindowManager::UpdateLayout(const commands::RendererCommand& command) {
         WindowUtil::GetWindowRectForMainWindowFromTargetPointAndPreedit(
             new_target_point, preedit_rect, main_window_size,
             main_window_zero_point, working_area, vertical);
+  }
+
+  if (should_defer_ruby_update) {
+    last_live_conversion_passive_suggestion_rect_ = {
+        main_window_rect.Left(), main_window_rect.Top(),
+        main_window_rect.Right(), main_window_rect.Bottom()};
+    has_last_live_conversion_passive_suggestion_rect_ = true;
+    ruby_window_->OnUpdate(command,
+                           &last_live_conversion_passive_suggestion_rect_);
   }
 
   const DWORD set_windows_pos_flags = SWP_NOACTIVATE | SWP_SHOWWINDOW;

--- a/src/renderer/win32/window_manager.h
+++ b/src/renderer/win32/window_manager.h
@@ -78,6 +78,8 @@ class WindowManager {
   // without candidate_window; in that case the renderer can keep the existing
   // passive suggestion window visible instead of hiding it.
   bool last_live_conversion_passive_suggestion_visible_;
+  RECT last_live_conversion_passive_suggestion_rect_;
+  bool has_last_live_conversion_passive_suggestion_rect_;
   int candidates_finger_print_;
   DWORD thread_id_;
 };


### PR DESCRIPTION
## 概要

この PR では、ライブ変換中に表示される Ruby window が passive suggestion window と重ならないようにしました。

Mozkey ではライブ変換中でもサジェストを表示できるため、Ruby window と passive suggestion window が同時に表示される場合があります。従来は Ruby window が候補 / サジェスト側の表示矩形を考慮せずに先に配置されるため、特に live conversion や Zenz live correction の更新タイミングで、Ruby window がサジェストに重なることがありました。

## 変更内容

* RubyWindow::OnUpdate に avoidance rect を渡せるように変更
* Ruby window は従来どおり上側表示を優先
* 上側が候補 / サジェスト UI と重なる場合は下側へ fallback
* 上下どちらも使えない場合は Ruby window を非表示
* live conversion passive suggestion の表示矩形を WindowManager 側で保持
* Zenz live correction の再描画で candidate_window が一時的に無い場合でも、直前の passive suggestion rect を Ruby window の回避対象として使うように変更

## 意図

Ruby window と候補 / サジェスト表示は、どちらも入力中の判断を補助する UI です。

ただし、両者が同じ位置に重なると、読みの確認と候補選択のどちらも見づらくなります。そのため、この PR では両者を重ねて表示するのではなく、Ruby window を上側優先で配置しつつ、候補 / サジェストと衝突する場合は下側へ fallback するようにしました。

上側・下側のどちらにも安全に表示できない場合は、Ruby window を一時的に非表示にします。これにより、候補 / サジェストとの重なりによる視認性低下を避けます。

この変更により、ライブ変換中および Zenz live correction 中に、Ruby window が passive suggestion window に被さるケースを抑制します。

## 確認内容

* `//renderer/win32:win32_renderer_util_test`
* `//renderer:window_util_test`
* Windows release package build
* 実機確認

  * ライブ変換中、Ruby window と passive suggestion window が重ならないこと
  * Zenz 補正後に previous passive suggestion が保持される場合でも Ruby window が重ならないこと
  * 通常時は Ruby window が上側表示を優先すること

## 補足

Zed など一部 TSF アプリで、preedit_rectangle が得られず composition_target のみを基準に Ruby window を配置する場合、本文との重なりが残るケースがあります。

この問題は host editor 側の行矩形 / preedit 矩形取得に関わる別問題であり、本 PR では passive suggestion window との衝突回避に範囲を絞っています。

