### PR TITLE
Suppress shifted ASCII auto suggestions when dictionary suggest is off

### DIFF
--- a/src/composer/composer.cc
+++ b/src/composer/composer.cc
@@ -551,6 +551,7 @@ Composer::Composer(std::shared_ptr<const Table> table,
       comeback_input_mode_(transliteration::HIRAGANA),
       input_field_type_(commands::Context::NORMAL),
       shifted_sequence_count_(0),
+      is_in_shifted_ascii_revert_context_(false),
       max_length_(kMaxPreeditLength),
       request_(std::move(request)),
       config_(std::move(config)),
@@ -603,17 +604,20 @@ void Composer::SetTable(std::shared_ptr<const Table> table) {
 void Composer::SetRequest(std::shared_ptr<const commands::Request> request) {
   DCHECK(request);
   request_ = std::move(request);
+  is_in_shifted_ascii_revert_context_ = false;
 }
 
 void Composer::SetConfig(std::shared_ptr<const config::Config> config) {
   DCHECK(config);
   config_ = std::move(config);
+  is_in_shifted_ascii_revert_context_ = false;
 }
 
 void Composer::SetInputMode(transliteration::TransliterationType mode) {
   comeback_input_mode_ = mode;
   input_mode_ = mode;
   shifted_sequence_count_ = 0;
+  is_in_shifted_ascii_revert_context_ = false;
   is_new_input_ = true;
   composition_.SetInputMode(GetTransliterator(mode));
 }
@@ -624,6 +628,7 @@ void Composer::SetTemporaryInputMode(
   comeback_input_mode_ = input_mode_;
   input_mode_ = mode;
   shifted_sequence_count_ = 0;
+  is_in_shifted_ascii_revert_context_ = false;
   is_new_input_ = true;
   composition_.SetInputMode(GetTransliterator(mode));
 }
@@ -640,6 +645,7 @@ void Composer::UpdateInputMode() {
       //   "A|B" and "あ|い", the input mode follows the character type.
       input_mode_ = GetTransliterationType(current_t12r, comeback_input_mode_);
       shifted_sequence_count_ = 0;
+      is_in_shifted_ascii_revert_context_ = false;
       is_new_input_ = true;
       composition_.SetInputMode(GetTransliterator(input_mode_));
       return;
@@ -688,6 +694,7 @@ void Composer::ApplyTemporaryInputMode(const absl::string_view input,
   // When input is not an ASCII code, reset the input mode to the one before
   // temporary input mode.
   if (OneCharLen(input.front()) != 1) {
+    is_in_shifted_ascii_revert_context_ = false;
     // Call SetInputMode() only when the current input mode is temporary, which
     // is detected by the if-condition below.  Without this check,
     // SetInputMode() is called always for multi-byte charactesrs.  This causes
@@ -709,6 +716,7 @@ void Composer::ApplyTemporaryInputMode(const absl::string_view input,
       (!caps_locked && ('a' <= key && key <= 'z'));
 
   if (alpha_with_shift) {
+    is_in_shifted_ascii_revert_context_ = false;
     if (switch_mode == config::Config::ASCII_INPUT_MODE) {
       if (input_mode_ == transliteration::HALF_ASCII ||
           input_mode_ == transliteration::FULL_ASCII) {
@@ -730,6 +738,7 @@ void Composer::ApplyTemporaryInputMode(const absl::string_view input,
     if (shifted_sequence_count_ > 1 &&
         switch_mode == config::Config::ASCII_INPUT_MODE) {
       SetInputMode(comeback_input_mode_);
+      is_in_shifted_ascii_revert_context_ = true;
     }
     if (switch_mode == config::Config::KATAKANA_INPUT_MODE) {
       SetInputMode(comeback_input_mode_);
@@ -740,6 +749,7 @@ void Composer::ApplyTemporaryInputMode(const absl::string_view input,
     // because "Continuous shifted input" feature should be reset
     // when the input meets non-alphabet character.
     shifted_sequence_count_ = 0;
+    is_in_shifted_ascii_revert_context_ = false;
   }
 }
 
@@ -1372,7 +1382,10 @@ bool Composer::TransformCharactersForNumbers(std::string* query) {
   return true;
 }
 
-void Composer::SetNewInput() { is_new_input_ = true; }
+void Composer::SetNewInput() {
+  is_in_shifted_ascii_revert_context_ = false;
+  is_new_input_ = true;
+}
 
 bool Composer::IsToggleable() const {
   // When |is_new_input_| is true, a new chunk is always created and, hence, key

--- a/src/composer/composer.h
+++ b/src/composer/composer.h
@@ -355,6 +355,9 @@ class Composer final {
 
   bool is_new_input() const { return is_new_input_; }
   size_t shifted_sequence_count() const { return shifted_sequence_count_; }
+  bool is_in_shifted_ascii_revert_context() const {
+    return is_in_shifted_ascii_revert_context_;
+  }
   absl::string_view source_text() const { return source_text_; }
   std::string* mutable_source_text() { return &source_text_; }
   void set_source_text(absl::string_view source_text);
@@ -391,6 +394,12 @@ class Composer final {
   commands::Context::InputFieldType input_field_type_;
 
   size_t shifted_sequence_count_;
+
+  // True while the current ASCII-letter run follows a reverted temporary
+  // shifted ASCII sequence.  This is a semantic latch for the pattern where
+  // two or more shifted alphabet keys temporarily enter ASCII mode, and the
+  // following unshifted alphabet key returns input to the comeback mode.
+  bool is_in_shifted_ascii_revert_context_;
 
   // The original text for the composition.  The value is usually
   // empty, and used for reverse conversion.

--- a/src/composer/composer_test.cc
+++ b/src/composer/composer_test.cc
@@ -97,6 +97,8 @@ void ExpectSameComposer(const Composer& lhs, const Composer& rhs) {
   EXPECT_EQ(lhs.GetOutputMode(), rhs.GetOutputMode());
   EXPECT_EQ(lhs.GetComebackInputMode(), rhs.GetComebackInputMode());
   EXPECT_EQ(lhs.shifted_sequence_count(), rhs.shifted_sequence_count());
+  EXPECT_EQ(lhs.is_in_shifted_ascii_revert_context(),
+            rhs.is_in_shifted_ascii_revert_context());
   EXPECT_EQ(lhs.source_text(), rhs.source_text());
   EXPECT_EQ(lhs.max_length(), rhs.max_length());
   EXPECT_EQ(lhs.GetInputFieldType(), rhs.GetInputFieldType());
@@ -1206,6 +1208,38 @@ TEST_F(ComposerTest, ShiftKeyOperation) {
 
     EXPECT_EQ(composer_->GetStringForPreedit(), "Aa");
   }
+}
+
+TEST_F(ComposerTest, ShiftedAsciiRevertContext) {
+  table_->AddRule("a", "あ", "");
+  config_->set_shift_key_mode_switch(Config::ASCII_INPUT_MODE);
+
+  composer_->Reset();
+  composer_->SetInputMode(transliteration::HIRAGANA);
+
+  ASSERT_TRUE(InsertKey("A", composer_.get()));
+  EXPECT_FALSE(composer_->is_in_shifted_ascii_revert_context());
+
+  ASSERT_TRUE(InsertKey("A", composer_.get()));
+  EXPECT_FALSE(composer_->is_in_shifted_ascii_revert_context());
+
+  ASSERT_TRUE(InsertKey("a", composer_.get()));
+  EXPECT_TRUE(composer_->is_in_shifted_ascii_revert_context());
+  EXPECT_EQ(composer_->GetInputMode(), transliteration::HIRAGANA);
+  EXPECT_EQ(composer_->GetStringForPreedit(), "AAあ");
+
+  // Keep the latch for the following unshifted alphabet run.  This lets the
+  // session suppress the whole passive ASCII-rescue suggestion window, not only
+  // the first letter after the temporary ASCII mode is reverted.
+  ASSERT_TRUE(InsertKey("a", composer_.get()));
+  EXPECT_TRUE(composer_->is_in_shifted_ascii_revert_context());
+  EXPECT_EQ(composer_->GetStringForPreedit(), "AAああ");
+
+  ASSERT_TRUE(InsertKey(".", composer_.get()));
+  EXPECT_FALSE(composer_->is_in_shifted_ascii_revert_context());
+
+  ASSERT_TRUE(InsertKey("A", composer_.get()));
+  EXPECT_FALSE(composer_->is_in_shifted_ascii_revert_context());
 }
 
 TEST_F(ComposerTest, ShiftKeyOperationForKatakana) {

--- a/src/session/session.cc
+++ b/src/session/session.cc
@@ -4493,6 +4493,12 @@ void Session::CancelLiveConversionForEditing() {
   context_->mutable_converter()->Cancel();
 }
 
+namespace {
+bool ShouldSuppressShiftedAsciiAutoSuggestion(
+    const config::Config& config,
+    const composer::Composer& composer);
+}  // namespace
+
 bool Session::MaybeStartLiveConversion(commands::Command* command) {
   if (!context_->GetConfig().use_live_conversion()) {
     return false;
@@ -4602,7 +4608,16 @@ bool Session::MaybeStartLiveConversion(commands::Command* command) {
     return true;
   }
 
-  if (!AttachLiveConversionSuggestionCandidateWindow(
+  const bool should_suppress_shifted_ascii_suggestion =
+      ShouldSuppressShiftedAsciiAutoSuggestion(context_->GetConfig(),
+                                               context_->composer());
+
+  if (should_suppress_shifted_ascii_suggestion) {
+    live_conversion_suggestion_candidate_window_.Clear();
+    pending_live_conversion_suggestion_candidate_window_.Clear();
+    command->mutable_output()->clear_candidate_window();
+  } else if (
+      !AttachLiveConversionSuggestionCandidateWindow(
           live_conversion_suggestion_input, command->mutable_output()) &&
       pending_live_conversion_suggestion_candidate_window.candidate_size() > 0) {
     live_conversion_suggestion_candidate_window_ =
@@ -7435,10 +7450,73 @@ bool SuppressSuggestion(const commands::Input& input) {
   }
   return false;
 }
+
+bool IsAsciiUpperAlpha(const char c) {
+  return 'A' <= c && c <= 'Z';
+}
+
+bool IsAsciiLowerAlpha(const char c) {
+  return 'a' <= c && c <= 'z';
+}
+
+bool LooksLikeShiftedAsciiRomanizedSuggestionContext(
+    const composer::Composer& composer) {
+  const transliteration::TransliterationType input_mode =
+      composer.GetInputMode();
+  if (input_mode == transliteration::HALF_ASCII ||
+      input_mode == transliteration::FULL_ASCII) {
+    return false;
+  }
+
+  const std::string raw = composer.GetRawString();
+  if (raw.size() < 3 || !IsAsciiUpperAlpha(raw[0]) ||
+      !IsAsciiUpperAlpha(raw[1])) {
+    return false;
+  }
+
+  bool has_lower_alpha = false;
+  for (const char c : raw) {
+    if (static_cast<unsigned char>(c) >= 0x80) {
+      return false;
+    }
+    if (IsAsciiLowerAlpha(c)) {
+      has_lower_alpha = true;
+    }
+  }
+  if (!has_lower_alpha) {
+    return false;
+  }
+
+  // Example:
+  //   raw     = "AIde"
+  //   preedit = "AI + Japanese text"
+  //
+  // This is the ambiguity caused by the shifted ASCII sequence being reverted
+  // to Japanese input.  When dictionary suggest is disabled, do not surface the
+  // raw ASCII rescue candidate automatically.
+  return raw != composer.GetStringForPreedit();
+}
+
+bool ShouldSuppressShiftedAsciiAutoSuggestion(
+    const config::Config& config,
+    const composer::Composer& composer) {
+  if (config.use_dictionary_suggest()) {
+    return false;
+  }
+  return composer.is_in_shifted_ascii_revert_context() ||
+         LooksLikeShiftedAsciiRomanizedSuggestionContext(composer);
+}
 }  // namespace
 
 bool Session::Suggest(const commands::Input& input) {
   if (SuppressSuggestion(input)) {
+    return false;
+  }
+
+  if (ShouldSuppressShiftedAsciiAutoSuggestion(context_->GetConfig(),
+                                               context_->composer())) {
+    live_conversion_suggestion_candidate_window_.Clear();
+    pending_live_conversion_suggestion_candidate_window_.Clear();
     return false;
   }
 
@@ -7478,6 +7556,13 @@ bool Session::AttachLiveConversionSuggestionCandidateWindow(
   output->clear_candidate_window();
 
   if (SuppressSuggestion(input)) {
+    return false;
+  }
+
+  if (ShouldSuppressShiftedAsciiAutoSuggestion(context_->GetConfig(),
+                                               context_->composer())) {
+    live_conversion_suggestion_candidate_window_.Clear();
+    pending_live_conversion_suggestion_candidate_window_.Clear();
     return false;
   }
 
@@ -7531,10 +7616,17 @@ bool Session::AttachLiveConversionSuggestionCandidateWindow(
 }
 
 bool Session::AttachCachedLiveConversionSuggestionCandidateWindow(
-    commands::Output* output) const {
+    commands::Output* output) {
   DCHECK(output);
 
   output->clear_candidate_window();
+
+  if (ShouldSuppressShiftedAsciiAutoSuggestion(context_->GetConfig(),
+                                               context_->composer())) {
+    live_conversion_suggestion_candidate_window_.Clear();
+    pending_live_conversion_suggestion_candidate_window_.Clear();
+    return false;
+  }
 
   const commands::CandidateWindow* candidate_window = nullptr;
   if (live_conversion_suggestion_candidate_window_.has_category() &&

--- a/src/session/session.h
+++ b/src/session/session.h
@@ -535,7 +535,7 @@ class Session {
       const mozc::commands::Input& input,
       mozc::commands::Output* output);
   bool AttachCachedLiveConversionSuggestionCandidateWindow(
-      mozc::commands::Output* output) const;
+      mozc::commands::Output* output);
   bool CommitLiveConversionResult(mozc::commands::Command* command);
   bool CommitPendingLiveConversionDisplayDirectly(
       mozc::commands::Command* command);

--- a/src/session/session_test.cc
+++ b/src/session/session_test.cc
@@ -99,6 +99,10 @@ class SessionTestPeer : testing::TestPeer<Session> {
   PEER_METHOD(DiscardPendingDirectCommitLearning);
   PEER_METHOD(HandlePendingDirectCommitLearningForKeyEvent);
   PEER_METHOD(HandlePendingDirectCommitLearningForSessionCommand);
+  PEER_METHOD(Suggest);
+  PEER_METHOD(MaybeStartLiveConversion);
+  PEER_METHOD(AttachLiveConversionSuggestionCandidateWindow);
+  PEER_METHOD(AttachCachedLiveConversionSuggestionCandidateWindow);
 
   PEER_VARIABLE(context_);
   PEER_VARIABLE(undo_contexts_);
@@ -108,6 +112,8 @@ class SessionTestPeer : testing::TestPeer<Session> {
   PEER_VARIABLE(live_conversion_preedit_);
   PEER_VARIABLE(live_conversion_value_);
   PEER_VARIABLE(live_conversion_preedit_output_);
+  PEER_VARIABLE(pending_live_conversion_suggestion_candidate_window_);
+  PEER_VARIABLE(live_conversion_suggestion_candidate_window_);
   PEER_VARIABLE(zenz_live_key_);
   PEER_VARIABLE(zenz_live_value_);
   PEER_VARIABLE(zenz_live_mozc_value_);
@@ -1743,6 +1749,123 @@ TEST_F(SessionTest, LiveConversionAttachesPassiveSuggestionCandidateWindow) {
   EXPECT_FALSE(session_peer.live_conversion_active_());
   EXPECT_FALSE(command.output().live_conversion());
   EXPECT_PREEDIT("阿", command);
+}
+
+TEST_F(SessionTest,
+       ShiftedAsciiRevertSuppressesPassiveSuggestionWhenDictionarySuggestOff) {
+  MockEngine engine;
+  std::shared_ptr<MockConverter> converter = CreateEngineConverterMock(&engine);
+
+  Session session(engine);
+  SessionTestPeer session_peer(session);
+  InitSessionToPrecomposition(&session);
+
+  config::Config config;
+  config::ConfigHandler::GetDefaultConfig(&config);
+  config.set_use_dictionary_suggest(false);
+  config.set_shift_key_mode_switch(config::Config::ASCII_INPUT_MODE);
+  session.SetConfig(config);
+
+  commands::Command command;
+  ASSERT_TRUE(SendKey("A", &session, &command));
+  ASSERT_TRUE(SendKey("A", &session, &command));
+  ASSERT_TRUE(SendKey("a", &session, &command));
+  ASSERT_TRUE(session.context()
+                  .composer()
+                  .is_in_shifted_ascii_revert_context());
+
+  commands::Input input;
+  input.set_type(commands::Input::SEND_KEY);
+  commands::Output output;
+
+  EXPECT_CALL(*converter, StartPrediction(_, _)).Times(0);
+  EXPECT_FALSE(session_peer.Suggest(input));
+  EXPECT_FALSE(output.has_candidate_window());
+
+  EXPECT_FALSE(session_peer.AttachLiveConversionSuggestionCandidateWindow(
+      input, &output));
+  EXPECT_FALSE(output.has_candidate_window());
+
+  commands::CandidateWindow& cached_window =
+      session_peer.live_conversion_suggestion_candidate_window_();
+  cached_window.set_category(commands::SUGGESTION);
+  cached_window.add_candidate()->set_value("AAa");
+
+  EXPECT_FALSE(session_peer.AttachCachedLiveConversionSuggestionCandidateWindow(
+      &output));
+  EXPECT_FALSE(output.has_candidate_window());
+  EXPECT_EQ(session_peer.live_conversion_suggestion_candidate_window_()
+                .candidate_size(),
+            0);
+}
+
+TEST_F(
+    SessionTest,
+    ShiftedAsciiRevertSuppressesPendingSuggestionRestoreInMaybeStartLiveConversion) {
+  MockEngine engine;
+  std::shared_ptr<MockConverter> converter = CreateEngineConverterMock(&engine);
+
+  Session session(engine);
+  SessionTestPeer session_peer(session);
+  InitSessionToPrecomposition(&session);
+
+  config::Config config;
+  config::ConfigHandler::GetDefaultConfig(&config);
+  config.set_use_live_conversion(false);
+  config.set_use_dictionary_suggest(false);
+  config.set_shift_key_mode_switch(config::Config::ASCII_INPUT_MODE);
+  session.SetConfig(config);
+
+  commands::Command command;
+  ASSERT_TRUE(SendKey("A", &session, &command));
+  ASSERT_TRUE(SendKey("I", &session, &command));
+  ASSERT_TRUE(SendKey("d", &session, &command));
+  ASSERT_TRUE(SendKey("e", &session, &command));
+  ASSERT_EQ(session.context().state(), ImeContext::COMPOSITION);
+
+  const std::string raw = session.context().composer().GetRawString();
+  const std::string preedit =
+      session.context().composer().GetStringForPreedit();
+  ASSERT_EQ(raw, "AIde");
+  ASSERT_NE(preedit, raw);
+
+  // Re-applying the config clears the transient Composer latch.  This verifies
+  // that the raw/preedit shape guard also suppresses delayed pending restore,
+  // which covers cases such as AInara and editing/backspace paths where the
+  // original input-path latch is no longer reliable.
+  config.set_use_live_conversion(true);
+  session.SetConfig(config);
+  ASSERT_FALSE(
+      session.context().composer().is_in_shifted_ascii_revert_context());
+
+  commands::CandidateWindow& pending_window =
+      session_peer.pending_live_conversion_suggestion_candidate_window_();
+  pending_window.set_category(commands::SUGGESTION);
+  pending_window.add_candidate()->set_value(raw);
+
+  Segments live_segments;
+  Segment* live_segment = live_segments.add_segment();
+  live_segment->set_key(session.context().composer().GetQueryForConversion());
+  AddCandidate(session.context().composer().GetQueryForConversion(), preedit,
+               live_segment);
+
+  EXPECT_CALL(*converter, StartConversion(_, _))
+      .Times(1)
+      .WillOnce(DoAll(SetArgPointee<1>(live_segments), Return(true)));
+  EXPECT_CALL(*converter, StartPrediction(_, _)).Times(0);
+
+  command.Clear();
+  ASSERT_TRUE(session_peer.MaybeStartLiveConversion(&command));
+
+  EXPECT_EQ(session.context().state(), ImeContext::CONVERSION);
+  EXPECT_TRUE(command.output().live_conversion());
+  EXPECT_FALSE(command.output().has_candidate_window());
+  EXPECT_EQ(session_peer.pending_live_conversion_suggestion_candidate_window_()
+                .candidate_size(),
+            0);
+  EXPECT_EQ(session_peer.live_conversion_suggestion_candidate_window_()
+                .candidate_size(),
+            0);
 }
 
 TEST_F(SessionTest, TabDuringLiveConversionFocusesPredictionCandidates) {


### PR DESCRIPTION
## 概要 #127

この PR では、システム辞書サジェストの自動表示が OFF の場合に、Shift 英字入力からかな入力へ復帰した composition で raw ASCII 候補が自動サジェスト表示される問題を修正します。

具体的には、`Shift+A Shift+I d e` のように入力した場合、preedit は `AIで` になる一方で、raw string 側の `AIde` が suggestion candidate window に表示されることがありました。

今回の変更では、このような raw ASCII rescue 候補を、システム辞書サジェスト自動表示 OFF 時には自動サジェストとして表示しないようにしています。

## 変更内容

* Composer に、Shift 英字連続入力から通常入力モードへ復帰した状態を表す semantic latch を追加
* システム辞書サジェスト自動表示が OFF の場合、Shift 英字復帰由来または raw/preedit 形状から raw ASCII rescue 候補と判断できる suggestion を抑止
* 以下の経路で同じ抑止を適用

  * 通常 `Suggest()`
  * live conversion 中の suggestion attach
  * cached live conversion suggestion attach
  * delayed live conversion の pending suggestion restore
* stale な suggestion candidate window が復活しないよう、live / pending suggestion cache を明示的に clear
* 回帰テストを追加

  * Composer の Shift 英字復帰 latch
  * `Suggest()` / live conversion suggestion attach / cached suggestion attach の抑止
  * `MaybeStartLiveConversion()` の pending restore 抑止

## 背景

ライブ変換中に Shift 英字を使うと、Composer 内部には raw string と preedit の両方が残ります。

例:

```text
raw:     AIde
preedit: AIで
```

この状態でシステム辞書サジェスト自動表示を OFF にしていても、raw 側の `AIde` が自動サジェストとして表示されることがありました。

これは設定意図と合わないため、サジェスト OFF 時には raw ASCII rescue 候補を自動表示しないようにします。

## 確認

* `bazelisk --output_user_root=C:/bzl test --config oss_windows --config release_build //composer:composer_test //session:session_test --test_output=errors --verbose_failures`
* `bazelisk --output_user_root=C:/bzl build --config oss_windows --config release_build //server:mozc_server --verbose_failures`
* 実機確認

  * システム辞書サジェスト自動表示 OFF
  * ライブ変換 ON
  * `Shift+A Shift+I d e`
  * preedit は `AIで`
  * `AIde` 候補ウィンドウが表示されないことを確認
