### PR TITLE
Refine Zenz feedback rejection final commit handling

### DIFF
--- a/src/session/session.cc
+++ b/src/session/session.cc
@@ -1842,6 +1842,13 @@ bool UseZenzFeedbackLearning(const config::Config& config) {
   return config.use_zenz_feedback_learning();
 }
 
+bool IsExplicitZenzHardRejectReason(absl::string_view reason) {
+  return reason == "hard_reject" ||
+         reason == "user_hard_reject" ||
+         reason == "manual_hard_reject" ||
+         reason == "explicit_hard_reject";
+}
+
 bool StartsWithString(absl::string_view text, absl::string_view prefix) {
   return text.size() >= prefix.size() &&
          text.substr(0, prefix.size()) == prefix;
@@ -3970,12 +3977,12 @@ bool Session::IMEOn(commands::Command* command) {
 
 bool Session::IMEOff(commands::Command* command) {
   ConfirmPendingDirectCommitLearning("ime_off_after_direct_commit_learning");
-  ConfirmPendingZenzFeedback();
 
   command->mutable_output()->set_consumed(true);
   ClearUndoContext();
 
   Commit(command);
+  ConfirmPendingZenzFeedback();
 
   // Reset the context.
   context_->mutable_converter()->Reset();
@@ -4010,7 +4017,6 @@ bool Session::MakeSureIMEOn(mozc::commands::Command* command) {
 bool Session::MakeSureIMEOff(mozc::commands::Command* command) {
   ConfirmPendingDirectCommitLearning(
       "make_sure_ime_off_after_direct_commit_learning");
-  ConfirmPendingZenzFeedback();
 
   if (command->input().has_command() &&
       command->input().command().has_composition_mode() &&
@@ -4027,6 +4033,7 @@ bool Session::MakeSureIMEOff(mozc::commands::Command* command) {
     context_->mutable_converter()->Reset();
     SetSessionState(ImeContext::DIRECT, context_.get());
   }
+  ConfirmPendingZenzFeedback();
   if (command->input().has_command() &&
       command->input().command().has_composition_mode()) {
     ApplyCompositionMode(command->input().command().composition_mode(),
@@ -5103,6 +5110,8 @@ void Session::SetPendingZenzFeedbackAccepted(
       context_class.empty() ? "empty" : std::string(context_class);
   pending_zenz_feedback_.value = std::string(value);
   pending_zenz_feedback_.reason.clear();
+  pending_zenz_feedback_.has_final_committed_value = false;
+  pending_zenz_feedback_.final_committed_value.clear();
 
   ZenzDebugOutput(absl::StrCat(
       "[zenz-feedback] pending accepted ",
@@ -5149,6 +5158,8 @@ void Session::SetPendingZenzFeedbackRejected(absl::string_view reason) {
       zenz_live_context_class_.empty() ? "empty" : zenz_live_context_class_;
   pending_zenz_feedback_.value = zenz_live_value_;
   pending_zenz_feedback_.reason = std::string(reason);
+  pending_zenz_feedback_.has_final_committed_value = false;
+  pending_zenz_feedback_.final_committed_value.clear();
 
   ZenzDebugOutput(absl::StrCat(
       "[zenz-feedback] pending rejected ",
@@ -5156,6 +5167,40 @@ void Session::SetPendingZenzFeedbackRejected(absl::string_view reason) {
       " ", ZenzRedactedTextStats("value", pending_zenz_feedback_.value),
       " context_class=", pending_zenz_feedback_.context_class,
       " reason=", pending_zenz_feedback_.reason));
+}
+
+void Session::ObservePendingZenzFeedbackCommittedResult(
+    const commands::Command& command,
+    absl::string_view reason) {
+  if (!pending_zenz_feedback_.pending ||
+      pending_zenz_feedback_.action != PendingZenzFeedback::Action::kRejected) {
+    return;
+  }
+
+  // Only a fully committed conversion/direct commit should resolve pending
+  // rejected feedback. Partial segment commits stay in CONVERSION and must not
+  // be interpreted as the user's final full-sequence decision.
+  if (context_->state() != ImeContext::PRECOMPOSITION) {
+    return;
+  }
+
+  if (!command.output().has_result() ||
+      !command.output().result().has_value()) {
+    return;
+  }
+
+  pending_zenz_feedback_.has_final_committed_value = true;
+  pending_zenz_feedback_.final_committed_value =
+      command.output().result().value();
+
+  ZenzDebugOutput(absl::StrCat(
+      "[zenz-feedback] observed final committed value reason=", reason,
+      " ", ZenzRedactedTextStats("key", pending_zenz_feedback_.key),
+      " ", ZenzRedactedTextStats("zenz_value", pending_zenz_feedback_.value),
+      " ", ZenzRedactedTextStats("final_value",
+                                  pending_zenz_feedback_.final_committed_value),
+      " context_class=", pending_zenz_feedback_.context_class,
+      " pending_reason=", pending_zenz_feedback_.reason));
 }
 
 void Session::ConfirmPendingZenzFeedback() {
@@ -5194,18 +5239,37 @@ void Session::ConfirmPendingZenzFeedback() {
         " context_class=", pending_zenz_feedback_.context_class));
   } else if (pending_zenz_feedback_.action ==
              PendingZenzFeedback::Action::kRejected) {
-    ZenzDebugOutput(absl::StrCat(
-        "[zenz-feedback] confirm pending rejected ",
-        ZenzRedactedTextStats("key", pending_zenz_feedback_.key),
-        " ", ZenzRedactedTextStats("value", pending_zenz_feedback_.value),
-        " context_class=", pending_zenz_feedback_.context_class,
-        " reason=", pending_zenz_feedback_.reason));
+    if (!IsExplicitZenzHardRejectReason(pending_zenz_feedback_.reason) &&
+        !pending_zenz_feedback_.has_final_committed_value) {
+      ZenzDebugOutput(absl::StrCat(
+          "[zenz-feedback] neutralize pending rejected without final commit ",
+          ZenzRedactedTextStats("key", pending_zenz_feedback_.key),
+          " ", ZenzRedactedTextStats("value", pending_zenz_feedback_.value),
+          " context_class=", pending_zenz_feedback_.context_class,
+          " reason=", pending_zenz_feedback_.reason));
+    } else if (!IsExplicitZenzHardRejectReason(pending_zenz_feedback_.reason) &&
+               pending_zenz_feedback_.final_committed_value ==
+                   pending_zenz_feedback_.value) {
+      ZenzDebugOutput(absl::StrCat(
+          "[zenz-feedback] neutralize pending rejected same final value ",
+          ZenzRedactedTextStats("key", pending_zenz_feedback_.key),
+          " ", ZenzRedactedTextStats("value", pending_zenz_feedback_.value),
+          " context_class=", pending_zenz_feedback_.context_class,
+          " reason=", pending_zenz_feedback_.reason));
+    } else {
+      ZenzDebugOutput(absl::StrCat(
+          "[zenz-feedback] confirm pending rejected ",
+          ZenzRedactedTextStats("key", pending_zenz_feedback_.key),
+          " ", ZenzRedactedTextStats("value", pending_zenz_feedback_.value),
+          " context_class=", pending_zenz_feedback_.context_class,
+          " reason=", pending_zenz_feedback_.reason));
 
-    zenz_feedback_store_.RecordRejected(
-        pending_zenz_feedback_.key,
-        pending_zenz_feedback_.context_class,
-        pending_zenz_feedback_.value,
-        pending_zenz_feedback_.reason);
+      zenz_feedback_store_.RecordRejected(
+          pending_zenz_feedback_.key,
+          pending_zenz_feedback_.context_class,
+          pending_zenz_feedback_.value,
+          pending_zenz_feedback_.reason);
+    }
   }
 
   pending_zenz_feedback_ = PendingZenzFeedback();
@@ -8436,6 +8500,7 @@ void Session::Output(commands::Command* command) {
   OutputMode(command);
   context_->mutable_converter()->PopOutput(context_->composer(),
                                            command->mutable_output());
+  ObservePendingZenzFeedbackCommittedResult(*command, "output_result");
 }
 
 void Session::OutputMode(commands::Command* command) const {

--- a/src/session/session.h
+++ b/src/session/session.h
@@ -383,6 +383,12 @@ class Session {
     std::string context_class;
     std::string value;
     std::string reason;
+
+    // Set when a rejected Zenz candidate is followed by a real commit.
+    // This lets ambiguous operations such as Space revert become neutral when
+    // the final committed text is identical to the Zenz value.
+    bool has_final_committed_value = false;
+    std::string final_committed_value;
   };
 
   PendingZenzFeedback pending_zenz_feedback_;
@@ -604,6 +610,9 @@ class Session {
       absl::string_view context_class,
       absl::string_view value);
   void SetPendingZenzFeedbackRejected(absl::string_view reason);
+  void ObservePendingZenzFeedbackCommittedResult(
+      const mozc::commands::Command& command,
+      absl::string_view reason);
   void ConfirmPendingZenzFeedback();
   void DiscardPendingZenzFeedback(absl::string_view reason);
   void HandlePendingZenzFeedbackForKeyEvent(

--- a/src/session/session_test.cc
+++ b/src/session/session_test.cc
@@ -92,6 +92,8 @@ class SessionTestPeer : testing::TestPeer<Session> {
   PEER_METHOD(MaybeApplyZenzFeedbackLiveCorrection);
   PEER_METHOD(SetPendingZenzFeedbackAccepted);
   PEER_METHOD(SetPendingZenzFeedbackRejected);
+  PEER_METHOD(ObservePendingZenzFeedbackCommittedResult);
+  PEER_METHOD(ConfirmPendingZenzFeedback);
   PEER_METHOD(DiscardPendingZenzFeedback);
   PEER_METHOD(HandlePendingZenzFeedbackForKeyEvent);
   PEER_METHOD(SetPendingDirectCommitLearningFromCommittedResult);
@@ -114,6 +116,7 @@ class SessionTestPeer : testing::TestPeer<Session> {
   PEER_VARIABLE(live_conversion_preedit_output_);
   PEER_VARIABLE(pending_live_conversion_suggestion_candidate_window_);
   PEER_VARIABLE(live_conversion_suggestion_candidate_window_);
+  PEER_VARIABLE(zenz_live_visible_generation_);
   PEER_VARIABLE(zenz_live_key_);
   PEER_VARIABLE(zenz_live_value_);
   PEER_VARIABLE(zenz_live_mozc_value_);
@@ -1272,6 +1275,123 @@ TEST_F(SessionTest, PendingZenzFeedbackStoresContextClassOnly) {
   EXPECT_EQ(
       session_peer.pending_zenz_feedback_().context_class.find("hunter2"),
       std::string::npos);
+}
+
+
+#if defined(_WIN32)
+void SetPendingRejectedZenzFeedbackForTest(SessionTestPeer* session_peer) {
+  session_peer->context_()->set_state(ImeContext::CONVERSION);
+  session_peer->live_conversion_active_() = true;
+  session_peer->live_conversion_key_() = "かれはてんてきです";
+  session_peer->live_conversion_value_() = "彼は点滴です";
+  session_peer->zenz_live_visible_generation_() = 1;
+  session_peer->zenz_live_key_() = "かれはてんてきです";
+  session_peer->zenz_live_value_() = "彼は天敵です";
+  session_peer->zenz_live_mozc_value_() = "彼は点滴です";
+  session_peer->zenz_live_context_class_() = "empty";
+
+  session_peer->SetPendingZenzFeedbackRejected("space_revert_zenz_to_mozc");
+  session_peer->context_()->set_state(ImeContext::PRECOMPOSITION);
+}
+#endif  // defined(_WIN32)
+
+TEST_F(SessionTest, PendingRejectedZenzFeedbackIsNeutralWithoutFinalCommit) {
+#if defined(_WIN32)
+  MockEngine engine;
+  std::shared_ptr<MockConverter> converter = CreateEngineConverterMock(&engine);
+
+  ScopedUserProfileForZenzFeedbackSessionTest profile;
+  ASSERT_TRUE(profile.ok());
+
+  Session session(engine);
+  SessionTestPeer session_peer(session);
+  InitSessionToPrecomposition(&session);
+  EnableZenzFeedbackLearning(&session);
+  SetPendingRejectedZenzFeedbackForTest(&session_peer);
+  ASSERT_TRUE(session_peer.pending_zenz_feedback_().pending);
+
+  session_peer.ConfirmPendingZenzFeedback();
+
+  EXPECT_FALSE(session_peer.pending_zenz_feedback_().pending);
+  EXPECT_TRUE(session_peer.zenz_feedback_store_().ListEntries().empty());
+#else
+  GTEST_SKIP() << "Zenz feedback store persists only on Windows.";
+#endif
+}
+
+TEST_F(SessionTest, PendingRejectedZenzFeedbackIsNeutralWhenFinalCommitMatches) {
+#if defined(_WIN32)
+  MockEngine engine;
+  std::shared_ptr<MockConverter> converter = CreateEngineConverterMock(&engine);
+
+  ScopedUserProfileForZenzFeedbackSessionTest profile;
+  ASSERT_TRUE(profile.ok());
+
+  Session session(engine);
+  SessionTestPeer session_peer(session);
+  InitSessionToPrecomposition(&session);
+  EnableZenzFeedbackLearning(&session);
+  SetPendingRejectedZenzFeedbackForTest(&session_peer);
+  ASSERT_TRUE(session_peer.pending_zenz_feedback_().pending);
+
+  commands::Command command;
+  command.mutable_output()->mutable_result()->set_type(
+      commands::Result::STRING);
+  command.mutable_output()->mutable_result()->set_key("かれはてんてきです");
+  command.mutable_output()->mutable_result()->set_value("彼は天敵です");
+
+  session_peer.ObservePendingZenzFeedbackCommittedResult(command, "test");
+  ASSERT_TRUE(session_peer.pending_zenz_feedback_()
+                  .has_final_committed_value);
+  EXPECT_EQ(session_peer.pending_zenz_feedback_().final_committed_value,
+            "彼は天敵です");
+
+  session_peer.ConfirmPendingZenzFeedback();
+
+  EXPECT_FALSE(session_peer.pending_zenz_feedback_().pending);
+  EXPECT_TRUE(session_peer.zenz_feedback_store_().ListEntries().empty());
+#else
+  GTEST_SKIP() << "Zenz feedback store persists only on Windows.";
+#endif
+}
+
+TEST_F(SessionTest, PendingRejectedZenzFeedbackIsRecordedWhenFinalCommitDiffers) {
+#if defined(_WIN32)
+  MockEngine engine;
+  std::shared_ptr<MockConverter> converter = CreateEngineConverterMock(&engine);
+
+  ScopedUserProfileForZenzFeedbackSessionTest profile;
+  ASSERT_TRUE(profile.ok());
+
+  Session session(engine);
+  SessionTestPeer session_peer(session);
+  InitSessionToPrecomposition(&session);
+  EnableZenzFeedbackLearning(&session);
+  SetPendingRejectedZenzFeedbackForTest(&session_peer);
+  ASSERT_TRUE(session_peer.pending_zenz_feedback_().pending);
+
+  commands::Command command;
+  command.mutable_output()->mutable_result()->set_type(
+      commands::Result::STRING);
+  command.mutable_output()->mutable_result()->set_key("かれはてんてきです");
+  command.mutable_output()->mutable_result()->set_value("彼は点滴です");
+
+  session_peer.ObservePendingZenzFeedbackCommittedResult(command, "test");
+  session_peer.ConfirmPendingZenzFeedback();
+
+  EXPECT_FALSE(session_peer.pending_zenz_feedback_().pending);
+
+  const std::vector<ZenzFeedbackEntry> entries =
+      session_peer.zenz_feedback_store_().ListEntries();
+  ASSERT_EQ(entries.size(), 1);
+  EXPECT_EQ(entries[0].key, "かれはてんてきです");
+  EXPECT_EQ(entries[0].context_class, "empty");
+  EXPECT_EQ(entries[0].value, "彼は天敵です");
+  EXPECT_EQ(entries[0].accepted_count, 0);
+  EXPECT_EQ(entries[0].rejected_count, 1);
+#else
+  GTEST_SKIP() << "Zenz feedback store persists only on Windows.";
+#endif
 }
 
 #if defined(_WIN32)


### PR DESCRIPTION
## 概要

この PR では、Zenz feedback learning における rejected feedback の確定処理を見直し、Space などで Zenz 補正表示から通常 Mozc 変換へ戻した後、最終的にユーザーが確定した文字列を見て rejected feedback を保存するかどうかを判定するようにしました。

従来は、Zenz 補正表示中に Space で通常 Mozc 変換へ戻した場合、その時点で pending rejected feedback が作られ、後続の入力などでそのまま rejected として保存されていました。

しかし Space は必ずしも「この Zenz 候補を拒否する」という意味ではなく、「通常候補を確認したい」「候補一覧から選び直したい」という操作でもあります。そのため、Space 後に最終的な確定結果が Zenz 候補と同じだった場合まで rejected として保存すると、Zenz 候補を不必要に弱める可能性がありました。

今回の変更では、pending rejected feedback に final committed value を記録できるようにし、確定時の結果に基づいて次のように扱います。

* 最終確定値が観測できない場合は、通常 rejected feedback を neutral として破棄
* 最終確定値が Zenz 候補と同じ場合は、rejected として保存せず neutral として破棄
* 最終確定値が Zenz 候補と異なる場合のみ、full-sequence soft negative として保存
* explicit hard reject 系 reason は、final committed value による neutral 判定の対象外として扱う

これにより、Space revert のような曖昧な操作を過剰に rejected feedback として学習せず、実際にユーザーが別の結果を確定した場合だけ soft negative として反映できます。

## 変更内容

* `PendingZenzFeedback` に final committed value の保持フィールドを追加
* 通常確定後の `Output()` で、pending rejected feedback に対して `command.output().result().value()` を観測
* `ConfirmPendingZenzFeedback()` の rejected 分岐で、final committed value に基づく neutralize 判定を追加
* `IMEOff()` / `MakeSureIMEOff()` では、commit 後に pending Zenz feedback を confirm するよう順序を調整
* final committed value 未観測 / Zenz 候補と同一 / Zenz 候補と相違の3ケースを session test に追加

## 意図

Zenz feedback store は full-sequence の accepted / soft negative / hard reject を管理する責務に留め、Space revert のようなユーザー操作の意味解釈は Session 側で行う方針です。

今回の修正では、Zenz feedback store の score semantics には手を入れず、Session 側で「本当に rejected として保存すべきか」を確定直前に判定します。

これにより、通常候補確認のための Space 操作が過剰な negative feedback になることを防ぎつつ、最終的に別候補を確定した場合には従来通り soft negative として反映できます。

## テスト

実行済みです。

```powershell
bazelisk --output_user_root=C:/bzl test `
  --config oss_windows `
  --config release_build `
  //session:session_test `
  --test_output=errors

bazelisk --output_user_root=C:/bzl test `
  --config oss_windows `
  --config release_build `
  //session:zenz_feedback_store_test `
  --test_output=errors

bazelisk --output_user_root=C:/bzl test `
  --config oss_windows `
  --config release_build `
  //session:session_test `
  //session:zenz_feedback_store_test `
  //rewriter:zenz_feedback_candidate_rewriter_test `
  --test_output=errors
```

また、`//server:mozc_server` を release build し、インストール先の `mozc_server.exe` を直接差し替えて実機確認済みです。

確認内容:

* Zenz 補正表示後、Space で通常 Mozc 変換へ戻し、最終的に Zenz と同じ文字列を確定しても候補が不自然に弱体化しないこと
* Zenz 補正表示後、Space で通常 Mozc 変換へ戻し、Zenz と異なる文字列を確定する経路が問題なく動作すること
