### PR TITLE
Add contextual recomposition boundary scorer

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Windows 用のビルド済み MSI は [Releases](https://github.com/koyasi777/mo
 - デフォルトでは 1 文字だけの未確定文字列で、助詞などの誤変換を避けるためライブ変換を実行しない
 - `え~`、`えー`、`ん？` のような「かな1文字 + 装飾的な末尾記号」でも、短すぎる漢字化を避けるためライブ変換を抑制
 - 感嘆詞・口語評価語・くだけた挨拶の入力途中ではライブ変換のちらつきを抑えつつ、完成した `うっそ`、`くっそ`、`やっば`、`すっげぇ`、`めっちゃ`、`ちっす`、`ちょりっす`、`ほえ～`、`ほぇ～`、`ほっほーん` などは生成辞書候補として自然なかな表記を救出
-- 確定済みの左文脈や直前の文節、限定的な右文脈を参照し、`mainにマージしました`、`githubには`、`2名しかいない`、`追記したい`、`山梨県立美術館`、`滋賀方面` のような文脈で、助詞・複合機能語・機能表現・接尾的な語構成・地名接尾構成が同音漢字候補に負ける挙動を抑制
+- 確定済みの左文脈や直前の文節、限定的な右文脈を参照し、`mainにマージしました`、`githubには`、`彼になった`、`彼なのか`、`2名しかいない`、`追記したい`、`山梨県立美術館`、`滋賀方面` のような文脈で、助詞・複合機能語・名詞相当の左文脈に続く叙述・疑問の機能語列・機能表現・接尾的な語構成・地名接尾構成が同音漢字候補に負ける挙動を抑制
 - キー設定エディタで、1つのキー入力に対して複数のコマンドを順序付きで割り当て可能
 - 複数コマンドは `Commit|IMEOff` のような形式で保存され、設定画面では `Commit → IMEOff` のように編集可能
 - MS-IME 風キー設定では、確定済み文字列を選択した状態で Space を押すと再変換し、未選択時は従来どおり空白を入力
@@ -295,6 +295,8 @@ Zenz ライブ補正では、Zenzai v3/v3.2 の特殊トークン形式に沿っ
 内部的には、名詞相当の確定済み左文脈を history segment として復元し、`に`、`を`、`が`、`へ`、`で` などの短い助詞候補が、同音の漢字・数字・記号・濁点付き仮名候補に負けにくくなるように候補順位を補正します。
 
 また、名詞相当の左文脈の後では、`には`、`にも`、`では`、`でも`、`とは` のような保守的な複合機能語も補正対象にします。たとえば `github` を確定した直後に `には` と入力した場合、`github二は` よりも `githubには` を優先しやすくします。
+
+さらに、名詞相当の確定済み左文脈の直後では、現在入力の先頭にある機能語 prefix や、`なのか`、`なのだ`、`なんです` のような名詞述語に続く機能語列が、`担った` や `七日` のような内容語候補に食われるケースも抑制します。たとえば `彼` を確定してから `になった` や `なのか` と入力した場合、`彼担った` / `彼七日` ではなく、`彼になった` / `彼なのか` を優先しやすくします。
 
 また、名詞や数量表現の後に続く `しか + 否定表現` のような機能表現も保護します。たとえば `2めいしかいない` では、途中の `2名司会...`、`2名視界...`、`2名士会内` のような同音漢字経路よりも、`2名しかいない` を優先しやすくします。
 
@@ -602,7 +604,7 @@ Main features added in this fork
 - By default, suppresses live conversion for one-character compositions to avoid over-converting particles
 - Suppresses live conversion for very short kana compositions with decorative trailing symbols such as `え~`, `えー`, or `ん？`
 - Suppresses live-conversion flicker for unfinished expressive kana prefixes, while completed expressive forms such as `うっそ`, `くっそ`, `やっば`, `すっげぇ`, `めっちゃ`, `ちっす`, `ちょりっす`, `ほえ～`, `ほぇ～`, and `ほっほーん` are rescued as generated dictionary candidates
-- Uses committed left context, previous segments, and limited right context to reduce unnatural homophone results in cases such as `mainにマージしました`, `githubには`, `2名しかいない`, `追記したい`, `山梨県立美術館`, and `滋賀方面`
+- Uses committed left context, previous segments, and limited right context to reduce unnatural homophone results in cases such as `mainにマージしました`, `githubには`, `彼になった`, `彼なのか`, `2名しかいない`, `追記したい`, `山梨県立美術館`, and `滋賀方面`
 - Allows assigning multiple commands to a single key binding as an ordered command sequence
 - Stores command sequences as `Commit|IMEOff` and shows them in the keymap editor as `Commit → IMEOff`
 - In the MS-IME style keymap, pressing Space while committed text is selected reconverts that selection; with no selection, Space still inserts a normal space
@@ -863,6 +865,11 @@ It also reranks conservative compound functional-particle expressions such as
 `には`, `にも`, `では`, `でも`, and `とは` after noun-like left context. For
 example, after committing `github`, typing `には` is biased toward `githubには`
 instead of `github二は`.
+
+It also protects functional-prefix and whole functional-chain paths immediately
+after noun-like committed context. For example, after committing `彼`, typing
+`になった` or `なのか` is biased toward `彼になった` / `彼なのか` instead of
+content-node hijacks such as `彼担った` / `彼七日`.
 
 It also protects common functional expressions such as `しか` followed by a
 negative expression after a noun or quantity-like context. For example,

--- a/src/converter/immutable_converter.cc
+++ b/src/converter/immutable_converter.cc
@@ -430,6 +430,316 @@ bool HasFunctionalPathInRange(const FunctionalReachability& reachable,
   return reachable[begin_pos][end_pos];
 }
 
+enum class BoundaryContextForRecomposition {
+  kNoHistory,
+  kClosedNominal,
+  kOpenParticle,
+  kPredicateOrFunctional,
+  kPunctuation,
+  kUnknown,
+};
+
+struct FunctionalPrefixEvidence {
+  size_t begin_pos = 0;
+  size_t end_pos = 0;
+  absl::string_view key;
+};
+
+bool EndsWithAnyStringView(
+    absl::string_view text,
+    std::initializer_list<absl::string_view> suffixes) {
+  for (absl::string_view suffix : suffixes) {
+    if (EndsWithStringView(text, suffix)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool StartsWithAnyStringView(
+    absl::string_view text,
+    std::initializer_list<absl::string_view> prefixes) {
+  for (absl::string_view prefix : prefixes) {
+    if (StartsWithStringView(text, prefix)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool EndsWithJapanesePunctuationLike(absl::string_view value) {
+  return EndsWithAnyStringView(value, {
+      "。", "、", "！", "？", "!", "?", ".", ",", " ", "　",
+  });
+}
+
+bool EndsWithOpenParticleLike(absl::string_view value) {
+  // These endings usually keep an argument/attachment slot open.  In such
+  // contexts, content predicates after the boundary can be legitimate:
+  //   責任を | になった -> 責任を担った
+  return EndsWithAnyStringView(value, {
+      "を", "が", "は", "も", "に", "で", "へ", "と", "の",
+      "から", "まで", "より", "や",
+  });
+}
+
+bool IsNominalHistoryNode(const dictionary::PosMatcher& pos_matcher,
+                          const Node& node) {
+  if (pos_matcher.IsContentNoun(node.lid) ||
+      pos_matcher.IsContentNoun(node.rid) ||
+      pos_matcher.IsPronoun(node.lid) || pos_matcher.IsPronoun(node.rid) ||
+      pos_matcher.IsUniqueNoun(node.lid) ||
+      pos_matcher.IsUniqueNoun(node.rid) ||
+      pos_matcher.IsGeneralNoun(node.lid) ||
+      pos_matcher.IsGeneralNoun(node.rid) ||
+      pos_matcher.IsUnknown(node.lid) || pos_matcher.IsUnknown(node.rid)) {
+    return true;
+  }
+
+  // Surface fallback for user dictionary history, ASCII identifiers, product
+  // names, numbers, and other committed noun-like tokens whose POS IDs are not
+  // always reliable enough at this boundary.
+  return Util::ContainsScriptType(node.value, Util::KANJI) ||
+         Util::ContainsScriptType(node.value, Util::KATAKANA) ||
+         Util::ContainsScriptType(node.value, Util::ALPHABET) ||
+         Util::ContainsScriptType(node.value, Util::NUMBER);
+}
+
+BoundaryContextForRecomposition ClassifyBoundaryContextForRecomposition(
+    const dictionary::PosMatcher& pos_matcher, const Node& node) {
+  if (node.value.empty()) {
+    return BoundaryContextForRecomposition::kUnknown;
+  }
+
+  if (EndsWithJapanesePunctuationLike(node.value)) {
+    return BoundaryContextForRecomposition::kPunctuation;
+  }
+
+  if (EndsWithOpenParticleLike(node.value)) {
+    return BoundaryContextForRecomposition::kOpenParticle;
+  }
+
+  if (IsNominalHistoryNode(pos_matcher, node)) {
+    return BoundaryContextForRecomposition::kClosedNominal;
+  }
+
+  if (pos_matcher.IsFunctional(node.lid) || pos_matcher.IsFunctional(node.rid)) {
+    return BoundaryContextForRecomposition::kPredicateOrFunctional;
+  }
+
+  return BoundaryContextForRecomposition::kUnknown;
+}
+
+BoundaryContextForRecomposition ClassifyBoundaryContextForRecomposition(
+    const dictionary::PosMatcher& pos_matcher, const Lattice& lattice,
+    size_t conversion_begin_pos) {
+  if (conversion_begin_pos == 0) {
+    return BoundaryContextForRecomposition::kNoHistory;
+  }
+
+  const Node* fallback = nullptr;
+  for (const Node* prev : lattice.end_nodes(conversion_begin_pos)) {
+    if (prev == nullptr || prev->end_pos != conversion_begin_pos) {
+      continue;
+    }
+    if (prev->node_type != Node::HIS_NODE || prev->value.empty()) {
+      continue;
+    }
+
+    // MakeLattice may insert an EOS-like HIS_NODE with rid == 0 at the end of
+    // history.  Prefer the concrete history node when available.
+    if (prev->rid != 0) {
+      return ClassifyBoundaryContextForRecomposition(pos_matcher, *prev);
+    }
+    if (fallback == nullptr) {
+      fallback = prev;
+    }
+  }
+
+  if (fallback != nullptr) {
+    return ClassifyBoundaryContextForRecomposition(pos_matcher, *fallback);
+  }
+
+  return BoundaryContextForRecomposition::kUnknown;
+}
+
+bool IsSupportedFunctionalPrefixForRecomposition(absl::string_view key) {
+  if (key.empty()) {
+    return false;
+  }
+
+  // A single "と" or "の" is too ambiguous for this generic scorer:
+  //   写真 | とった
+  //   田 | の字
+  // Compound paths such as "とは" can still be used because they carry more
+  // functional evidence.
+  if (key == "と" || key == "の") {
+    return false;
+  }
+
+  if (key == "に" || key == "で" || key == "へ" || key == "を" ||
+      key == "が" || key == "は" || key == "も") {
+    return true;
+  }
+
+  if (key.size() > absl::string_view("に").size() &&
+      StartsWithAnyStringView(key, {
+          "に", "で", "と", "の", "は", "も", "が", "を", "へ",
+          "から", "まで", "より",
+      })) {
+    return true;
+  }
+
+  return false;
+}
+
+bool IsSupportedWholeFunctionalChainForRecomposition(absl::string_view key) {
+  if (key.empty()) {
+    return false;
+  }
+
+  // Copular/adnominal functional chains after a closed nominal history.
+  //
+  // Examples:
+  //   彼 | なのか   -> 彼なのか, not 彼七日
+  //   彼 | なのだ   -> 彼なのだ
+  //   彼 | なんです -> 彼なんです
+  //
+  // Do not accept bare "な" to avoid broad lexical demotion such as ななめ.
+  return StartsWithStringView(key, "なの") || StartsWithStringView(key, "なん");
+}
+
+bool HasContinuationNodeFrom(const Lattice& lattice, size_t begin_pos,
+                             const Node& excluded_node) {
+  if (begin_pos >= lattice.key().size()) {
+    return false;
+  }
+
+  for (const Node* node : lattice.begin_nodes(begin_pos)) {
+    if (node == nullptr || node == &excluded_node) {
+      continue;
+    }
+    if (node->node_type != Node::NOR_NODE) {
+      continue;
+    }
+    if (node->end_pos <= node->begin_pos) {
+      continue;
+    }
+    return true;
+  }
+
+  return false;
+}
+
+std::optional<FunctionalPrefixEvidence> FindFunctionalPrefixEvidence(
+    const FunctionalReachability& reachable, const Lattice& lattice,
+    size_t conversion_begin_pos, const Node& competing_node) {
+  if (competing_node.begin_pos != conversion_begin_pos) {
+    return std::nullopt;
+  }
+  if (competing_node.end_pos > lattice.key().size()) {
+    return std::nullopt;
+  }
+
+  const absl::string_view competing_key =
+      lattice.key().substr(conversion_begin_pos,
+                           competing_node.end_pos - conversion_begin_pos);
+
+  // Whole-span functional chain evidence.
+  //
+  // This covers cases like:
+  //   彼 | なのか
+  //
+  // where the competing content node consumes the whole current span
+  // ("なのか" -> "七日") and there is no separate continuation node after
+  // the functional chain.
+  if (HasFunctionalPathInRange(reachable, conversion_begin_pos,
+                               competing_node.end_pos) &&
+      IsSupportedWholeFunctionalChainForRecomposition(competing_key)) {
+    return FunctionalPrefixEvidence{conversion_begin_pos,
+                                    competing_node.end_pos, competing_key};
+  }
+
+  // Require at least two reading characters after the functional prefix.  This
+  // avoids broad demotion of compact expressions such as 二時 and keeps the
+  // scorer focused on phrase-like boundary drift.
+  constexpr size_t kMinRemainingChars = 2;
+
+  for (size_t end_pos = conversion_begin_pos + 1;
+       end_pos < competing_node.end_pos; ++end_pos) {
+    const absl::string_view remaining_key =
+        lattice.key().substr(end_pos, competing_node.end_pos - end_pos);
+    if (Util::CharsLen(remaining_key) < kMinRemainingChars) {
+      continue;
+    }
+    if (!HasFunctionalPathInRange(reachable, conversion_begin_pos, end_pos)) {
+      continue;
+    }
+
+    if (!HasContinuationNodeFrom(lattice, end_pos, competing_node)) {
+      continue;
+    }
+
+    const absl::string_view prefix_key =
+        lattice.key().substr(conversion_begin_pos,
+                             end_pos - conversion_begin_pos);
+    if (!IsSupportedFunctionalPrefixForRecomposition(prefix_key)) {
+      continue;
+    }
+
+    FunctionalPrefixEvidence evidence;
+    evidence.begin_pos = conversion_begin_pos;
+    evidence.end_pos = end_pos;
+    evidence.key = prefix_key;
+    return evidence;
+  }
+
+  return std::nullopt;
+}
+
+bool IsPrefixConsumingContentNodeForRecomposition(
+    const dictionary::PosMatcher& pos_matcher, const Node& node,
+    size_t conversion_begin_pos) {
+  if (node.node_type != Node::NOR_NODE) {
+    return false;
+  }
+  if ((node.attributes & Node::USER_DICTIONARY) != 0) {
+    return false;
+  }
+  if (node.begin_pos != conversion_begin_pos) {
+    return false;
+  }
+  if (node.end_pos <= node.begin_pos) {
+    return false;
+  }
+  if (node.key.empty() || node.value.empty() || node.key == node.value) {
+    return false;
+  }
+  if (Util::GetScriptType(node.key) != Util::HIRAGANA) {
+    return false;
+  }
+
+  // Functional/kana nodes are the protected side, not the penalty target.
+  if (pos_matcher.IsFunctional(node.lid) || pos_matcher.IsFunctional(node.rid)) {
+    return false;
+  }
+  if (pos_matcher.IsUniqueNoun(node.lid) || pos_matcher.IsUniqueNoun(node.rid)) {
+    return false;
+  }
+
+  return Util::ContainsScriptType(node.value, Util::KANJI) ||
+         Util::ContainsScriptType(node.value, Util::KATAKANA) ||
+         Util::ContainsScriptType(node.value, Util::NUMBER);
+}
+
+bool IsNumericContentNodeForRecomposition(
+    const dictionary::PosMatcher& pos_matcher, const Node& node) {
+  return pos_matcher.IsNumber(node.lid) ||
+         pos_matcher.IsNumber(node.rid) ||
+         pos_matcher.IsKanjiNumber(node.lid) ||
+         pos_matcher.IsKanjiNumber(node.rid);
+}
+
 bool HasKanaFunctionalPredecessor(const dictionary::PosMatcher& pos_matcher,
                                   const Lattice& lattice,
                                   const Node& target,
@@ -2376,6 +2686,7 @@ bool ImmutableConverter::MakeLattice(const ConversionRequest& request,
 
   if (!is_reverse && !conversion_key.empty()) {
     ApplyFunctionalKanaGuard(history_key, lattice);
+    ApplyContextualRecompositionScorer(history_key, lattice);
     ApplySahenShitaiGuard(history_key, lattice);
     ApplyAdministrativeRitsuGuard(history_key, lattice);
     ApplyPlaceSuffixGuard(history_key, lattice);
@@ -2638,6 +2949,54 @@ void ImmutableConverter::ApplyFunctionalKanaGuard(
       node->wcost += GetFunctionalKanaGuardPenalty(
           pos_matcher_, *lattice, reachable, *node);
     }
+  }
+}
+
+void ImmutableConverter::ApplyContextualRecompositionScorer(
+    absl::string_view history_key, Lattice* lattice) const {
+  if (lattice == nullptr || history_key.empty()) {
+    return;
+  }
+
+  const size_t conversion_begin_pos = history_key.size();
+  if (conversion_begin_pos >= lattice->key().size()) {
+    return;
+  }
+
+  const BoundaryContextForRecomposition context =
+      ClassifyBoundaryContextForRecomposition(pos_matcher_, *lattice,
+                                              conversion_begin_pos);
+  if (context != BoundaryContextForRecomposition::kClosedNominal) {
+    return;
+  }
+
+  const FunctionalReachability reachable =
+      BuildFunctionalReachability(pos_matcher_, *lattice, conversion_begin_pos);
+
+  constexpr int kContextualRecompositionPenalty = 1800;
+  for (Node* node : lattice->begin_nodes(conversion_begin_pos)) {
+    if (node == nullptr) {
+      continue;
+    }
+    if (!IsPrefixConsumingContentNodeForRecomposition(pos_matcher_, *node,
+                                                     conversion_begin_pos)) {
+      continue;
+    }
+
+    const std::optional<FunctionalPrefixEvidence> evidence =
+        FindFunctionalPrefixEvidence(reachable, *lattice, conversion_begin_pos,
+                                     *node);
+    if (!evidence.has_value()) {
+      continue;
+    }
+    if (IsNumericContentNodeForRecomposition(pos_matcher_, *node) &&
+        !IsSupportedWholeFunctionalChainForRecomposition(evidence->key)) {
+      // Keep ordinary numeric expressions protected unless the evidence is a
+      // strong copular functional chain such as "なのか" / "なんです".
+      continue;
+    }
+
+    node->wcost += kContextualRecompositionPenalty;
   }
 }
 

--- a/src/converter/immutable_converter.h
+++ b/src/converter/immutable_converter.h
@@ -122,6 +122,14 @@ class ImmutableConverter : public ImmutableConverterInterface {
   void ApplyFunctionalKanaGuard(absl::string_view history_key,
                                 Lattice* lattice) const;
 
+  // Applies a Viterbi-time soft prior around the history/conversion boundary
+  // to reduce ranking drift caused by splitting an input sequence into
+  // committed history and current conversion.  This scorer uses only evidence
+  // already present in the current lattice: a functional-prefix or whole
+  // functional-chain path, and a competing content node that consumes it.
+  void ApplyContextualRecompositionScorer(absl::string_view history_key,
+                                          Lattice* lattice) const;
+
   void ApplySahenShitaiGuard(absl::string_view history_key,
                              Lattice* lattice) const;
 


### PR DESCRIPTION
## 概要

この PR では、通常変換において、確定済み左文脈と現在入力の境界で起きる ranking drift を抑えるため、`ImmutableConverter` に Viterbi 前の soft scorer を追加しました。

具体的には、名詞相当の確定済み左文脈の直後で、現在入力の先頭にある機能語 prefix / whole functional chain が、同音の内容語候補に食われるケースを抑制します。

例:

* `彼 | になった`

  * `彼担った` ではなく `彼になった` を優先しやすくする
* `彼 | なのか`

  * `彼七日` ではなく `彼なのか` を優先しやすくする

`|` は、左側を先に確定してから右側を入力する境界を表します。

## 背景

一括で `彼になった` / `彼なのか` と入力した場合は、ラティス上で `彼 + に + なった` や `彼 + な + の + か` のような経路が同時に評価されるため、比較的自然な候補になりやすいです。

一方で、`彼` を先に確定してから `になった` / `なのか` を入力すると、現在の conversion key は `になった` / `なのか` だけになります。その結果、`担った` や `七日` のような内容語候補が、確定済み左文脈に接続するはずの機能語列を食ってしまうことがありました。

この PR は、この「一括入力では自然だが、確定済み左文脈 + 現在入力に分かれると崩れる」問題を、個別語ではなく boundary scorer として扱います。

## 実装方針

`ImmutableConverter::MakeLattice()` でラティスを構築した後、Viterbi 前に `ApplyContextualRecompositionScorer()` を適用します。

この scorer は、現在のラティスに存在する情報だけを使います。

主な条件は以下です。

* 確定済み history が存在する
* history/conversion 境界の左側が名詞相当の閉じた文脈である
* 境界直後に、機能語 prefix または whole functional chain として解釈できる経路がある
* 同時に、その機能語列を食っている内容語 node がある
* 条件を満たした内容語 node に bounded penalty を加える

対象例:

* `に + なった`
* `では + ない`
* `とは + 違う`
* `な + の + か`
* `な + の + だ`
* `な + ん + です`

一方で、副作用を避けるため、以下のような文脈では発火しないようにしています。

* 左文脈が `を` / `が` / `に` / `で` / `の` などの open particle で終わる場合

  * 例: `責任を | になった` は `責任を担った` が自然なので、`担った` を下げない
* `と` / `の` 単独 prefix

  * 例: `写真 | とった`, `田 | の字`
* bare `な`

  * 例: `ななめ`, `なか`, `なつ` への副作用を避ける
* 通常の numeric node

  * 例: `二時`, `三個`
  * ただし `なのか -> 七日` のような whole functional chain hijack は例外的に対象

## 変更内容

* `BoundaryContextForRecomposition` を追加

  * history/conversion 境界の左側を分類
  * closed nominal / open particle / punctuation / functional などを区別
* `FunctionalPrefixEvidence` を追加

  * 機能語 prefix / whole functional chain の evidence を表現
* `ApplyContextualRecompositionScorer()` を追加

  * Viterbi 前に内容語 node の `wcost` を調整
* `FindFunctionalPrefixEvidence()` を追加

  * current lattice 上で functional path と competing content node の関係を検出
* `IsSupportedWholeFunctionalChainForRecomposition()` を追加

  * `なの...` / `なん...` 系だけを保守的に対象化
* README に、今回の左文脈境界補正の説明を追加

## テスト

以下のテストが通ることを確認しました。

```powershell
bazelisk --output_user_root=C:/bzl test `
  --config oss_windows `
  //converter:immutable_converter_test `
  //converter:nbest_generator_test `
  //engine:contextual_candidate_reranker_test `
  --verbose_failures
```

また、release build で `mozc_server.exe` をビルドし、実機に差し替えて動作確認しました。

```powershell
bazelisk --output_user_root=C:/bzl build `
  --config oss_windows `
  --config release_build `
  //server:mozc_server `
  --verbose_failures
```
