### PR TITLE
Suppress sahen shita content-word hijacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ Zenz ライブ補正では、Zenzai v3/v3.2 の特殊トークン形式に沿っ
 
 また、名詞や数量表現の後に続く `しか + 否定表現` のような機能表現も保護します。たとえば `2めいしかいない` では、途中の `2名司会...`、`2名視界...`、`2名士会内` のような同音漢字経路よりも、`2名しかいない` を優先しやすくします。
 
-また、サ変接続名詞や行政地名・施設名のような直前文脈、地名に続く場所接尾語のような限定的な右文脈も一部補正対象にします。たとえば `追記したい` では `追記死体` のような同音名詞候補を避け、`山梨県立美術館` では `山梨県率美術館` のような接尾的構成の崩れを抑制します。また、`滋賀方面` や `佐賀空港` のような語では、`子が方面` のような短い `内容語 + が` 分割を避けやすくします。
+また、サ変接続名詞や行政地名・施設名のような直前文脈、地名に続く場所接尾語のような限定的な右文脈も一部補正対象にします。たとえば `追記したい` では `追記死体` のような同音名詞候補を避け、サ変接続名詞を確定した直後の `した`、`したの`、`したん` では `下`、`舌`、`シタン` のような内容語候補に寄りすぎる挙動を抑制します。`山梨県立美術館` では `山梨県率美術館` のような接尾的構成の崩れを抑制します。また、`滋賀方面` や `佐賀空港` のような語では、`子が方面` のような短い `内容語 + が` 分割を避けやすくします。
 
 ### 句読点・記号の単打確定
 
@@ -878,7 +878,9 @@ homophone paths such as `2名司会...`, `2名視界...`, or `2名士会内`.
 
 It also protects some context-sensitive noun and suffix constructions. For
 example, `追記したい` is biased away from homophone noun candidates such as
-`追記死体`, `山梨県立美術館` is biased away from broken suffix paths such as
+`追記死体`. After a committed sahen noun, `した`, `したの`, and `したん`
+are also biased away from content-word hijacks such as `下`, `舌`, or
+`シタン`. `山梨県立美術館` is biased away from broken suffix paths such as
 `山梨県率美術館`, and place-suffix phrases such as `滋賀方面` or `佐賀空港`
 are biased away from short `content + が` splits such as `子が方面`.
 

--- a/src/converter/immutable_converter.cc
+++ b/src/converter/immutable_converter.cc
@@ -1250,6 +1250,115 @@ bool IsShitaiContentNounHijackNode(
   return true;
 }
 
+bool HasKanaSurfaceNodeAt(const Lattice& lattice, size_t begin_pos,
+                          absl::string_view surface) {
+  for (const Node* node : lattice.begin_nodes(begin_pos)) {
+    if (node == nullptr) {
+      continue;
+    }
+    if (node->node_type != Node::NOR_NODE) {
+      continue;
+    }
+    if (node->key == surface && node->value == surface) {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool HasSahenShitaPredicateEvidence(const Lattice& lattice,
+                                    size_t conversion_begin_pos) {
+  // Prefer the direct kana predicate node:
+  //   した -> した
+  if (HasKanaSurfaceNodeAt(lattice, conversion_begin_pos, "した")) {
+    return true;
+  }
+
+  // Some paths may be represented as:
+  //   し -> し
+  //   た -> た
+  for (const Node* node : lattice.begin_nodes(conversion_begin_pos)) {
+    if (node == nullptr) {
+      continue;
+    }
+    if (node->node_type != Node::NOR_NODE) {
+      continue;
+    }
+    if (node->key != "し" || node->value != "し") {
+      continue;
+    }
+    if (node->end_pos <= node->begin_pos ||
+        node->end_pos >= lattice.key().size()) {
+      continue;
+    }
+    if (HasKanaSurfaceNodeAt(lattice, node->end_pos, "た")) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+bool IsShitaContentHijackNode(
+    const dictionary::PosMatcher& pos_matcher, const Node& node,
+    size_t conversion_begin_pos) {
+  if (node.node_type != Node::NOR_NODE) {
+    return false;
+  }
+
+  if ((node.attributes & Node::USER_DICTIONARY) != 0) {
+    return false;
+  }
+
+  if (node.begin_pos != conversion_begin_pos) {
+    return false;
+  }
+
+  if (node.key.empty() || node.value.empty() || node.key == node.value) {
+    return false;
+  }
+
+  if (!StartsWithStringView(node.key, "した")) {
+    return false;
+  }
+
+  // Target only the "した..." content-hijack family.
+  //
+  // Examples:
+  //   確認 | した     -> 確認下
+  //   実行 | したの   -> 実行舌の
+  //   修正 | したん   -> 修正シタン
+  //   確認 | したのか -> 確認下のか / 確認舌のか
+  const bool is_shita_hijack =
+      StartsWithStringView(node.value, "下") ||
+      StartsWithStringView(node.value, "舌");
+  const bool is_shitan_hijack =
+      StartsWithStringView(node.key, "したん") &&
+      (Util::ContainsScriptType(node.value, Util::KANJI) ||
+       Util::ContainsScriptType(node.value, Util::KATAKANA));
+
+  if (!is_shita_hijack && !is_shitan_hijack) {
+    return false;
+  }
+
+  if (Util::GetScriptType(node.key) != Util::HIRAGANA) {
+    return false;
+  }
+
+  if (!Util::ContainsScriptType(node.value, Util::KANJI) &&
+      !Util::ContainsScriptType(node.value, Util::KATAKANA)) {
+    return false;
+  }
+
+  // Do not suppress proper nouns.
+  if (pos_matcher.IsUniqueNoun(node.lid) ||
+      pos_matcher.IsUniqueNoun(node.rid)) {
+    return false;
+  }
+
+  return true;
+}
+
 bool EndsWithAdministrativeUnit(absl::string_view value) {
   return EndsWithLiteral(value, "都") ||
          EndsWithLiteral(value, "道") ||
@@ -2688,6 +2797,7 @@ bool ImmutableConverter::MakeLattice(const ConversionRequest& request,
     ApplyFunctionalKanaGuard(history_key, lattice);
     ApplyContextualRecompositionScorer(history_key, lattice);
     ApplySahenShitaiGuard(history_key, lattice);
+    ApplySahenShitaContentHijackGuard(history_key, lattice);
     ApplyAdministrativeRitsuGuard(history_key, lattice);
     ApplyPlaceSuffixGuard(history_key, lattice);
     ApplyAdverbialNiGuard(history_key, lattice);
@@ -3037,6 +3147,51 @@ void ImmutableConverter::ApplySahenShitaiGuard(
     }
 
     node->wcost += kSahenShitaiHijackPenalty;
+  }
+}
+
+void ImmutableConverter::ApplySahenShitaContentHijackGuard(
+    absl::string_view history_key, Lattice* lattice) const {
+  if (lattice == nullptr) {
+    return;
+  }
+
+  if (history_key.empty()) {
+    return;
+  }
+
+  const size_t key_size = lattice->key().size();
+  const size_t conversion_begin_pos = history_key.size();
+
+  if (conversion_begin_pos >= key_size) {
+    return;
+  }
+
+  const absl::string_view conversion_key =
+      lattice->key().substr(conversion_begin_pos);
+
+  if (!StartsWithStringView(conversion_key, "した")) {
+    return;
+  }
+
+  if (!HasSahenNounHistoryPredecessor(
+          pos_matcher_, *lattice, conversion_begin_pos)) {
+    return;
+  }
+
+  if (!HasSahenShitaPredicateEvidence(*lattice, conversion_begin_pos)) {
+    return;
+  }
+
+  constexpr int kSahenShitaContentHijackPenalty = 2400;
+
+  for (Node* node : lattice->begin_nodes(conversion_begin_pos)) {
+    if (!IsShitaContentHijackNode(pos_matcher_, *node,
+                                  conversion_begin_pos)) {
+      continue;
+    }
+
+    node->wcost += kSahenShitaContentHijackPenalty;
   }
 }
 

--- a/src/converter/immutable_converter.h
+++ b/src/converter/immutable_converter.h
@@ -133,6 +133,13 @@ class ImmutableConverter : public ImmutableConverterInterface {
   void ApplySahenShitaiGuard(absl::string_view history_key,
                              Lattice* lattice) const;
 
+  // Suppresses "した..." -> content-word hijacks such as "下", "舌", and
+  // "シタン" after a committed sahen noun.  This is intentionally separate
+  // from the generic boundary scorer because these can be legitimate words in
+  // other contexts, e.g. "机の下", "舌の痛み", or "紫檀".
+  void ApplySahenShitaContentHijackGuard(absl::string_view history_key,
+                                         Lattice* lattice) const;
+
   // Penalizes "りつ" content nodes such as "率" or "律" after administrative
   // history contexts where the suffix "立" is much more likely, as in:
   //   山梨県 + りつ + 美術館 -> 山梨県立美術館


### PR DESCRIPTION
## 概要

この PR では、サ変接続名詞を確定した直後に `した` / `したの` / `したん` を入力した場合、`下`、`舌`、`シタン` のような内容語候補へ寄りすぎる挙動を抑制しました。

たとえば、以下のような分割入力で起きる誤変換を軽減します。

* `実行 | したの` → `実行舌の`
* `修正 | したん` → `修正シタン`
* `確認 | したのか` → `確認下のか` / `確認舌のか`

今回の変更では、一般的な `した` の変換順位を直接下げるのではなく、確定済み左文脈がサ変接続名詞であり、現在入力が `した...` で始まる場合だけ、該当する content-word hijack 候補へ soft penalty を加えます。

## 背景

既存の `ApplySahenShitaiGuard` では、`追記したい` が `追記死体` のような同音名詞候補へ寄るケースを抑制していました。

一方で、実機確認では、`したい` だけでなく、サ変接続名詞の直後に続く `した` / `したの` / `したん` でも、以下のような内容語化が起きることが分かりました。

* `した` → `下`
* `したの` → `舌の`
* `したん` → `シタン`

`したん` は関西弁・口語表現として自然に使われるため、サ変接続名詞の直後では `修正したん` / `実行したん` のような述語連接を優先しやすくする必要があります。

## 実装方針

`ImmutableConverter` に `ApplySahenShitaContentHijackGuard` を追加しました。

この guard は、以下の条件を満たす場合だけ発火します。

* 確定済み左文脈側にサ変接続名詞の predecessor がある
* 現在入力部分が `した` で始まる
* lattice 上に `した`、または `し + た` のかな述語 evidence が存在する
* competing node が `した...` を `下` / `舌` / `シタン` などの内容語候補として消費している
* user dictionary candidate や proper noun は対象外

これにより、`机の下`、`舌の痛み`、`紫檀`、単独の `した` など、内容語として正当な文脈には影響しにくい形にしています。

## 変更内容

* `HasKanaSurfaceNodeAt` を追加
* `HasSahenShitaPredicateEvidence` を追加
* `IsShitaContentHijackNode` を追加
* `ApplySahenShitaContentHijackGuard` を追加
* `MakeLattice` の Viterbi 前 scorer / guard chain に新 guard を追加
* README の文脈補正説明に、`した` / `したの` / `したん` 系の救済を追記

## 意図的に対象外にしたもの

今回の変更は、すべての `した` 変換を一般的に補正するものではありません。

特に、以下は壊さないことを重視しています。

* `机の下`
* `一番下`
* `舌の痛み`
* `紫檀`
* 単独の `した`
* ユーザー辞書由来候補
* 固有名詞候補

そのため、発火条件を「サ変接続名詞の確定済み左文脈 + `した...`」に限定しています。

## テスト

以下のテストが通ることを確認しました。

```powershell
bazelisk --output_user_root=C:/bzl test `
  --config oss_windows `
  //converter:immutable_converter_test `
  //converter:nbest_generator_test `
  --verbose_failures
```

また、以下の server build が成功することを確認しました。

```powershell
bazelisk --output_user_root=C:/bzl build `
  --config oss_windows `
  --config release_build `
  //server:mozc_server `
  --verbose_failures
```

## 実機確認

`mozc_server.exe` を直接差し替えて、以下の入力を確認しました。

Positive:

* `実行 | したの`
* `実行 | したのです`
* `実行 | したのか`
* `修正 | したん`
* `追加 | したんです`
* `修正 | したんや`
* `修正 | したんか`
* `確認 | したの`

Negative:

* `机の | した`
* `テーブルの | した`
* `橋の | した`
* `画面の | した`
* `一番 | した`

`実行舌の` や `修正シタン` に寄っていたケースが、期待どおり `実行したの` / `修正したん` 側へ改善することを確認しました。
