### PR TITLE
Upstream sync/20260624 audit

### DIFF
--- a/src/build_defs.bzl
+++ b/src/build_defs.bzl
@@ -467,6 +467,11 @@ def mozc_win32_cc_prod_binary(
         visibility = visibility,
     )
 
+register_extension_info(
+    extension = mozc_win32_cc_prod_binary,
+    label_regex_for_dep = "{extension_name}",
+)
+
 def mozc_cc_win32_library(
         name,
         srcs = [],
@@ -752,6 +757,11 @@ def mozc_macos_application(name, bundle_name, infoplists, strings = [], bundle_i
         **kwargs
     )
 
+register_extension_info(
+    extension = mozc_macos_application,
+    label_regex_for_dep = "{extension_name}",
+)
+
 def mozc_macos_bundle(name, bundle_name, infoplists, strings = [], bundle_id = None, tags = [], **kwargs):
     """Rule to create .bundle for macOS.
 
@@ -776,6 +786,11 @@ def mozc_macos_bundle(name, bundle_name, infoplists, strings = [], bundle_id = N
         tags = tags + MOZC_TAGS.MAC_ONLY,
         **kwargs
     )
+
+register_extension_info(
+    extension = mozc_macos_bundle,
+    label_regex_for_dep = "{extension_name}",
+)
 
 def _get_value(args):
     for arg in args:

--- a/src/build_defs.bzl
+++ b/src/build_defs.bzl
@@ -171,6 +171,14 @@ def _mozc_gen_win32_resource_file(
         tool = "//build_tools:gen_win32_resource_header",
     )
 
+# Alias to the rule for Windows resource
+mozc_win32_resource = windows_resource
+
+register_extension_info(
+    extension = mozc_win32_resource,
+    label_regex_for_dep = "{extension_name}",
+)
+
 def mozc_win32_resource_from_template(
         name,
         src,
@@ -200,10 +208,7 @@ def mozc_win32_resource_from_template(
         "GoogleJapaneseInput": ["GOOGLE_JAPANESE_INPUT_BUILD"],
     }.get(BRANDING, [])
 
-    # Create main resource
-    win32_resource_files_main = windows_resource
-
-    win32_resource_files_main(
+    mozc_win32_resource(
         name = name,
         rc_files = [":" + generated_rc_file],
         manifests = manifests,

--- a/src/build_tools/embed_file.py
+++ b/src/build_tools/embed_file.py
@@ -32,6 +32,7 @@
 import argparse
 import os
 import sys
+import textwrap
 
 
 def _ParseArgs():
@@ -70,7 +71,9 @@ def _EmbedAsStringView(input_path, name, output_file):
     sys.exit(1)
 
   # 3. Validate delimiter conflict
-  delimiter_conflict = f'){name}'
+  # C++ Raw String literal delimiters have a length limit of 16 characters.
+  delimiter = name[:16]
+  delimiter_conflict = f'){delimiter}'
   if delimiter_conflict in content:
     sys.stderr.write(
         f'Error: {input_path} contains the delimiter string'
@@ -79,27 +82,26 @@ def _EmbedAsStringView(input_path, name, output_file):
     )
     sys.exit(1)
 
-  output_file.write("""\
-#ifdef MOZC_EMBEDDED_FILE_%(name)s
-#error "%(name)s was already included or defined elsewhere"
-#else
-#define MOZC_EMBEDDED_FILE_%(name)s
-constexpr absl::string_view %(name)s = R"%(name)s(
-%(content)s)%(name)s";
-#endif  // MOZC_EMBEDDED_FILE_%(name)s
-""" % {'name': name, 'content': content})
+  output_file.write(textwrap.dedent(f"""\
+      #ifdef MOZC_EMBEDDED_FILE_{name}
+      #error "{name} was already included or defined elsewhere"
+      #else
+      #define MOZC_EMBEDDED_FILE_{name}
+      constexpr absl::string_view {name} = R"{delimiter}({content}){delimiter}";
+      #endif  // MOZC_EMBEDDED_FILE_{name}
+      """))
 
 
 def _EmbedAsUint64Array(input_path, name, output_file):
   """Embed file as uint64_t array using EmbeddedFile struct."""
 
-  output_file.write("""\
-#ifdef MOZC_EMBEDDED_FILE_%(name)s
-#error "%(name)s was already included or defined elsewhere"
-#else
-#define MOZC_EMBEDDED_FILE_%(name)s
-constexpr uint64_t %(name)s_data[] = {
-""" % {'name': name})
+  output_file.write(textwrap.dedent(f"""\
+      #ifdef MOZC_EMBEDDED_FILE_{name}
+      #error "{name} was already included or defined elsewhere"
+      #else
+      #define MOZC_EMBEDDED_FILE_{name}
+      constexpr uint64_t {name}_data[] = {{
+      """))
 
   with open(input_path, 'rb') as infile:
     # Read in chunks of 32 bytes (representing one printed line of 4 uint64_t
@@ -115,14 +117,15 @@ constexpr uint64_t %(name)s_data[] = {
       # Write the entire row to the output file (indenting with 2 spaces)
       output_file.write('  ' + ', '.join(hex_strings) + ',\n')
 
-  output_file.write("""\
-};
-constexpr EmbeddedFile %(name)s = {
-  %(name)s_data,
-  %(size)d,
-};
-#endif  // MOZC_EMBEDDED_FILE_%(name)s
-""" % {'name': name, 'size': os.stat(input_path).st_size})
+  size = os.stat(input_path).st_size
+  output_file.write(textwrap.dedent(f"""\
+      }};
+      constexpr EmbeddedFile {name} = {{
+        {name}_data,
+        {size},
+      }};
+      #endif  // MOZC_EMBEDDED_FILE_{name}
+      """))
 
 
 def main():

--- a/src/engine/data_loader_test.cc
+++ b/src/engine/data_loader_test.cc
@@ -37,7 +37,6 @@
 #include "absl/random/random.h"
 #include "absl/status/status.h"
 #include "absl/strings/string_view.h"
-#include "absl/time/clock.h"
 #include "absl/time/time.h"
 #include "data_manager/data_manager.h"
 #include "protocol/engine_builder.pb.h"
@@ -107,8 +106,11 @@ TEST_F(DataLoaderTest, AsyncBuild) {
         return absl::OkStatus();
       }));
 
-  // Sends the same request. It is accepted, but callback is not called.
-  EXPECT_TRUE(loader.StartNewDataBuildTask(request_, kNeverCalled));
+  // Sends the same request again. The callback is never called for the
+  // duplicate (guaranteed by kNeverCalled). Whether the call returns true
+  // depends on whether the first load has already finished by this point, so
+  // its return value is timing-dependent and intentionally not asserted.
+  loader.StartNewDataBuildTask(request_, kNeverCalled);
 
   loader.Wait();
 
@@ -282,8 +284,12 @@ TEST_F(DataLoaderTest, WaitHighPriorityDataTimeoutTest) {
   EXPECT_TRUE(loader.StartNewDataBuildTask(make_request(100), callback));
   EXPECT_TRUE(loader.StartNewDataBuildTask(make_request(200), callback));
 
-  // Timeout. priority = 50 is loaded.
-  absl::SleepFor(absl::Milliseconds(200));
+  // No high priority data is registered, so the loader waits for the internal
+  // timeout and then loads the current top-priority request (priority = 50).
+  // Wait for that load to finish rather than racing a fixed sleep against the
+  // timeout, which is flaky on loaded machines.
+  loader.Wait();
+  EXPECT_EQ(callback_called, 1);  // only 50.
 
   // Then priority = 10 is loaded.
   EXPECT_TRUE(loader.StartNewDataBuildTask(make_request(10), callback));


### PR DESCRIPTION
## 概要

この PR では、upstream Mozc の変更のうち、Mozkey の変換ロジック、Zenz live correction、renderer runtime、installer / TIP 登録に直接影響しにくい build / tooling / test 系の小さな変更を取り込みました。

upstream 側には converter、boundary.def、renderer style sanitizer、installer、version 周辺など Mozkey の独自変更と衝突しやすい変更も含まれているため、この PR では低リスクな変更に限定しています。

## 取り込んだ upstream commit

- ce4f2480c5d8 Refactoring of embed_file.py.
- 9afbd9860f30 Make //engine:data_loader_test deterministic (#1522)
- e3e467ef9ece Register Mozc Starlark macros with build_cleaner.
- ecf3825501e8 Introduce an alias for Windows resource rules.

## 主な変更

- `embed_file.py` の出力処理を upstream に合わせて整理
  - C++ raw string delimiter を 16 文字以内に制限
  - `--as_string_view` 出力時の不要な先頭改行を削除
- `//engine:data_loader_test` の timing-dependent な assertion を避け、flaky になりにくい形に修正
- build cleaner 向けに Mozc Starlark macro / Windows resource rule alias を登録
- Windows resource rule を `mozc_win32_resource` alias 経由で扱うように整理

## 確認

- `bazelisk --output_user_root=C:/bzl test --config oss_windows //build_tools/... //engine:data_loader_test --test_output=errors --verbose_failures`
- `bazelisk --output_user_root=C:/bzl build --config oss_windows --config release_build //renderer/... --verbose_failures`
- `bazelisk --output_user_root=C:/bzl test --config oss_windows //renderer/... --test_output=errors --verbose_failures`
- `bazelisk --output_user_root=C:/bzl build --config oss_windows --config release_build //server:mozc_server --verbose_failures`
- `bazelisk --output_user_root=C:/bzl build --config oss_windows --config release_build package --verbose_failures`
- `git diff --check main..HEAD`

## 補足

`embed_file.py --as_string_view` の実使用箇所は `renderer_style.textproto` の埋め込みのみであることを確認しました。renderer build / test も通っているため、今回の先頭改行削除による実害はないと判断しています。

converter、dictionary、boundary.def、prediction、Zenz、renderer sanitizer、installer / TIP 周辺の upstream 変更は、この PR には含めず、後続 PR で個別に確認します。
