### PR TITLE
Upstream sync/20260624 base tooling

### DIFF
--- a/src/base/BUILD.bazel
+++ b/src/base/BUILD.bazel
@@ -433,10 +433,12 @@ mozc_cc_library(
         ":mmap",
         ":port",
         "//base/strings:pfchar",
+        "@com_google_absl//absl/base",
         "@com_google_absl//absl/log",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/strings:resize_and_overwrite",
         "@com_google_absl//absl/strings:str_format",
         "@com_google_absl//absl/types:span",
     ] + mozc_select(

--- a/src/base/android_util.cc
+++ b/src/base/android_util.cc
@@ -94,7 +94,7 @@ bool AndroidUtil::GetPropertyFromFile(const std::string& key,
   bool found = false;
   std::string lhs;
   std::string rhs;
-  while (getline(ifs, line)) {
+  while (std::getline(ifs, line)) {
     if (!mozc::AndroidUtil::ParseLine(line, &lhs, &rhs)) {
       continue;
     }

--- a/src/base/file_util.cc
+++ b/src/base/file_util.cc
@@ -43,9 +43,11 @@
 #include <system_error>  // NOLINT(build/c++11)
 #include <utility>
 
+#include "absl/base/casts.h"
 #include "absl/log/log.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
+#include "absl/strings/resize_and_overwrite.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_format.h"
 #include "absl/strings/str_replace.h"
@@ -625,8 +627,11 @@ absl::StatusOr<std::string> FileUtil::GetContents(
   ifs.seekg(0, std::ios_base::beg);
   std::string content;
   if (mode & std::ios::binary) {
-    content.resize(size);
-    ifs.read(content.data(), size);
+    absl::StringResizeAndOverwrite(
+        content, size, [&](char* buf, size_t buf_size) {
+          ifs.read(buf, buf_size);
+          return absl::implicit_cast<size_t>(ifs.gcount());
+        });
   } else {
     // In the text mode, the read size can be smaller than the file size as
     // "\r\n" can be translated to "\n" on Windows. Therefore, we just reserve a

--- a/src/base/strings/unicode_test.cc
+++ b/src/base/strings/unicode_test.cc
@@ -405,7 +405,7 @@ TEST_P(Utf8AsCharsTest, Substring) {
 
 // Tests if the `DCHECK` fo reading the `end` iterator hits.
 // `DCHECK` is enabled only if `NDEBUG` is not defined.
-#if !defined(NDEBUG)
+#if !defined(NDEBUG) && defined(EXPECT_DEATH)
 TEST(Utf8AsCharsDeathTest, Empty) {
   Utf8AsUnicodeChar utf8_as_unicode_char("");
   auto it = utf8_as_unicode_char.begin();
@@ -425,7 +425,7 @@ TEST(Utf8AsCharsDeathTest, End) {
   EXPECT_DEATH(it.char32(), "");
   EXPECT_DEATH(++it, "");
 }
-#endif  // !defined(NDEBUG)
+#endif  // !defined(NDEBUG) && defined(EXPECT_DEATH)
 
 TEST(Utf8AsCharsStandaloneTest, Comparators) {
   const Utf8AsChars a("aA");

--- a/src/base/win32/BUILD.bazel
+++ b/src/base/win32/BUILD.bazel
@@ -210,6 +210,7 @@ mozc_cc_library(
         "@com_google_absl//absl/base:core_headers",
         "@com_google_absl//absl/log:check",
         "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/strings:resize_and_overwrite",
     ],
 )
 

--- a/src/base/win32/wide_char.cc
+++ b/src/base/win32/wide_char.cc
@@ -38,6 +38,7 @@
 
 #include "absl/base/casts.h"
 #include "absl/log/check.h"
+#include "absl/strings/resize_and_overwrite.h"
 #include "absl/strings/string_view.h"
 
 namespace mozc::win32 {
@@ -71,18 +72,20 @@ std::wstring Utf8ToWide(const absl::string_view input) {
     return std::wstring();
   }
 
-  size_t wchar_count = WideCharsLen(input);
+  const size_t wchar_count = WideCharsLen(input);
   std::wstring result;
   // MultiByteToWideChar doesn't null-terminate the output string when the
   // length is explicitly specified.
-  result.resize(wchar_count);
-
-  // This API call should always succeed as long as the codepage (CP_UTF8) and
-  // flag (0) are valid.
-  const int copied_wchars = ::MultiByteToWideChar(
-      CP_UTF8, 0, input.data(), input.size(), result.data(), result.size());
-  CHECK_GE(copied_wchars, 0);
-  DCHECK_EQ(wchar_count, copied_wchars);
+  absl::StringResizeAndOverwrite(
+      result, wchar_count, [&](wchar_t* buf, size_t size) {
+        // This API call should always succeed as long as the codepage
+        // (CP_UTF8) and flag (0) are valid.
+        const int copied_wchars = ::MultiByteToWideChar(
+            CP_UTF8, 0, input.data(), input.size(), buf, size);
+        CHECK_GE(copied_wchars, 0);
+        DCHECK_EQ(wchar_count, copied_wchars);
+        return absl::implicit_cast<size_t>(copied_wchars);
+      });
   return result;
 }
 
@@ -102,13 +105,15 @@ std::string WideToUtf8(const std::wstring_view input) {
   std::string result;
   // WideCharToMultiByte doesn't null-terminate the output string when the
   // length is explicitly specified.
-  result.resize(char_count);
-  const int copied_chars =
-      ::WideCharToMultiByte(CP_UTF8, 0, input.data(), input.size(),
-                            result.data(), result.size(), nullptr, nullptr);
-
-  CHECK_GE(copied_chars, 0);
-  DCHECK_EQ(char_count, copied_chars);
+  absl::StringResizeAndOverwrite(
+      result, char_count, [&](char* buf, size_t size) {
+        const int copied_chars =
+            ::WideCharToMultiByte(CP_UTF8, 0, input.data(), input.size(), buf,
+                                  size, nullptr, nullptr);
+        CHECK_GE(copied_chars, 0);
+        DCHECK_EQ(char_count, copied_chars);
+        return absl::implicit_cast<size_t>(copied_chars);
+      });
   return result;
 }
 


### PR DESCRIPTION
## 概要

この PR では、upstream Mozc の base / test 周辺の小さな更新を取り込みました。

converter、dictionary、boundary.def、prediction、renderer sanitizer、installer / TIP 周辺の変更は含めていません。

## 取り込んだ upstream commit

- 759ae2c66d98 Restrict Utf8AsCharsDeathTest to environments where EXPECT_DEATH is defined.
- 2a8aa23ef823 Fix 1 ClangTidyReadability finding
- 6fce2f32cf43 Avoid unnecessary string-resizes in wide_char.cc
- ff20a11465ad Avoid unnecessary string-resizes in file_util.cc

## 主な変更

- `Utf8AsCharsDeathTest` を `EXPECT_DEATH` が使える環境だけで compile するように修正
- `android_util.cc` の `getline` 呼び出しを `std::getline` に明示化
- Windows の UTF-8 / wide string 変換処理で `absl::StringResizeAndOverwrite` を使用
- `FileUtil::GetContents` の binary read で `absl::StringResizeAndOverwrite` を使用

## 除外した upstream commit

- `642e73fe330e Migrate py_test files in mozc build_tools to absl.testing.absltest`
  - 現行 Mozkey の `oss_windows` 構成では `//third_party/py/absl/testing:absltest` が `--deleted_packages` により利用できないため、この PR では除外しました。
- `988fbca7744f Refactor SystemUtil::GetOSVersionString...`
  - `src/base/system_util.cc` で conflict したため、この PR では除外しました。内容は codehealth refactor であり、今回の同期対象として必須ではないと判断しています。

## 確認

- `bazelisk --output_user_root=C:/bzl test --config oss_windows //base/... --test_output=errors --verbose_failures`
- `bazelisk --output_user_root=C:/bzl build --config oss_windows --config release_build //server:mozc_server --verbose_failures`
- `bazelisk --output_user_root=C:/bzl build --config oss_windows --config release_build package --verbose_failures`
- `git diff --check main..HEAD`
