### PR TITLE
Upstream sync/20260624 windows build

### DIFF
--- a/src/BUILD.bazel
+++ b/src/BUILD.bazel
@@ -222,6 +222,7 @@ cc_library(
             "_ATL_NO_HOSTING",
             "ID_TRACE_LEVEL=1",
             "_MIDL_USE_GUIDDEF_",
+            "NO_SHLWAPI_STRFCNS",
             "PSAPI_VERSION=2",
             "UNICODE",
             "_UNICODE",

--- a/src/base/file/recursive.cc
+++ b/src/base/file/recursive.cc
@@ -63,8 +63,6 @@
 #include <ftw.h>
 #endif  // __ANDROID__ || TARGET_OS_IPHONE
 
-#undef StrCat
-
 namespace mozc::file {
 
 #ifdef _WIN32

--- a/src/base/win32/win_util.cc
+++ b/src/base/win32/win_util.cc
@@ -54,11 +54,6 @@
 #include "base/vlog.h"
 #include "base/win32/wide_char.h"
 
-// Disable StrCat macro to use absl::StrCat.
-#ifdef StrCat
-#undef StrCat
-#endif  // StrCat
-
 namespace mozc {
 namespace {
 

--- a/src/renderer/win32/win32_image_util_test.cc
+++ b/src/renderer/win32/win32_image_util_test.cc
@@ -35,8 +35,6 @@
 
 #include <cstdlib>
 
-#undef StrCat
-
 #include <cstddef>
 #include <cstdint>
 #include <memory>

--- a/src/renderer/win32/win32_renderer_util_test.cc
+++ b/src/renderer/win32/win32_renderer_util_test.cc
@@ -33,8 +33,6 @@
 #include <atltypes.h>
 #include <windows.h>
 
-#undef StrCat  // b/328804050
-
 #include <bit>
 #include <cstdint>
 #include <memory>

--- a/src/win32/custom_action/custom_action.cc
+++ b/src/win32/custom_action/custom_action.cc
@@ -37,8 +37,6 @@
 #include <wow64apiset.h>
 // clang-format on
 
-#undef StrCat  // NOLINT: TODO: triggers clang-tidy, defined by windows.h.
-
 #include <cstdarg>
 #include <cstddef>
 #include <memory>

--- a/src/win32/tip/build_tip_forwarder_dll.py
+++ b/src/win32/tip/build_tip_forwarder_dll.py
@@ -307,8 +307,11 @@ def build_on_windows(args: argparse.Namespace) -> None:
         info.get_rc_file_content(), encoding='utf-8', newline='\r\n'
     )
 
+    # Note: '/c65001' specifies UTF-8 codepage for rc.exe.
+    # Previously this was passed as '/8', which is an invalid option for rc.exe
+    # (fatal error RC1106: invalid option: /8) on Windows 11 SDK (10.0.22621.0).
     exec_command(
-        [rc, '/nologo', '/r', '/8', str(rc_file)],
+        [rc, '/nologo', '/r', '/c65001', str(rc_file)],
         cwd=work_dir,
         env=env,
         dryrun=args.dryrun,


### PR DESCRIPTION
## 概要

この PR では、upstream Mozc の Windows build / resource 周辺の小さな更新を取り込みました。

converter、dictionary、boundary.def、prediction、renderer sanitizer、installer / TIP 登録ロジック本体の変更は含めていません。

## 取り込んだ upstream commit

* fdfcc30b9b1f Define `NO_SHLWAPI_STRFCNS` to not define `StrCat` (#1508)
* 28da5a39f9a7 Use `/c65001` instead of `/8` in rc.exe command in `build_tip_forwarder_dll.py`

## 主な変更

* Windows build で `StrCat` macro の名前衝突を避けるため、`NO_SHLWAPI_STRFCNS` を定義
* それに伴い、各ファイルに個別に置かれていた `#undef StrCat` を削除
* TIP forwarder DLL の resource compile 時に、`rc.exe` の文字コード指定を `/8` から `/c65001` に更新

## 補足

`src/win32/custom_action/custom_action.cc` にも差分がありますが、installer custom action の処理内容を変更したものではなく、`StrCat` macro 回避のための preprocessor 整理のみです。

そのため、この PR では実機インストールは行わず、Windows build / renderer test / package build によって確認しています。

## 確認

* `bazelisk --output_user_root=C:/bzl test --config oss_windows //base/win32/... --test_output=errors --verbose_failures`
* `bazelisk --output_user_root=C:/bzl test --config oss_windows //renderer/... --test_output=errors --verbose_failures`
* `bazelisk --output_user_root=C:/bzl build --config oss_windows --config release_build //server:mozc_server --verbose_failures`
* `bazelisk --output_user_root=C:/bzl build --config oss_windows --config release_build package --verbose_failures`
* `git diff --check main..HEAD`
