### PR TITLE
Upstream sync/20260624 sanitizer foundation

### DIFF
--- a/src/base/BUILD.bazel
+++ b/src/base/BUILD.bazel
@@ -323,6 +323,7 @@ mozc_cc_library(
     visibility = ["//:__subpackages__"],
     deps = [
         ":util",
+        "//base/strings:unicode",
         "@com_google_absl//absl/strings",
     ],
 )
@@ -334,6 +335,7 @@ mozc_cc_test(
     deps = [
         ":text_normalizer",
         "//testing:gunit_main",
+        "@com_google_absl//absl/strings",
     ],
 )
 

--- a/src/base/BUILD.bazel
+++ b/src/base/BUILD.bazel
@@ -27,6 +27,8 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+load("@com_google_protobuf//bazel:cc_proto_library.bzl", "cc_proto_library")
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
 load(
     "//:build_defs.bzl",
     "mozc_cc_library",
@@ -1092,5 +1094,54 @@ mozc_cc_test(
         "@com_google_absl//absl/algorithm:container",
         "@com_google_absl//absl/strings:string_view",
         "@com_google_absl//absl/types:span",
+    ],
+)
+
+mozc_cc_library(
+    name = "protobuf_util",
+    srcs = ["protobuf_util.cc"],
+    hdrs = ["protobuf_util.h"],
+    tags = ["noandroid"],
+    target_compatible_with = mozc_select(
+        android = ["@platforms//:incompatible"],
+        default = [],
+        ios = ["@platforms//:incompatible"],
+        macos = [],
+    ),
+    visibility = ["//:__subpackages__"],
+    deps = [
+        "//base/protobuf:descriptor",
+        "//base/protobuf:message",
+        "@com_google_absl//absl/functional:function_ref",
+        "@com_google_absl//absl/strings:string_view",
+    ],
+)
+
+proto_library(
+    name = "protobuf_util_test_proto",
+    testonly = True,
+    srcs = ["protobuf_util_test.proto"],
+)
+
+cc_proto_library(
+    name = "protobuf_util_test_cc_proto",
+    testonly = True,
+    deps = [":protobuf_util_test_proto"],
+)
+
+mozc_cc_test(
+    name = "protobuf_util_test",
+    size = "small",
+    srcs = ["protobuf_util_test.cc"],
+    tags = ["noandroid"],
+    target_compatible_with = mozc_select(
+        android = ["@platforms//:incompatible"],
+        ios = ["@platforms//:incompatible"],
+    ),
+    deps = [
+        ":protobuf_util",
+        ":protobuf_util_test_cc_proto",
+        "//testing:gunit_main",
+        "@com_google_absl//absl/strings:string_view",
     ],
 )

--- a/src/base/protobuf_util.cc
+++ b/src/base/protobuf_util.cc
@@ -1,0 +1,102 @@
+// Copyright 2010-2021, Google Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "base/protobuf_util.h"
+
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "absl/functional/function_ref.h"
+#include "absl/strings/string_view.h"
+#include "base/protobuf/descriptor.h"
+#include "base/protobuf/message.h"
+
+namespace mozc {
+namespace protobuf_util {
+
+void SanitizeMessageStrings(
+    protobuf::Message& message,
+    absl::FunctionRef<std::optional<std::string>(absl::string_view)>
+        sanitizer) {
+  const protobuf::Reflection* reflection = message.GetReflection();
+
+  // ListFields only populates fields that are explicitly set in the message.
+  std::vector<const protobuf::FieldDescriptor*> fields;
+  reflection->ListFields(message, &fields);
+
+  for (const protobuf::FieldDescriptor* field : fields) {
+    // Recursively sanitize nested messages.
+    if (field->type() == protobuf::FieldDescriptor::TYPE_MESSAGE) {
+      if (field->is_repeated()) {
+        const int count = reflection->FieldSize(message, field);
+        for (int i = 0; i < count; ++i) {
+          protobuf::Message* sub_message =
+              reflection->MutableRepeatedMessage(&message, field, i);
+          SanitizeMessageStrings(*sub_message, sanitizer);
+        }
+      } else {
+        protobuf::Message* sub_message =
+            reflection->MutableMessage(&message, field);
+        SanitizeMessageStrings(*sub_message, sanitizer);
+      }
+      continue;
+    }
+
+    // Only sanitize strings.
+    if (field->type() != protobuf::FieldDescriptor::TYPE_STRING) {
+      continue;
+    }
+
+    // Sanitize a non-repeated string.
+    if (!field->is_repeated()) {
+      const absl::string_view val = reflection->GetStringView(message, field);
+      if (std::optional<std::string> new_val = sanitizer(val);
+          new_val.has_value()) {
+        reflection->SetString(&message, field, *std::move(new_val));
+      }
+      continue;
+    }
+
+    // Sanitize repeated strings.
+    const int count = reflection->FieldSize(message, field);
+    for (int i = 0; i < count; ++i) {
+      const absl::string_view val =
+          reflection->GetRepeatedStringView(message, field, i);
+      if (std::optional<std::string> new_val = sanitizer(val);
+          new_val.has_value()) {
+        reflection->SetRepeatedString(&message, field, i, *std::move(new_val));
+      }
+    }
+  }
+}
+
+}  // namespace protobuf_util
+}  // namespace mozc

--- a/src/base/protobuf_util.cc
+++ b/src/base/protobuf_util.cc
@@ -77,7 +77,9 @@ void SanitizeMessageStrings(
 
     // Sanitize a non-repeated string.
     if (!field->is_repeated()) {
-      const absl::string_view val = reflection->GetStringView(message, field);
+      protobuf::Reflection::ScratchSpace scratch;
+      const absl::string_view val =
+          reflection->GetStringView(message, field, scratch);
       if (std::optional<std::string> new_val = sanitizer(val);
           new_val.has_value()) {
         reflection->SetString(&message, field, *std::move(new_val));
@@ -87,9 +89,10 @@ void SanitizeMessageStrings(
 
     // Sanitize repeated strings.
     const int count = reflection->FieldSize(message, field);
+    protobuf::Reflection::ScratchSpace scratch;
     for (int i = 0; i < count; ++i) {
       const absl::string_view val =
-          reflection->GetRepeatedStringView(message, field, i);
+          reflection->GetRepeatedStringView(message, field, i, scratch);
       if (std::optional<std::string> new_val = sanitizer(val);
           new_val.has_value()) {
         reflection->SetRepeatedString(&message, field, i, *std::move(new_val));

--- a/src/base/protobuf_util.h
+++ b/src/base/protobuf_util.h
@@ -1,0 +1,54 @@
+// Copyright 2010-2021, Google Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#ifndef MOZC_BASE_PROTOBUF_UTIL_H_
+#define MOZC_BASE_PROTOBUF_UTIL_H_
+
+#include <optional>
+#include <string>
+
+#include "absl/functional/function_ref.h"
+#include "absl/strings/string_view.h"
+#include "base/protobuf/message.h"
+
+namespace mozc {
+namespace protobuf_util {
+
+// Applies `sanitizer` to all string fields in the given `message` (including
+// nested messages). If `sanitizer` returns a string, the field is replaced.
+// If it returns std::nullopt, the field is left unchanged.
+void SanitizeMessageStrings(
+    protobuf::Message& message,
+    absl::FunctionRef<std::optional<std::string>(absl::string_view)>
+        sanitizer);
+
+}  // namespace protobuf_util
+}  // namespace mozc
+
+#endif  // MOZC_BASE_PROTOBUF_UTIL_H_

--- a/src/base/protobuf_util_test.cc
+++ b/src/base/protobuf_util_test.cc
@@ -1,0 +1,115 @@
+// Copyright 2010-2021, Google Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "base/protobuf_util.h"
+
+#include <optional>
+#include <string>
+
+#include "absl/strings/string_view.h"
+#include "base/protobuf_util_test.pb.h"
+#include "testing/gunit.h"
+
+namespace mozc {
+namespace {
+
+TEST(ProtobufUtilTest, SanitizeMessageStrings) {
+  protobuf_util::TestMessage style;
+  style.set_test_string("test_string");
+  style.set_logo_file_name("logo.png");
+  style.set_is_enabled(false);
+
+  protobuf_util::TestMessage::TextStyle* text_style =
+      style.mutable_shortcut_style();
+  text_style->set_font_name("font_name");
+  text_style->set_font_size(10);
+
+  protobuf_util::SanitizeMessageStrings(
+      style, [](absl::string_view src) -> std::optional<std::string> {
+        if (src == "test_string") {
+          return "sanitized_test_string";
+        }
+        if (src == "font_name") {
+          return "sanitized_font_name";
+        }
+        return std::nullopt;  // Unchanged
+      });
+
+  EXPECT_EQ(style.test_string(), "sanitized_test_string");  // Changed
+  EXPECT_EQ(style.logo_file_name(), "logo.png");            // Unchanged
+  EXPECT_FALSE(style.is_enabled());                         // Unchanged
+  ASSERT_TRUE(style.has_shortcut_style());
+  EXPECT_EQ(style.shortcut_style().font_name(),
+            "sanitized_font_name");                    // Changed
+  EXPECT_EQ(style.shortcut_style().font_size(), 10);   // Unchanged
+}
+
+TEST(ProtobufUtilTest, SanitizeMessageStrings_RepeatedMessage) {
+  protobuf_util::TestRepeatedMessage storage;
+  protobuf_util::TestRepeatedMessage::Dictionary* dict1 =
+      storage.add_dictionaries();
+  dict1->set_name("dict1");
+  protobuf_util::TestRepeatedMessage::Entry* entry1 = dict1->add_entries();
+  entry1->set_key("key1");
+  entry1->set_value("value1");
+  entry1->set_score(1.5f);
+
+  protobuf_util::TestRepeatedMessage::Dictionary* dict2 =
+      storage.add_dictionaries();
+  dict2->set_name("dict2");
+  protobuf_util::TestRepeatedMessage::Entry* entry2 = dict2->add_entries();
+  entry2->set_key("key2");
+  entry2->set_value("value2");
+
+  protobuf_util::SanitizeMessageStrings(
+      storage, [](absl::string_view src) -> std::optional<std::string> {
+        if (src == "dict1") {
+          return "sanitized_dict1";
+        }
+        if (src == "key2") {
+          return "sanitized_key2";
+        }
+        if (src == "value1") {
+          return "sanitized_value1";
+        }
+        return std::nullopt;
+      });
+
+  EXPECT_EQ(storage.dictionaries(0).name(), "sanitized_dict1");
+  EXPECT_EQ(storage.dictionaries(0).entries(0).key(), "key1");
+  EXPECT_EQ(storage.dictionaries(0).entries(0).value(), "sanitized_value1");
+  EXPECT_EQ(storage.dictionaries(0).entries(0).score(), 1.5f);  // Unchanged
+
+  EXPECT_EQ(storage.dictionaries(1).name(), "dict2");
+  EXPECT_EQ(storage.dictionaries(1).entries(0).key(), "sanitized_key2");
+  EXPECT_EQ(storage.dictionaries(1).entries(0).value(), "value2");
+}
+
+}  // namespace
+}  // namespace mozc

--- a/src/base/protobuf_util_test.proto
+++ b/src/base/protobuf_util_test.proto
@@ -1,0 +1,60 @@
+// Copyright 2010-2021, Google Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+// Protocol buffer messages for testing protobuf_util.
+syntax = "proto2";
+
+package mozc.protobuf_util;
+
+option java_package = "mozc.protobufutil";
+
+message TestMessage {
+  optional string test_string = 1;
+  optional string logo_file_name = 2;
+  optional bool is_enabled = 3 [default = true];
+
+  message TextStyle {
+    optional string font_name = 1;
+    optional int32 font_size = 2;
+  }
+  optional TextStyle shortcut_style = 4;
+}
+
+message TestRepeatedMessage {
+  message Entry {
+    optional string key = 1;
+    optional string value = 2;
+    optional float score = 3;
+  }
+  message Dictionary {
+    optional string name = 1;
+    repeated Entry entries = 2;
+  }
+  repeated Dictionary dictionaries = 1;
+}

--- a/src/base/text_normalizer.cc
+++ b/src/base/text_normalizer.cc
@@ -30,11 +30,14 @@
 #include "base/text_normalizer.h"
 
 #include <array>
+#include <cstddef>
 #include <cstdint>
+#include <optional>
 #include <string>
 #include <utility>
 
 #include "absl/strings/string_view.h"
+#include "base/strings/unicode.h"
 #include "base/util.h"
 
 namespace mozc {
@@ -230,5 +233,36 @@ std::string TextNormalizer::NormalizeTextToSvs(absl::string_view input) {
     return output;
   }
   return std::string(input.data(), input.size());
+}
+
+std::optional<std::string> TextNormalizer::SanitizeText(absl::string_view input,
+                                                        size_t max_bytes) {
+  auto is_valid_text = [](absl::string_view str, size_t max_bytes) {
+    if (str.size() > max_bytes) [[unlikely]] {
+      return false;
+    }
+    for (const UnicodeChar c : Utf8AsUnicodeChar(str)) {
+      if (!c.ok() || c.char32() < 32 || c.char32() == 127) [[unlikely]] {
+        return false;
+      }
+    }
+    return true;
+  };
+  if (is_valid_text(input, max_bytes)) [[likely]] {
+    return std::nullopt;
+  }
+
+  std::string sanitized;
+  sanitized.reserve(max_bytes);
+  if (input.size() > max_bytes) {
+    input.remove_suffix(input.size() - max_bytes);
+  }
+  for (const UnicodeChar c : Utf8AsUnicodeChar(input)) {
+    if (!c.ok() || c.char32() < 32 || c.char32() == 127) {
+      continue;
+    }
+    sanitized.append(c.utf8());
+  }
+  return sanitized;
 }
 }  // namespace mozc

--- a/src/base/text_normalizer.h
+++ b/src/base/text_normalizer.h
@@ -33,6 +33,7 @@
 #ifndef MOZC_BASE_TEXT_NORMALIZER_H_
 #define MOZC_BASE_TEXT_NORMALIZER_H_
 
+#include <optional>
 #include <string>
 
 #include "absl/strings/string_view.h"
@@ -63,6 +64,12 @@ class TextNormalizer {
   // Returns false and keeps output as is, if no character is normalized.
   static bool NormalizeTextToSvs(absl::string_view input, std::string* output);
   static std::string NormalizeTextToSvs(absl::string_view input);
+
+  // Sanitizes the input text by enforcing byte limit, removing ASCII control
+  // characters, and filtering ill-formed UTF-8 sequences.
+  // Returns std::nullopt if no modification is necessary.
+  static std::optional<std::string> SanitizeText(absl::string_view input,
+                                                 size_t max_bytes);
 };
 
 }  // namespace mozc

--- a/src/base/text_normalizer_test.cc
+++ b/src/base/text_normalizer_test.cc
@@ -29,8 +29,10 @@
 
 #include "base/text_normalizer.h"
 
+#include <optional>
 #include <string>
 
+#include "absl/strings/string_view.h"
 #include "testing/gunit.h"
 
 namespace mozc {
@@ -119,6 +121,58 @@ TEST(TextNormalizerTest, NormalizeTextToSvs) {
   EXPECT_EQ(TextNormalizer::NormalizeTextToSvs("\uFA6D"), "\u8218\uFE00");
   // Next codeponit of 舘.
   EXPECT_EQ(TextNormalizer::NormalizeTextToSvs("\uFA6E"), "\uFA6E");
+}
+
+TEST(TextNormalizerTest, SanitizeText) {
+  // 1. No modifications
+  EXPECT_EQ(TextNormalizer::SanitizeText("abcあいう", 15), std::nullopt);
+  EXPECT_EQ(TextNormalizer::SanitizeText("", 10), std::nullopt);
+
+  // 2. Truncation by max_bytes (safely preserving UTF-8 boundaries)
+  // "あいうえお" is 15 bytes in UTF-8 (3 bytes per character).
+  // Triggered at limit 6 bytes (should cut exactly to "あい" -> 6 bytes).
+  EXPECT_EQ(*TextNormalizer::SanitizeText("あいうえお", 6), "あい");
+  EXPECT_EQ(*TextNormalizer::SanitizeText("あいうえお", 7), "あい");
+  EXPECT_EQ(*TextNormalizer::SanitizeText("あいうえお", 8), "あい");
+  EXPECT_EQ(*TextNormalizer::SanitizeText("あいうえお", 9), "あいう");
+
+  // 3. Skip control characters
+  EXPECT_EQ(
+      *TextNormalizer::SanitizeText(absl::string_view("abc\n\t\0def", 9), 10),
+      "abcdef");
+
+  // 4. Skip invalid UTF-8 sequences
+  // (including partial characters of "あ" \xE3\x81\x82)
+  EXPECT_EQ(*TextNormalizer::SanitizeText("abc\xFF""def", 10), "abcdef");
+  // \xE3 only (missing 2nd and 3rd bytes)
+  EXPECT_EQ(*TextNormalizer::SanitizeText("abc\xE3""def", 10), "abcdef");
+  // \xE3\x81 only (missing 3rd byte)
+  EXPECT_EQ(*TextNormalizer::SanitizeText("abc\xE3\x81""def", 10), "abcdef");
+  // \x81 only (missing 1st and 2nd bytes)
+  EXPECT_EQ(*TextNormalizer::SanitizeText("abc\x81""def", 10), "abcdef");
+  // \x81\x82 only (missing 1st byte)
+  EXPECT_EQ(*TextNormalizer::SanitizeText("abc\x81\x82""def", 10), "abcdef");
+
+  // 5. Valid emoji or SVS cases (no modifications -> std::nullopt)
+  // Emoji 😊 (4 bytes: \xF0\x9F\x98\x8A)
+  EXPECT_EQ(TextNormalizer::SanitizeText("😊", 10), std::nullopt);
+  // SVS 塚︀ (6 bytes: 塚\u585A [3] + FE00 [3])
+  EXPECT_EQ(TextNormalizer::SanitizeText("\u585A\uFE00", 10), std::nullopt);
+  // Combined Emoji and SVS (4 + 6 = 10 bytes)
+  EXPECT_EQ(TextNormalizer::SanitizeText("😊\u585A\uFE00", 10), std::nullopt);
+
+  // 6. Truncation of Emoji and SVS
+  // 😊 (4 bytes) triggers at 3 bytes -> truncated, broken byte ignored -> ""
+  EXPECT_EQ(*TextNormalizer::SanitizeText("😊", 3), "");
+  EXPECT_EQ(*TextNormalizer::SanitizeText("ab😊", 5), "ab");
+  // 塚︀ (6 bytes) truncated at 5 bytes -> U+FE00 SVS part is cut -> "\u585A"
+  EXPECT_EQ(*TextNormalizer::SanitizeText("\u585A\uFE00", 5), "\u585A");
+  EXPECT_EQ(*TextNormalizer::SanitizeText("\u585A\uFE00", 4), "\u585A");
+  EXPECT_EQ(*TextNormalizer::SanitizeText("\u585A\uFE00", 2), "");
+
+  // 7. Combined control skip and byte truncation
+  // "あ\nい\tうえお" is truncated by 11 bytes after skips -> "あいう".
+  EXPECT_EQ(*TextNormalizer::SanitizeText("あ\nい\tうえお", 11), "あいう");
 }
 
 }  // namespace mozc


### PR DESCRIPTION
## 概要

この PR では、upstream Mozc の sanitizer 基盤を取り込みました。

文字列 sanitizer の部品追加に限定し、user dictionary、RendererStyle、IBus config などへの実適用は含めていません。

## 取り込んだ upstream commit

* fa11e0a957d2 Add `TextNormalizer::SanitizeText` to filter invalid characters.
* 96c4937998f2 Add `ProtobufUtil` for sanitizing string fields in protobuf messages.
* fea1ebace034 Use `GetStringView` with `ScratchSpace`.

## 主な変更

* `TextNormalizer::SanitizeText` を追加

  * 最大 byte 数の制限
  * ASCII control character の除去
  * ill-formed UTF-8 sequence の除去
  * 変更不要な場合は `std::nullopt` を返す
* protobuf message 内の string field を再帰的に sanitize する `protobuf_util::SanitizeMessageStrings` を追加

  * nested message / repeated message / repeated string に対応
  * string field 以外は変更しない
  * sanitizer が `std::nullopt` を返した field は変更しない
* OSS build 向けに `Reflection::GetStringView` / `GetRepeatedStringView` へ `ScratchSpace` を渡す修正を追加

## 補足

この PR は sanitizer の基盤追加のみです。

以下のような実際の適用先は、この PR には含めていません。

* user dictionary entries への sanitizer 適用
* RendererStyle fields への sanitizer 適用
* IBus config proto への sanitizer 適用

日本語 IME では、改行、タブ、異体字セレクタ、絵文字、自由入力 text field などの扱いが field ごとに異なるため、実適用は別 PR で個別に確認します。

## 確認

* `bazelisk --output_user_root=C:/bzl test --config oss_windows //base:text_normalizer_test //base:protobuf_util_test --test_output=errors --verbose_failures`
* `bazelisk --output_user_root=C:/bzl test --config oss_windows //base/... --test_output=errors --verbose_failures`
* `bazelisk --output_user_root=C:/bzl build --config oss_windows --config release_build //server:mozc_server --verbose_failures`
* `bazelisk --output_user_root=C:/bzl build --config oss_windows --config release_build package --verbose_failures`
* `git diff --check main..HEAD`
