### PR TITLE
Use TextNormalizer for sanitizing user dictionary entries.

### DIFF
--- a/src/dictionary/BUILD.bazel
+++ b/src/dictionary/BUILD.bazel
@@ -380,14 +380,14 @@ mozc_cc_library(
         "//:__subpackages__",
     ],
     deps = [
+        "//base:text_normalizer",
         "//base:vlog",
         "//base/strings:japanese",
         "//base/strings:unicode",
         "//protocol:user_dictionary_storage_cc_proto",
-        "@com_google_absl//absl/algorithm:container",
         "@com_google_absl//absl/log",
         "@com_google_absl//absl/status",
-        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/strings:string_view",
     ],
 )
 

--- a/src/dictionary/user_dictionary_util.cc
+++ b/src/dictionary/user_dictionary_util.cc
@@ -31,19 +31,15 @@
 
 #include <string.h>
 
-#include <algorithm>
-#include <cstdint>
-#include <iterator>
-#include <memory>
+#include <optional>
 #include <string>
 #include <utility>
 
-#include "absl/algorithm/container.h"
 #include "absl/log/log.h"
 #include "absl/status/status.h"
-#include "absl/strings/str_replace.h"
 #include "absl/strings/string_view.h"
 #include "base/strings/japanese.h"
+#include "base/text_normalizer.h"
 #include "base/strings/unicode.h"
 #include "base/vlog.h"
 #include "protocol/user_dictionary_storage.pb.h"
@@ -155,40 +151,25 @@ absl::Status ValidateEntry(
 
 // static
 bool SanitizeEntry(user_dictionary::UserDictionary::Entry* entry) {
+  auto sanitize_field = [](std::string& field) -> bool {
+    if (std::optional<std::string> sanitized =
+            TextNormalizer::SanitizeText(field, kMaxStringSize)) {
+      field = *std::move(sanitized);
+      return true;
+    }
+    return false;
+  };
+
   bool modified = false;
-  modified |= Sanitize(entry->mutable_key(), kMaxStringSize);
-  modified |= Sanitize(entry->mutable_value(), kMaxStringSize);
+  modified |= sanitize_field(*entry->mutable_key());
+  modified |= sanitize_field(*entry->mutable_value());
+  modified |= sanitize_field(*entry->mutable_comment());
   if (!user_dictionary::UserDictionary::PosType_IsValid(entry->pos())) {
     // Fallback to NOUN.
     entry->set_pos(user_dictionary::UserDictionary::NOUN);
     modified = true;
   }
-  modified |= Sanitize(entry->mutable_comment(), kMaxStringSize);
   return modified;
-}
-
-// static
-bool Sanitize(std::string* str, size_t max_size) {
-  // First part: Remove invalid characters.
-  const int n = absl::StrReplaceAll(
-      {
-          {"\t", ""},
-          {"\n", ""},
-          {"\r", ""},
-      },
-      str);
-
-  // Second part: Truncate long strings.
-  if (str->size() <= max_size) {
-    return n > 0;
-  }
-  const Utf8AsChars chars(*str);
-  size_t pos = 0;
-  for (auto it = chars.begin(); pos + it.size() <= max_size; ++it) {
-    pos += it.size();
-  }
-  str->erase(pos);
-  return true;
 }
 
 absl::Status ValidateDictionaryName(const absl::string_view dictionary_name) {

--- a/src/dictionary/user_dictionary_util.h
+++ b/src/dictionary/user_dictionary_util.h
@@ -126,10 +126,7 @@ absl::Status ValidateEntry(const user_dictionary::UserDictionary::Entry& entry);
 // methods. Return true if the entry is changed.
 bool SanitizeEntry(user_dictionary::UserDictionary::Entry* entry);
 
-// Helper function for SanitizeEntry
-// "max_size" is the maximum allowed size of str. If str size exceeds
-// "max_size", remaining part is truncated by this function.
-bool Sanitize(std::string* str, size_t max_size);
+
 
 // Returns the error status of the validity for the given dictionary name.
 absl::Status ValidateDictionaryName(absl::string_view dictionary_name);

--- a/src/dictionary/user_dictionary_util_test.cc
+++ b/src/dictionary/user_dictionary_util_test.cc
@@ -130,36 +130,6 @@ TEST(UserDictionaryUtilTest, TestSanitizeEntry) {
   }
 }
 
-TEST(UserDictionaryUtilTest, TestSanitize) {
-  std::string str(10, '\t');
-  EXPECT_TRUE(Sanitize(&str, 5));
-  EXPECT_EQ(str, "");
-
-  str = "ab\tc";
-  EXPECT_TRUE(Sanitize(&str, 10));
-  EXPECT_EQ(str, "abc");
-
-  str = "かしゆか";
-  EXPECT_TRUE(Sanitize(&str, 3));
-  EXPECT_EQ(str, "か");
-
-  str = "かしゆか";
-  EXPECT_TRUE(Sanitize(&str, 4));
-  EXPECT_EQ(str, "か");
-
-  str = "かしゆか";
-  EXPECT_TRUE(Sanitize(&str, 5));
-  EXPECT_EQ(str, "か");
-
-  str = "かしゆか";
-  EXPECT_TRUE(Sanitize(&str, 6));
-  EXPECT_EQ(str, "かし");
-
-  str = "かしゆか";
-  EXPECT_FALSE(Sanitize(&str, 100));
-  EXPECT_EQ(str, "かしゆか");
-}
-
 TEST(UserDictionaryUtilTest, ValidateEntry) {
   // Create a valid entry.
   UserDictionary::Entry base_entry;


### PR DESCRIPTION
## 概要

この PR では、upstream Mozc の user dictionary sanitizer 更新を取り込みました。

第4弾で取り込んだ `TextNormalizer::SanitizeText` を、ユーザー辞書 entry の sanitize に利用する変更です。

RendererStyle、IBus config、converter、prediction、boundary.def などの変更は含めていません。

## 取り込んだ upstream commit

* 61bdcfc70af8 Use `TextNormalizer` for sanitizing user dictionary entries.

## 主な変更

* `UserDictionaryUtil::SanitizeEntry` の文字列 sanitize 処理を `TextNormalizer::SanitizeText` に統一
* sanitize 対象は user dictionary entry の以下の field

  * `key`
  * `value`
  * `comment`
* 従来の `\t` / `\n` / `\r` 除去と長すぎる文字列の切り詰めに加えて、以下も `TextNormalizer` 側で処理

  * ASCII control character
  * DEL `0x7f`
  * ill-formed UTF-8 sequence
* invalid な `pos` を `NOUN` に fallback する既存挙動は維持

## 補足

この PR は user dictionary entry の sanitizer 更新に限定しています。

`SanitizeEntry` の呼び出し箇所は dictionary tool 側の entry 更新・取り込み経路であり、既存辞書を load するだけで勝手に sanitize して保存する変更ではありません。

また、通常の日本語、絵文字、SVS は `TextNormalizer::SanitizeText` の byte limit 内では保持されます。

## 確認

* `bazelisk --output_user_root=C:/bzl test --config oss_windows //dictionary:user_dictionary_util_test --test_output=errors --verbose_failures`
* `bazelisk --output_user_root=C:/bzl test --config oss_windows //dictionary/... --test_output=errors --verbose_failures`
* `bazelisk --output_user_root=C:/bzl test --config oss_windows //base:text_normalizer_test --test_output=errors --verbose_failures`
* `bazelisk --output_user_root=C:/bzl build --config oss_windows --config release_build //server:mozc_server --verbose_failures`
* `bazelisk --output_user_root=C:/bzl build --config oss_windows --config release_build package --verbose_failures`
* `git diff --check main..HEAD`
