### PR TITLE
Add string sanitization to RendererStyle fields.

### DIFF
--- a/src/renderer/BUILD.bazel
+++ b/src/renderer/BUILD.bazel
@@ -251,7 +251,9 @@ mozc_cc_library(
     hdrs = ["renderer_style_handler.h"],
     visibility = ["//renderer:__subpackages__"],
     deps = [
+        "//base:protobuf_util",
         "//base:singleton",
+        "//base:text_normalizer",
         "//base/protobuf:text_format",
         "//protocol:renderer_cc_proto",
         "@com_google_absl//absl/log:check",

--- a/src/renderer/renderer_style_handler.cc
+++ b/src/renderer/renderer_style_handler.cc
@@ -37,7 +37,9 @@
 #include "absl/log/check.h"
 #include "absl/strings/string_view.h"
 #include "base/protobuf/text_format.h"
+#include "base/protobuf_util.h"
 #include "base/singleton.h"
+#include "base/text_normalizer.h"
 #include "protocol/renderer_style.pb.h"
 
 namespace mozc {
@@ -67,7 +69,6 @@ uint32_t ToRgb(const RendererStyle::RGBAColor& color, uint32_t fallback) {
          ((static_cast<uint32_t>(color.g()) & 0xff) << 8) |
          (static_cast<uint32_t>(color.b()) & 0xff);
 }
-
 
 int ScaleIntegerMetric(int value, uint32_t percent) {
   if (value <= 0) {
@@ -105,7 +106,8 @@ RendererStyleHandler::RubyWindowStyle RubyStyleFromRendererStyle(
     const RendererStyle& style) {
   RendererStyleHandler::RubyWindowStyle ruby_style;
   if (style.has_border_color()) {
-    ruby_style.border_color = ToRgb(style.border_color(), ruby_style.border_color);
+    ruby_style.border_color =
+        ToRgb(style.border_color(), ruby_style.border_color);
   }
   if (style.candidate_style().has_background_color()) {
     ruby_style.background_color =
@@ -227,6 +229,17 @@ void ApplyDarkCandidateWindowTheme(RendererStyle* style) {
   SetColor(infostyle->mutable_focused_border_color(), 0x3f, 0x4b, 0x59);
 }
 
+void SanitizeRendererStyleStrings(RendererStyle* style) {
+  if (style == nullptr) {
+    return;
+  }
+  protobuf_util::SanitizeMessageStrings(*style, [](absl::string_view src) {
+    // Limit the length of the string to 100 bytes and remove ill-formed
+    // UTF-8 sequences and ASCII control characters.
+    return TextNormalizer::SanitizeText(src, 100);
+  });
+}
+
 class RendererStyleHandlerImpl {
  public:
   RendererStyleHandlerImpl();
@@ -330,6 +343,7 @@ void RendererStyleHandlerImpl::GetDefaultRendererStyle(RendererStyle* style) {
   style->Clear();
   CHECK(mozc::protobuf::TextFormat::ParseFromString(kStyleTextProto, style));
   ApplyLightCandidateWindowTheme(style);
+  SanitizeRendererStyleStrings(style);
 }
 
 uint32_t RendererStyleHandlerImpl::GetCandidateWindowCornerRadius(


### PR DESCRIPTION
## 概要

この PR では、upstream Mozc の RendererStyle sanitizer を取り込みました。

第4弾で取り込んだ `protobuf_util::SanitizeMessageStrings` と `TextNormalizer::SanitizeText` を利用し、RendererStyle の string field を sanitize します。

IBus config、RendererStyle color refactor、converter、prediction、boundary.def などの変更は含めていません。

## 取り込んだ upstream commit

* c9ff09942301 Add string sanitization to RendererStyle fields.

## 主な変更

* `RendererStyle` 内の string field を sanitize する helper を追加
* `renderer_style.textproto` から default style を読み込んだ後、string field に対して sanitize を実行
* sanitize 内容

  * 最大 100 bytes への制限
  * ill-formed UTF-8 sequence の除去
  * ASCII control character の除去

## Mozkey 側での conflict 解消

Mozkey では `RendererStyleHandler` が以下のように拡張されています。

* singleton 経由で candidate / suggestion style を保持
* custom color を適用
* candidate window size を適用
* candidate / ruby font を適用
* ruby window style を保持

そのため、upstream の sanitizer block を `ApplyCandidateWindowTheme` には置かず、default style 読み込み直後の `RendererStyleHandlerImpl::GetDefaultRendererStyle` で呼ぶ形にしました。

これにより、default `renderer_style.textproto` 由来の string field を sanitize しつつ、Mozkey 独自の custom color / size / font 適用処理とは責務を分けています。

## 補足

RendererStyle の string field は主に以下です。

* `font_name`
* `caption_string`
* `column_minimum_width_string`
* `logo_file_name`

いずれも短い表示・resource 系文字列であり、100 bytes 制限と control character / ill-formed UTF-8 除去の対象として妥当と判断しています。

## 確認

* `bazelisk --output_user_root=C:/bzl test --config oss_windows //renderer:renderer_style_handler_test --test_output=errors --verbose_failures`
* `bazelisk --output_user_root=C:/bzl test --config oss_windows //renderer/... --test_output=errors --verbose_failures`
* `bazelisk --output_user_root=C:/bzl test --config oss_windows //base:protobuf_util_test //base:text_normalizer_test --test_output=errors --verbose_failures`
* `bazelisk --output_user_root=C:/bzl build --config oss_windows --config release_build //server:mozc_server --verbose_failures`
* `bazelisk --output_user_root=C:/bzl build --config oss_windows --config release_build package --verbose_failures`
* `git diff --check main..HEAD`
