### PR TITLE
Upstream sync/20260624 ibus config sanitizer

### DIFF
--- a/src/unix/ibus/BUILD.bazel
+++ b/src/unix/ibus/BUILD.bazel
@@ -261,7 +261,9 @@ mozc_cc_library(
     deps = [
         ":ibus_config_cc_proto",
         "//base:file_util",
+        "//base:protobuf_util",
         "//base:system_util",
+        "//base:text_normalizer",
         "//base/protobuf:text_format",
         "@com_google_absl//absl/log",
         "@com_google_absl//absl/status",

--- a/src/unix/ibus/BUILD.bazel
+++ b/src/unix/ibus/BUILD.bazel
@@ -44,6 +44,7 @@ load(
     "IBUS_MOZC_PATH",
     "LINUX_MOZC_SERVER_DIR",
 )
+load("//build_tools:embed_file.bzl", "mozc_embed_file")
 
 package(default_visibility = ["//visibility:private"])
 
@@ -240,12 +241,21 @@ cc_proto_library(
     deps = ["ibus_config_proto"],
 )
 
+mozc_embed_file(
+    name = "ibus_config_textproto_inc",
+    srcs = ["ibus_config.textproto"],
+    out = "ibus_config_textproto.inc",
+    as_string_view = True,
+    var_name = "kIbusConfigTextProto",
+)
+
 mozc_cc_library(
     name = "ibus_config",
     srcs = ["ibus_config.cc"],
     hdrs = [
         "ibus_config.h",
         ":gen_main_h",
+        ":ibus_config_textproto_inc",
     ],
     copts = ["-Wno-unused-variable"],
     deps = [

--- a/src/unix/ibus/gen_mozc_xml.py
+++ b/src/unix/ibus/gen_mozc_xml.py
@@ -67,12 +67,6 @@ def GetXmlElement(key, value):
   return '  <%s>%s</%s>' % (key, value, key)
 
 
-def GetTextProtoElement(key, value):
-  if isinstance(value, int) or key == 'composition_mode':
-    return '  %s : %s' % (key, value)
-  return '  %s : "%s"' % (key, value)
-
-
 def GetEnginesXml(engine_common, engines):
   """Outputs a XML data for ibus-daemon.
 
@@ -94,42 +88,6 @@ def GetEnginesXml(engine_common, engines):
       output.append(GetXmlElement(key, value))
     output.append('</engine>')
   output.append('</engines>')
-  return '\n'.join(output)
-
-
-def GetIbusConfigTextProto(engines):
-  """Outputs a TextProto data for iBus config.
-
-  Args:
-    engines: A dictionary from a property name to a list of property values of
-      engines. For example, {'name': ['mozc-jp', 'mozc', 'mozc-dv']}.
-
-  Returns:
-    output string in TextProto.
-  """
-  output = [
-      '# `ibus write-cache; ibus restart` might be necessary to apply changes.'
-  ]
-  for engine in engines:
-    output.append('engines {')
-    for key, value in engine.items():
-      output.append(GetTextProtoElement(key, value))
-    output.append('}')
-  output.append('active_on_launch: False')
-  output.append('mozc_renderer {')
-  output.append("  # Set 'False' to use IBus' candidate window.")
-  output.append('  enabled : True')
-  output.append(
-      "  # For Wayland sessions, 'mozc_renderer' will be used if and "
-      'only if any value'
-  )
-  output.append(
-      '  # set in this field (e.g. "GNOME", "KDE") is found in '
-      '$XDG_CURRENT_DESKTOP.'
-  )
-  output.append(f'  # {XDG_CURRENT_DESKTOP_URL}')
-  output.append('  compatible_wayland_desktop_names : ["GNOME"]')
-  output.append('}')
   return '\n'.join(output)
 
 
@@ -181,9 +139,6 @@ def OutputCpp(component, engine_common, engines):
   print('const size_t kEngineArrayLen = %s;' % len(engines))
   print('const char kEnginesXml[] = R"#(', end='')
   print(GetEnginesXml(engine_common, engines))
-  print(')#";')
-  print('const char kIbusConfigTextProto[] = R"#(', end='')
-  print(GetIbusConfigTextProto(engines))
   print(')#";')
   print(CPP_FOOTER % guard_name)
 

--- a/src/unix/ibus/ibus_config.cc
+++ b/src/unix/ibus/ibus_config.cc
@@ -51,6 +51,9 @@ namespace mozc {
 constexpr char kIbusConfigFile[] = "ibus_config.textproto";
 
 namespace {
+// Defines absl::string_view kIbusConfigTextProto.
+#include "unix/ibus/ibus_config_textproto.inc"
+
 std::string UpdateConfigFile() {
   const std::string engines_file = FileUtil::JoinPath(
       SystemUtil::GetUserProfileDirectory(), kIbusConfigFile);
@@ -58,7 +61,7 @@ std::string UpdateConfigFile() {
     absl::StatusOr<std::string> config = FileUtil::GetContents(engines_file);
     if (!config.ok()) {
       LOG(ERROR) << config.status();
-      return kIbusConfigTextProto;
+      return std::string(kIbusConfigTextProto);
     }
     return *std::move(config);
   } else if (absl::IsNotFound(s)) {
@@ -67,10 +70,10 @@ std::string UpdateConfigFile() {
         !s.ok()) {
       LOG(ERROR) << "Failed to write " << engines_file << ": " << s;
     }
-    return kIbusConfigTextProto;
+    return std::string(kIbusConfigTextProto);
   } else {
     LOG(ERROR) << "Cannot check if " << engines_file << "exists: " << s;
-    return kIbusConfigTextProto;
+    return std::string(kIbusConfigTextProto);
   }
 }
 

--- a/src/unix/ibus/ibus_config.cc
+++ b/src/unix/ibus/ibus_config.cc
@@ -43,12 +43,14 @@
 #include "base/file_util.h"
 #include "base/protobuf/text_format.h"
 #include "base/system_util.h"
+#include "base/protobuf_util.h"
+#include "base/text_normalizer.h"
 #include "unix/ibus/ibus_config.pb.h"
 #include "unix/ibus/main.h"
 
 namespace mozc {
 
-constexpr char kIbusConfigFile[] = "ibus_config.textproto";
+constexpr absl::string_view kIbusConfigFile = "ibus_config.textproto";
 
 namespace {
 // Defines absl::string_view kIbusConfigTextProto.
@@ -57,24 +59,28 @@ namespace {
 std::string UpdateConfigFile() {
   const std::string engines_file = FileUtil::JoinPath(
       SystemUtil::GetUserProfileDirectory(), kIbusConfigFile);
-  if (absl::Status s = FileUtil::FileExists(engines_file); s.ok()) {
+  absl::Status s = FileUtil::FileExists(engines_file);
+  if (s.ok()) {
     absl::StatusOr<std::string> config = FileUtil::GetContents(engines_file);
-    if (!config.ok()) {
-      LOG(ERROR) << config.status();
-      return std::string(kIbusConfigTextProto);
+    if (config.ok()) {
+      return *std::move(config);
     }
-    return *std::move(config);
-  } else if (absl::IsNotFound(s)) {
-    if (absl::Status s =
-            FileUtil::SetContents(engines_file, kIbusConfigTextProto);
-        !s.ok()) {
+
+    LOG(ERROR) << config.status();
+    return std::string(kIbusConfigTextProto);
+  }
+
+  if (absl::IsNotFound(s)) {
+    // If the file does not exist, create a new one with the default setting.
+    s = FileUtil::SetContents(engines_file, kIbusConfigTextProto);
+    if (!s.ok()) {
       LOG(ERROR) << "Failed to write " << engines_file << ": " << s;
     }
     return std::string(kIbusConfigTextProto);
-  } else {
-    LOG(ERROR) << "Cannot check if " << engines_file << "exists: " << s;
-    return std::string(kIbusConfigTextProto);
   }
+
+  LOG(ERROR) << "Cannot check if " << engines_file << "exists: " << s;
+  return std::string(kIbusConfigTextProto);
 }
 
 std::string NormalizeLayout(const std::string& layout) {
@@ -151,6 +157,12 @@ bool IbusConfig::Initialize() {
 
 bool IbusConfig::LoadConfig(const std::string& config_data) {
   const bool valid_user_config = ParseConfig(config_data, config_);
+
+  protobuf_util::SanitizeMessageStrings(config_, [](absl::string_view src) {
+    // Limit the length of each string field to 100 bytes and remove ill-formed
+    // UTF-8 sequences and ASCII control characters.
+    return TextNormalizer::SanitizeText(src, 100);
+  });
 
   engine_xml_ = CreateEnginesXml(config_);
   if (!valid_user_config) {

--- a/src/unix/ibus/ibus_config.textproto
+++ b/src/unix/ibus/ibus_config.textproto
@@ -1,0 +1,71 @@
+# Copyright 2010-2021, Google Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+#     * Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above
+# copyright notice, this list of conditions and the following disclaimer
+# in the documentation and/or other materials provided with the
+# distribution.
+#     * Neither the name of Google Inc. nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# proto-file: unix/ibus/ibus_config.proto
+# proto-message: mozc.ibus.Config
+#
+# `ibus write-cache; ibus restart` might be necessary to apply changes.
+engines {
+  name : "mozc-jp"
+  longname : "Mozc"
+  layout : "default"
+  layout_variant : ""
+  layout_option : ""
+  rank : 80
+  symbol : "あ"
+}
+engines {
+  name : "mozc-on"
+  longname : "Mozc:あ"
+  layout : "default"
+  layout_variant : ""
+  layout_option : ""
+  rank : 99
+  symbol : "あ"
+  composition_mode : HIRAGANA
+}
+engines {
+  name : "mozc-off"
+  longname : "Mozc:A_"
+  layout : "default"
+  layout_variant : ""
+  layout_option : ""
+  rank : 99
+  symbol : "A"
+  composition_mode : DIRECT
+}
+active_on_launch: False
+mozc_renderer {
+  # Set 'False' to use IBus' candidate window.
+  enabled : True
+  # For Wayland sessions, 'mozc_renderer' will be used if and only if any value
+  # set in this field (e.g. "GNOME", "KDE") is found in $XDG_CURRENT_DESKTOP.
+  # https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html#recognized-keys
+  compatible_wayland_desktop_names : ["GNOME"]
+}

--- a/src/unix/ibus/ibus_config.textproto
+++ b/src/unix/ibus/ibus_config.textproto
@@ -31,6 +31,12 @@
 # proto-message: mozc.ibus.Config
 #
 # `ibus write-cache; ibus restart` might be necessary to apply changes.
+#
+# Configuration reference:
+# https://github.com/google/mozc/blob/master/docs/configurations.md#ibus
+#
+# string fields are limited to 100 bytes.
+
 engines {
   name : "mozc-jp"
   longname : "Mozc"


### PR DESCRIPTION
## 概要

この PR では、upstream Mozc の IBus config 関連変更を取り込みました。

IBus config の default `.textproto` を `gen_mozc_xml.py` 内で生成する方式から、専用ファイル `ibus_config.textproto` として保持し、`mozc_embed_file` で埋め込む形に整理しています。

あわせて、IBus config の string field に対して sanitizer を適用し、ユーザー提供 config data に含まれる長すぎる文字列、ill-formed UTF-8、ASCII control character を除去するようにしました。

Windows renderer、TSF、Zenz、converter、dictionary、prediction、boundary.def などの変更は含めていません。

## 取り込んだ upstream commit

* 2c8465647a10 Move IBus config textproto to a dedicated file.
* 6407cfb22109 Sanitize string fields in IBus config proto.

## 主な変更

* `src/unix/ibus/ibus_config.textproto` を追加
* IBus config の default textproto を `mozc_embed_file` で埋め込み
* `gen_mozc_xml.py` から IBus config textproto 生成処理を削除
* `IbusConfig::LoadConfig()` で `protobuf_util::SanitizeMessageStrings` を実行
* string field ごとに最大 100 bytes、ill-formed UTF-8 除去、ASCII control character 除去を適用

## Mozkey 側での調整

Mozkey 側では `gen_mozc_xml.py` が `kEnginesXml` を引き続き生成する構造になっていたため、conflict 解消時に以下の方針にしました。

* `kEnginesXml` の生成経路は維持
* `kIbusConfigTextProto` の Python 生成だけを削除
* IBus config textproto は専用ファイル `ibus_config.textproto` から埋め込む

また、現在の Mozkey 側の `mozc_embed_file` macro では upstream の `skip_until` 属性を受け付けないため、`skip_until = "# proto-file:"` は使用しない形に調整しました。

`ibus_config.textproto` の先頭部分は comment であり、TextFormat parser 上の問題はありません。

## 確認

* `python -m py_compile .\src\unix\ibus\gen_mozc_xml.py`
* `bazelisk --output_user_root=C:/bzl test --config oss_windows //base:protobuf_util_test //base:text_normalizer_test --test_output=errors --verbose_failures`
* `bazelisk --output_user_root=C:/bzl build --config oss_windows //unix/ibus:ibus_config --verbose_failures`
* `bazelisk --output_user_root=C:/bzl build --config oss_windows --config release_build package --verbose_failures`
* `git diff --check main..HEAD`
