### PR TITLE
Upstream sync/20260624 ibus embed followups

### DIFF
--- a/src/build_tools/embed_file.bzl
+++ b/src/build_tools/embed_file.bzl
@@ -31,10 +31,23 @@
 
 load("//bazel:run_build_tool.bzl", "mozc_run_build_tool")
 
-def mozc_embed_file(name, srcs, out, var_name, as_string_view = False, **kwargs):
+def mozc_embed_file(name, srcs, out, var_name, as_string_view = False, skip_until = None, **kwargs):
+    """Generates a C++ source file defining a variable containing the input file's contents.
+
+    Args:
+      name: The name of the rule.
+      srcs: The input file(s) to embed.
+      out: The name of the generated C++ source file.
+      var_name: The name of the C++ variable to define.
+      as_string_view: If True, defines the variable as an absl::string_view instead of a raw array.
+      skip_until: If specified, skips lines until the string provided is encountered in a line.
+      **kwargs: Additional arguments to pass to the underlying rule.
+    """
     args = ["--name=" + var_name]
     if as_string_view:
         args.append("--as_string_view")
+    if skip_until:
+        args.append("--skip_until=" + skip_until)
 
     mozc_run_build_tool(
         name = name,

--- a/src/build_tools/embed_file.py
+++ b/src/build_tools/embed_file.py
@@ -44,16 +44,30 @@ def _ParseArgs():
       '--output', type=argparse.FileType(mode='w', encoding='utf-8')
   )
   parser.add_argument('--as_string_view', action='store_true')
+  parser.add_argument(
+      '--skip_until',
+      help='If specified, drops all lines in the file before the first line '
+      'containing this string. The line containing the string is kept.',
+  )
   return parser.parse_args()
 
 
-def _EmbedAsStringView(input_path, name, output_file):
-  """Embed file as absl::string_view using Raw String Literal."""
+def _EmbedAsStringView(input_path, name, output_file, skip_until=None):
+  """Embed file as absl::string_view using Raw String Literal.
+
+  Args:
+    input_path: Path to the input file to be embedded.
+    name: The name of the `absl::string_view` variable to be generated.
+    output_file: The file object where the generated C++ code will be written.
+    skip_until: If specified, lines in the input file before the first line
+      containing this string are skipped. The line containing the string is
+      included in the output.
+  """
   # Load input file as binary to validate UTF-8 and Null bytes
   with open(input_path, 'rb') as infile:
     data = infile.read()
 
-  # 1. Validate invalid UTF-8 byte sequence
+  # Validate invalid UTF-8 byte sequence
   try:
     content = data.decode('utf-8', errors='strict')
   except UnicodeDecodeError as e:
@@ -62,7 +76,17 @@ def _EmbedAsStringView(input_path, name, output_file):
     )
     sys.exit(1)
 
-  # 2. Validate Null byte
+  # Skip lines up to the first occurrence of `skip_until`.
+  # This is useful for stripping off license headers or other text inserted by
+  # Copybara and keeping only the core contents (e.g. from `# proto-file:`).
+  if skip_until:
+    lines = content.splitlines(keepends=True)
+    for i, line in enumerate(lines):
+      if skip_until in line:
+        content = ''.join(lines[i:])
+        break
+
+  # Validate Null byte
   if '\0' in content:
     sys.stderr.write(
         f'Error: {input_path} contains a null byte (\\0), which is not'
@@ -70,7 +94,7 @@ def _EmbedAsStringView(input_path, name, output_file):
     )
     sys.exit(1)
 
-  # 3. Validate delimiter conflict
+  # Validate delimiter conflict
   # C++ Raw String literal delimiters have a length limit of 16 characters.
   delimiter = name[:16]
   delimiter_conflict = f'){delimiter}'
@@ -131,8 +155,14 @@ def _EmbedAsUint64Array(input_path, name, output_file):
 def main():
   args = _ParseArgs()
   if args.as_string_view:
-    _EmbedAsStringView(args.input, args.name, args.output)
+    _EmbedAsStringView(args.input, args.name, args.output, args.skip_until)
   else:
+    if args.skip_until:
+      sys.stderr.write(
+          'Error: --skip_until is only supported when --as_string_view is '
+          'enabled.\n'
+      )
+      sys.exit(1)
     _EmbedAsUint64Array(args.input, args.name, args.output)
 
 

--- a/src/renderer/BUILD.bazel
+++ b/src/renderer/BUILD.bazel
@@ -239,6 +239,7 @@ mozc_embed_file(
     srcs = ["renderer_style.textproto"],
     out = "renderer_style.inc",
     as_string_view = True,
+    skip_until = "# proto-file:",
     var_name = "kStyleTextProto",
 )
 

--- a/src/renderer/renderer_style.textproto
+++ b/src/renderer/renderer_style.textproto
@@ -27,7 +27,7 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-# proto-file: third_party/mozc/src/protocol/renderer_style.proto
+# proto-file: protocol/renderer_style.proto
 # proto-message: RendererStyle
 window_border: 1
 scrollbar_width: 4

--- a/src/unix/ibus/BUILD.bazel
+++ b/src/unix/ibus/BUILD.bazel
@@ -246,6 +246,7 @@ mozc_embed_file(
     srcs = ["ibus_config.textproto"],
     out = "ibus_config_textproto.inc",
     as_string_view = True,
+    skip_until = "# proto-file:",
     var_name = "kIbusConfigTextProto",
 )
 


### PR DESCRIPTION
## 概要

この PR では、upstream Mozc の `embed_file.py` / `mozc_embed_file` に追加された `skip_until` 対応を取り込みました。

`skip_until` を指定すると、入力ファイル内で指定文字列が最初に現れる行までをスキップし、その行以降を embedded content として扱えます。これにより、license header などを除外し、`# proto-file:` 以降の textproto 本体だけを C++ に埋め込めるようになります。

あわせて、`renderer_style.textproto` の `# proto-file:` path 更新も取り込みました。

## 取り込んだ upstream commit

* 23366530244c Add the --skip_until option to embed_file.py.
* 68e4cc472da1 Update the path of `proto-file:`.

## Mozkey 側での追加調整

前回の IBus config textproto 分離 PR では、Mozkey 側の `mozc_embed_file` が `skip_until` に未対応だったため、`src/unix/ibus/BUILD.bazel` では一時的に `skip_until` を外していました。

今回 `skip_until` 対応を取り込んだため、IBus config textproto の埋め込みにも `skip_until = "# proto-file:"` を戻しました。

## 主な変更

* `embed_file.py` に `--skip_until` option を追加
* `mozc_embed_file` macro に `skip_until` parameter を追加
* `renderer_style.textproto` の `# proto-file:` path を更新
* `renderer_style.textproto` の埋め込みで `skip_until = "# proto-file:"` を使用
* `ibus_config.textproto` の埋め込みでも `skip_until = "# proto-file:"` を使用

## 確認

* `python -m py_compile .\build_tools\embed_file.py`
* `python -m py_compile .\unix\ibus\gen_mozc_xml.py`
* `bazelisk --output_user_root=C:/bzl build --config oss_windows //unix/ibus:ibus_config --verbose_failures`
* `bazelisk --output_user_root=C:/bzl build --config oss_windows //renderer:renderer_style_handler --verbose_failures`
* `bazelisk --output_user_root=C:/bzl build --config oss_windows --config release_build package --verbose_failures`
* `git diff --check main..HEAD`
