### PR TITLE
Upstream sync/20260624 ibus cleanup

### DIFF
--- a/src/unix/ibus/gen_mozc_xml.py
+++ b/src/unix/ibus/gen_mozc_xml.py
@@ -67,30 +67,6 @@ def GetXmlElement(key, value):
   return '  <%s>%s</%s>' % (key, value, key)
 
 
-def GetEnginesXml(engine_common, engines):
-  """Outputs a XML data for ibus-daemon.
-
-  Args:
-    engine_common: A dictionary from a property name to a property value that
-      are commonly used in all engines. For example, {'language': 'ja'}.
-    engines: A dictionary from a property name to a list of property values of
-      engines. For example, {'name': ['mozc-jp', 'mozc', 'mozc-dv']}.
-
-  Returns:
-    output string in XML.
-  """
-  output = ['<engines>']
-  for engine in engines:
-    output.append('<engine>')
-    for key, value in engine_common.items():
-      output.append(GetXmlElement(key, value))
-    for key, value in engine.items():
-      output.append(GetXmlElement(key, value))
-    output.append('</engine>')
-  output.append('</engines>')
-  return '\n'.join(output)
-
-
 def OutputXml(component, ibus_mozc_path):
   """Outputs a XML data for ibus-daemon.
 
@@ -119,7 +95,7 @@ def OutputCppVariable(prefix, key, value):
   print('const char k%s%s[] = "%s";' % (prefix, key.capitalize(), value))
 
 
-def OutputCpp(component, engine_common, engines):
+def OutputCpp(component, engine_common):
   """Outputs a C++ header file for mozc/unix/ibus/main.cc.
 
   Args:
@@ -127,8 +103,6 @@ def OutputCpp(component, engine_common, engines):
       ibus-mozc component. For example, {'name': 'com.google.IBus.Mozc'}.
     engine_common: A dictionary from a property name to a property value that
       are commonly used in all engines. For example, {'language': 'ja'}.
-    engines: A dictionary from a property name to a list of property values of
-      engines. For example, [{'name': 'mozc-jp',...}, {'name': 'mozc'},...]
   """
   guard_name = 'MOZC_UNIX_IBUS_MAIN_H_'
   print(CPP_HEADER % (guard_name, guard_name))
@@ -136,10 +110,6 @@ def OutputCpp(component, engine_common, engines):
     OutputCppVariable('Component', key, value)
   for key, value in engine_common.items():
     OutputCppVariable('Engine', key, value)
-  print('const size_t kEngineArrayLen = %s;' % len(engines))
-  print('const char kEnginesXml[] = R"#(', end='')
-  print(GetEnginesXml(engine_common, engines))
-  print(')#";')
   print(CPP_FOOTER % guard_name)
 
 
@@ -207,42 +177,8 @@ def main():
       'setup': setup_path + ' --mode=config_dialog',
   }
 
-  # DO NOT change the engine name 'mozc-jp'. The names is referenced by
-  # unix/ibus/mozc_engine.cc.
-  engines = [
-      {
-          'name': 'mozc-jp',
-          'longname': product_name,
-          'layout': 'default',
-          'layout_variant': '',
-          'layout_option': '',
-          'rank': 80,
-          'symbol': 'あ',
-      },
-      {
-          'name': 'mozc-on',
-          'longname': product_name + ':あ',
-          'layout': 'default',
-          'layout_variant': '',
-          'layout_option': '',
-          'rank': 99,
-          'symbol': 'あ',
-          'composition_mode': 'HIRAGANA',
-      },
-      {
-          'name': 'mozc-off',
-          'longname': product_name + ':A_',
-          'layout': 'default',
-          'layout_variant': '',
-          'layout_option': '',
-          'rank': 99,
-          'symbol': 'A',
-          'composition_mode': 'DIRECT',
-      },
-  ]
-
   if options.output_cpp:
-    OutputCpp(component, engine_common, engines)
+    OutputCpp(component, engine_common)
   else:
     OutputXml(component, ibus_mozc_path)
   return 0

--- a/src/unix/ibus/ibus_config.cc
+++ b/src/unix/ibus/ibus_config.cc
@@ -83,8 +83,9 @@ std::string UpdateConfigFile() {
   return std::string(kIbusConfigTextProto);
 }
 
-std::string NormalizeLayout(const std::string& layout) {
+std::string NormalizeLayout(absl::string_view layout) {
   std::string output;
+  output.reserve(layout.size());
   for (const char c : layout) {
     if (absl::ascii_isalnum(c) || c == '_' || c == '-' || c == '/') {
       output += c;
@@ -95,7 +96,7 @@ std::string NormalizeLayout(const std::string& layout) {
   return output;
 }
 
-bool ParseConfig(const std::string& data, ibus::Config& config) {
+bool ParseConfig(absl::string_view data, ibus::Config& config) {
   const bool success =
       mozc::protobuf::TextFormat::ParseFromString(data, &config);
   if (!success) {
@@ -115,7 +116,7 @@ bool ParseConfig(const std::string& data, ibus::Config& config) {
   return success;
 }
 
-std::string EscapeXmlValue(const std::string& value) {
+std::string EscapeXmlValue(absl::string_view value) {
   return absl::StrReplaceAll(value, {{"&", "&amp;"},
                                      {"<", "&lt;"},
                                      {">", "&gt;"},
@@ -155,7 +156,7 @@ bool IbusConfig::Initialize() {
   return LoadConfig(config_data);
 }
 
-bool IbusConfig::LoadConfig(const std::string& config_data) {
+bool IbusConfig::LoadConfig(absl::string_view config_data) {
   const bool valid_user_config = ParseConfig(config_data, config_);
 
   protobuf_util::SanitizeMessageStrings(config_, [](absl::string_view src) {
@@ -166,9 +167,9 @@ bool IbusConfig::LoadConfig(const std::string& config_data) {
 
   engine_xml_ = CreateEnginesXml(config_);
   if (!valid_user_config) {
-    engine_xml_ +=
+    absl::StrAppend(&engine_xml_,
         ("<!-- Failed to parse the user config. -->\n"
-         "<!-- Used the default setting instead. -->\n");
+         "<!-- Used the default setting instead. -->\n"));
   }
 
   return valid_user_config;

--- a/src/unix/ibus/ibus_config.h
+++ b/src/unix/ibus/ibus_config.h
@@ -51,7 +51,7 @@ class IbusConfig {
 
   // Loads textproto and updates instance variables.
   // Returns false if failed to parse config_data.
-  bool LoadConfig(const std::string& config_data);
+  bool LoadConfig(absl::string_view config_data);
 
   const std::string& GetEnginesXml() const;
   const std::string& GetLayout(absl::string_view name) const;


### PR DESCRIPTION
## 概要

この PR では、upstream Mozc の IBus cleanup を取り込みました。

`gen_mozc_xml.py` から未使用になった IBus engine XML の C++ header 生成処理を削除し、`ibus_config` の文字列引数まわりを `absl::string_view` に整理しています。

Windows renderer、TSF、Zenz、converter、dictionary、prediction、boundary.def などの変更は含めていません。

## 取り込んだ upstream commit

* dacc0a4b6944 Remove generation of IBus engine XML.
* fb2240632585 Refactor: Use absl::string_view in ibus_config.

## 主な変更

* `gen_mozc_xml.py` から `kEngineArrayLen` / `kEnginesXml` 生成処理を削除
* `gen_mozc_xml.py` から不要になった engine list / XML 生成 helper を削除
* IBus config 関連の関数引数を `const std::string&` から `absl::string_view` に変更
* `NormalizeLayout()` で出力文字列に `reserve()` を追加
* parse failure 時の XML 追記を `absl::StrAppend()` に変更

## 補足

`IbusConfig::GetEnginesXml()` は引き続き残しています。

これは `gen_mozc_xml.py` が C++ header に固定 XML を生成する旧経路とは別で、現在の `ibus_config.textproto` から runtime に engine XML を生成して返す正規経路です。

そのため、今回削除したのは `gen_mozc_xml.py` 内の古い `kEngineArrayLen` / `kEnginesXml` 生成処理だけです。

## 確認

* `python -m py_compile .\unix\ibus\gen_mozc_xml.py`
* `git grep -n "kEnginesXml\|kEngineArrayLen\|GetEnginesXml\|GetIbusConfigTextProto" -- src/unix/ibus/gen_mozc_xml.py`

  * 無出力であることを確認
* `bazelisk --output_user_root=C:/bzl build --config oss_windows //unix/ibus:ibus_config --verbose_failures`
* `bazelisk --output_user_root=C:/bzl build --config oss_windows --config release_build package --verbose_failures`
* `git diff --check main..HEAD`

## 未実施 / 補足

* `//unix/ibus:ibus_config_test` は Windows host platform では Linux constraint により incompatible のため実行対象外でした。
