### PR TITLE
Remove `Singleton` from `client.cc` (#1513)

### DIFF
--- a/src/client/BUILD.bazel
+++ b/src/client/BUILD.bazel
@@ -84,7 +84,6 @@ mozc_cc_library(
         "//base:file_util",
         "//base:process",
         "//base:run_level",
-        "//base:singleton",
         "//base:system_util",
         "//base:version",
         "//base:vlog",

--- a/src/client/client.cc
+++ b/src/client/client.cc
@@ -48,7 +48,6 @@
 #include "base/file_stream.h"
 #include "base/file_util.h"
 #include "base/process.h"
-#include "base/singleton.h"
 #include "base/system_util.h"
 #include "base/version.h"
 #include "base/vlog.h"
@@ -926,19 +925,14 @@ bool Client::OpenBrowser(absl::string_view url) {
 }
 
 namespace {
-class DefaultClientFactory : public ClientFactoryInterface {
- public:
-  std::unique_ptr<ClientInterface> NewClient() override {
-    return std::make_unique<Client>();
-  }
-};
 
 ClientFactoryInterface *g_client_factory = nullptr;
+
 }  // namespace
 
 std::unique_ptr<ClientInterface> ClientFactory::NewClient() {
   if (g_client_factory == nullptr) {
-    return Singleton<DefaultClientFactory>::get()->NewClient();
+    return std::make_unique<Client>();
   } else {
     return g_client_factory->NewClient();
   }


### PR DESCRIPTION
## 概要

この PR では、upstream Mozc の `client.cc` に対する Singleton 除去を取り込みました。

`ClientFactory::NewClient()` の default path で使っていた `DefaultClientFactory` / `base::Singleton` を削除し、factory が注入されていない場合は直接 `std::make_unique<Client>()` する形に整理しています。

server 起動、IPC request、session request、client factory injection の意味論には変更を加えていません。

## 取り込んだ upstream commit

* 0d1e27959eb3 Remove `Singleton` from `client.cc` (#1513)

## 主な変更

* `DefaultClientFactory` を削除
* `ClientFactory::NewClient()` の default path を `std::make_unique<Client>()` に変更
* `client.cc` から `base/singleton.h` include を削除
* `src/client/BUILD.bazel` から `//base:singleton` 依存を削除

## 確認

* `git grep -n "DefaultClientFactory\|Singleton<.*Client\|base/singleton.h" -- src/client`

  * 無出力であることを確認
* `bazelisk --output_user_root=C:/bzl test --config oss_windows //client/... --test_output=errors --verbose_failures`

  * `//client:client_test`
* `bazelisk --output_user_root=C:/bzl test --config oss_windows //ipc/... --test_output=errors --verbose_failures`

  * `//ipc:ipc_path_manager_test`
  * `//ipc:ipc_test`
  * `//ipc:named_event_test`
  * `//ipc:process_watch_dog_test`
* `bazelisk --output_user_root=C:/bzl build --config oss_windows --config release_build //server:mozc_server --verbose_failures`
* `bazelisk --output_user_root=C:/bzl build --config oss_windows --config release_build package --verbose_failures`
* `git diff --check main..HEAD`
