### PR TITLE
Separate android_util into its own build target.

### DIFF
--- a/src/base/BUILD.bazel
+++ b/src/base/BUILD.bazel
@@ -475,16 +475,14 @@ mozc_cc_test(
 
 mozc_cc_library(
     name = "system_util",
-    # TODO(b/269889028): android_util and win_util have cyclic dependency
-    # between this library. Solve it and make them independent libraries.
+    # TODO(b/269889028): win_util has cyclic dependency between this library.
+    # Solve it and make them independent libraries.
     srcs = ["system_util.cc"] +
            mozc_select(
-               android = ["android_util.cc"],
                windows = ["//base/win32:win_util_cc"],
            ),
     hdrs = ["system_util.h"] +
            mozc_select(
-               android = ["android_util.h"],
                windows = ["//base/win32:win_util_h"],
            ),
     local_defines = mozc_select(
@@ -511,6 +509,7 @@ mozc_cc_library(
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/synchronization",
     ] + mozc_select(
+        android = [":android_util"],
         ios = ["//base/mac:mac_util"],
         macos = ["//base/mac:mac_util"],
         windows = [
@@ -531,6 +530,34 @@ mozc_cc_test(
         ":file_util_mock",
         ":system_util",
         "//testing:gunit_main",
+    ],
+)
+
+mozc_cc_library(
+    name = "android_util",
+    srcs = ["android_util.cc"],
+    hdrs = ["android_util.h"],
+    visibility = ["//visibility:private"],
+    deps = [
+        ":util",
+        "@com_google_absl//absl/base:config",
+        "@com_google_absl//absl/base:core_headers",
+        "@com_google_absl//absl/log:check",
+        "@com_google_absl//absl/synchronization",
+    ],
+)
+
+mozc_cc_test(
+    name = "android_util_test",
+    size = "small",
+    srcs = ["android_util_test.cc"],
+    visibility = ["//visibility:private"],
+    deps = [
+        ":android_util",
+        ":port",
+        ":util",
+        "//testing:gunit_main",
+        "//testing:test_peer",
     ],
 )
 

--- a/src/base/android_util.cc
+++ b/src/base/android_util.cc
@@ -29,7 +29,11 @@
 
 #include "base/android_util.h"
 
+#include <cstddef>
 #include <fstream>
+#include <map>
+#include <set>
+#include <string>
 #include <utility>
 
 #include "absl/base/const_init.h"
@@ -54,7 +58,7 @@ constexpr char AndroidUtil::kSystemPropertySdkVersion[] =
 // static
 std::string AndroidUtil::GetSystemProperty(const std::string& key,
                                            const std::string& default_value) {
-  absl::MutexLock lock(&sys_prop_mutex);
+  absl::MutexLock lock(sys_prop_mutex);
   std::map<std::string, std::string>::iterator it = property_cache.find(key);
   if (it != property_cache.end()) {
     // Cache is found.

--- a/src/base/android_util.h
+++ b/src/base/android_util.h
@@ -30,8 +30,6 @@
 #ifndef MOZC_BASE_ANDROID_UTIL_H_
 #define MOZC_BASE_ANDROID_UTIL_H_
 
-#include <jni.h>
-
 #include <map>
 #include <set>
 #include <string>

--- a/src/base/android_util_test.cc
+++ b/src/base/android_util_test.cc
@@ -29,9 +29,10 @@
 
 #include "base/android_util.h"
 
+#include <cstddef>
 #include <string>
 
-#include "base/util.h"
+#include "base/port.h"
 #include "testing/gunit.h"
 #include "testing/test_peer.h"
 
@@ -43,14 +44,22 @@ class AndroidUtilTestPeer : public testing::TestPeer<AndroidUtil> {
 };
 
 TEST(AndroidUtilTest, GetSystemProperty) {
+  // AndroidUtil::GetSystemProperty works only on Android.
+  if constexpr (!port::IsAndroid()) {
+    return;
+  }
+
   // Valid cases
-  EXPECT_NE("", AndroidUtil::GetSystemProperty(
-                    AndroidUtil::kSystemPropertyOsVersion, ""));
+  EXPECT_NE(
+      AndroidUtil::GetSystemProperty(AndroidUtil::kSystemPropertyOsVersion, ""),
+      "");
   // Check cache
-  EXPECT_NE("", AndroidUtil::GetSystemProperty(
-                    AndroidUtil::kSystemPropertyOsVersion, ""));
-  EXPECT_NE("", AndroidUtil::GetSystemProperty(
-                    AndroidUtil::kSystemPropertyModel, ""));
+  EXPECT_NE(
+      AndroidUtil::GetSystemProperty(AndroidUtil::kSystemPropertyOsVersion, ""),
+      "");
+  EXPECT_NE(
+      AndroidUtil::GetSystemProperty(AndroidUtil::kSystemPropertyModel, ""),
+      "");
 
   // Invalid cases.
   EXPECT_EQ(AndroidUtil::GetSystemProperty("INVALID_KEY", ""), "");

--- a/src/base/system_util.cc
+++ b/src/base/system_util.cc
@@ -850,6 +850,9 @@ std::string SystemUtil::GetOSVersionString() {
   const std::string ret = "MacOSX " + MacUtil::GetOSVersionString();
   // TODO(toshiyuki): get more specific info
   return ret;
+#elif defined(__ANDROID__)
+  return "Android " + AndroidUtil::GetSystemProperty(
+                          AndroidUtil::kSystemPropertyOsVersion, "Unknown");
 #elif defined(__linux__)
   const std::string ret = "Linux";
   return ret;


### PR DESCRIPTION
## 概要

この PR では、upstream Mozc の `android_util` BUILD target 分離を取り込みました。

従来は Android 向けの `android_util.cc` / `android_util.h` が `system_util` target に含まれていましたが、専用の `android_util` target と `android_util_test` target に分離されています。

Windows / Mozkey の通常入力処理、Zenz live correction、renderer には直接触れていません。

## 取り込んだ upstream commit

* 060b96ef6d2a Separate android_util into its own build target.

## 主な変更

* `src/base/BUILD.bazel` に `android_util` target を追加
* `src/base/BUILD.bazel` に `android_util_test` target を追加
* `system_util` の Android select で `:android_util` に依存するよう整理
* `android_util.cc` の include を補完
* `android_util.h` から不要な `jni.h` include を削除
* `android_util_test` を非 Android 環境でも安全に通る形に整理
* `SystemUtil::GetOSVersionString()` に Android 分岐を追加

## conflict 解決方針

`src/base/BUILD.bazel` で conflict が発生しました。

upstream 側には `apple = ["//base/mac:mac_util"]` への変更が含まれていましたが、これは別 upstream commit の範囲なので、この PR では採用していません。

現在の Mozkey 側の `ios` / `macos` 分離を維持しつつ、`android = [":android_util"]` だけを追加しました。

## 確認

* `git grep -n "android_util" -- src/base/BUILD.bazel src/base/system_util.cc`

  * `android = [":android_util"]`
  * `name = "android_util"`
  * `name = "android_util_test"`
  * `src/base/system_util.cc` の `base/android_util.h` include を確認
* `bazelisk --output_user_root=C:/bzl test --config oss_windows //base:android_util_test --test_output=errors --verbose_failures`
* `bazelisk --output_user_root=C:/bzl test --config oss_windows //base:system_util_test --test_output=errors --verbose_failures`
* `bazelisk --output_user_root=C:/bzl test --config oss_windows //base/... --test_output=errors --verbose_failures`

  * 52 tests pass
* `bazelisk --output_user_root=C:/bzl build --config oss_windows --config release_build //server:mozc_server --verbose_failures`
* `bazelisk --output_user_root=C:/bzl build --config oss_windows --config release_build package --verbose_failures`
* `git diff --check main..HEAD`
