### PR TITLE
Fix memory leak in SupplementalModel reload.

### DIFF
--- a/src/engine/engine.cc
+++ b/src/engine/engine.cc
@@ -183,6 +183,12 @@ bool Engine::SendSupplementalModelReloadRequest(
   return true;
 }
 
+void Engine::ClearOldSupplementalModels() {
+  if (converter_) {
+    converter_->modules().GetSupplementalModel().ClearOldModels();
+  }
+}
+
 void Engine::ImportUserDictionary(std::string name, std::string tsv) {
   if (async_user_dictionary_importer_) {
     async_user_dictionary_importer_->Import(std::move(name), std::move(tsv));

--- a/src/engine/engine.h
+++ b/src/engine/engine.h
@@ -127,6 +127,8 @@ class Engine : public EngineInterface {
   bool SendSupplementalModelReloadRequest(
       const EngineReloadRequest& request) override;
 
+  void ClearOldSupplementalModels() override;
+
   void ImportUserDictionary(std::string name, std::string tsv) override;
 
   void SetAlwaysWaitForTesting(bool value) { always_wait_for_testing_ = value; }

--- a/src/engine/engine_interface.h
+++ b/src/engine/engine_interface.h
@@ -100,6 +100,9 @@ class EngineInterface {
   virtual bool MaybeReloadEngine(EngineReloadResponse* response) {
     return false;
   }
+
+  // Clears old supplemental models to avoid memory leaks.
+  virtual void ClearOldSupplementalModels() {}
   virtual bool SendEngineReloadRequest(const EngineReloadRequest& request) {
     return false;
   }

--- a/src/engine/supplemental_model_interface.h
+++ b/src/engine/supplemental_model_interface.h
@@ -58,6 +58,9 @@ class SupplementalModelInterface {
     return EngineReloadResponse();
   }
 
+  // Destroys old models that were replaced during reload.
+  virtual void ClearOldModels() {}
+
   // Returns true if supplemental model is available.
   // Useful to run intensive operations before using supplemental model.
   //

--- a/src/session/session_handler.cc
+++ b/src/session/session_handler.cc
@@ -304,6 +304,9 @@ bool SessionHandler::SetRequest(commands::Command* command) {
 }
 
 bool SessionHandler::EvalCommand(commands::Command* command) {
+  if (engine_) {
+    engine_->ClearOldSupplementalModels();
+  }
   if (!is_available_) {
     LOG(ERROR) << "SessionHandler is not available.";
     return false;


### PR DESCRIPTION
## 概要

この PR では、upstream Mozc の SupplementalModel reload 時の memory leak 修正を取り込みました。

補助モデル reload 後に差し替えられた古い model を、次回の user command 評価時に明示的に clear できるようにする hook を追加しています。

## 取り込んだ upstream commit

* 347a65f1cc42 Fix memory leak in SupplementalModel reload.

## 主な変更

* `EngineInterface` に `ClearOldSupplementalModels()` を追加
* `Engine` に `ClearOldSupplementalModels()` 実装を追加
* `SupplementalModelInterface` に `ClearOldModels()` を追加
* `SessionHandler::EvalCommand()` の冒頭で `engine_->ClearOldSupplementalModels()` を呼ぶように変更

## 補足

`SupplementalModelInterface::ClearOldModels()` の default 実装は no-op です。

そのため、具体的な supplemental model 実装を持たない構成では実質的な動作変更はありません。

`SessionHandler::EvalCommand()` に hook が入るため入力コマンド経路には触れますが、通常変換ロジック、Zenz live correction、renderer 表示処理そのものには変更を加えていません。

## 確認

* `git grep -n "ClearOldSupplementalModels\|ClearOldModels" -- src`

  * 想定範囲のみであることを確認
* `bazelisk --output_user_root=C:/bzl test --config oss_windows //engine/... --test_output=errors --verbose_failures`

  * 8 tests pass
* `bazelisk --output_user_root=C:/bzl test --config oss_windows //session:session_handler_test --test_output=errors --verbose_failures`
* `bazelisk --output_user_root=C:/bzl test --config oss_windows //session:session_test --test_output=errors --verbose_failures`
* `bazelisk --output_user_root=C:/bzl test --config oss_windows //session:session_handler_stress_test --test_output=errors --verbose_failures`
* `bazelisk --output_user_root=C:/bzl build --config oss_windows --config release_build //server:mozc_server --verbose_failures`
* `bazelisk --output_user_root=C:/bzl build --config oss_windows --config release_build package --verbose_failures`
* `git diff --check main..HEAD`
