### PR TITLE
Refactor SystemUtil::GetOSVersionString to use absl::StrCat and simpl…

### DIFF
--- a/src/base/system_util.cc
+++ b/src/base/system_util.cc
@@ -832,33 +832,26 @@ const wchar_t* SystemUtil::GetSystemDir() {
 // version only when initializing.
 std::string SystemUtil::GetOSVersionString() {
 #ifdef _WIN32
-  std::string ret = "Windows";
   OSVERSIONINFOEX osvi = {0};
   osvi.dwOSVersionInfoSize = sizeof(OSVERSIONINFOEX);
   if (GetVersionEx(reinterpret_cast<OSVERSIONINFO*>(&osvi))) {
-    ret += ".";
-    ret += std::to_string(static_cast<uint32_t>(osvi.dwMajorVersion));
-    ret += ".";
-    ret += std::to_string(static_cast<uint32_t>(osvi.dwMinorVersion));
-    ret += "." + std::to_string(osvi.wServicePackMajor);
-    ret += "." + std::to_string(osvi.wServicePackMinor);
-  } else {
-    LOG(WARNING) << "GetVersionEx failed";
+    return absl::StrCat("Windows.", osvi.dwMajorVersion, ".",
+                        osvi.dwMinorVersion, ".", osvi.wServicePackMajor, ".",
+                        osvi.wServicePackMinor);
   }
-  return ret;
+  LOG(WARNING) << "GetVersionEx failed";
+  return "Windows";
 #elif defined(__APPLE__)
-  const std::string ret = "MacOSX " + MacUtil::GetOSVersionString();
   // TODO(toshiyuki): get more specific info
-  return ret;
+  return absl::StrCat("MacOSX ", MacUtil::GetOSVersionString());
 #elif defined(__ANDROID__)
-  return "Android " + AndroidUtil::GetSystemProperty(
-                          AndroidUtil::kSystemPropertyOsVersion, "Unknown");
+  return absl::StrCat("Android ",
+                      AndroidUtil::GetSystemProperty(
+                          AndroidUtil::kSystemPropertyOsVersion, "Unknown"));
 #elif defined(__linux__)
-  const std::string ret = "Linux";
-  return ret;
+  return "Linux";
 #else   // !_WIN32 && !__APPLE__ && !__linux__
-  const std::string ret = "Unknown";
-  return ret;
+  return "Unknown";
 #endif  // _WIN32, __APPLE__, __linux__
 }
 


### PR DESCRIPTION
## 概要

この PR では、upstream Mozc の `SystemUtil::GetOSVersionString()` refactor を取り込みました。

OS version string の組み立てを `absl::StrCat` ベースに整理し、不要な一時変数を削除しています。

## 取り込んだ upstream commit

* 988fbca7744f Refactor SystemUtil::GetOSVersionString to use absl::StrCat and simplify.

## 主な変更

* Windows / macOS / Android の OS version string 組み立てを `absl::StrCat` に整理
* Linux / Unknown の返却処理から不要な一時変数を削除
* Windows で `GetVersionEx` が失敗した場合の fallback を `Windows` に整理

## 補足

変更対象は `src/base/system_util.cc` の `SystemUtil::GetOSVersionString()` に限定されています。

通常変換、Zenz live correction、renderer 表示処理、Windows installer / TIP 登録処理には変更を加えていません。

## 確認

* `git diff main..HEAD -- src/base/system_util.cc`

  * `SystemUtil::GetOSVersionString()` の整理のみであることを確認
* `bazelisk --output_user_root=C:/bzl test --config oss_windows //base:system_util_test --test_output=errors --verbose_failures`
* `bazelisk --output_user_root=C:/bzl test --config oss_windows //base/... --test_output=errors --verbose_failures`

  * 52 tests pass
* `bazelisk --output_user_root=C:/bzl build --config oss_windows --config release_build //server:mozc_server --verbose_failures`
* `bazelisk --output_user_root=C:/bzl build --config oss_windows --config release_build package --verbose_failures`
* `git diff --check main..HEAD`
