### PR TITLE
Protect nara functional chains after nominal context

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ Zenz ライブ補正では、Zenzai v3/v3.2 の特殊トークン形式に沿っ
 
 また、名詞相当の左文脈の後では、`には`、`にも`、`では`、`でも`、`とは` のような保守的な複合機能語も補正対象にします。たとえば `github` を確定した直後に `には` と入力した場合、`github二は` よりも `githubには` を優先しやすくします。
 
-さらに、名詞相当の確定済み左文脈の直後では、現在入力の先頭にある機能語 prefix や、`なのか`、`なのだ`、`なんです` のような名詞述語に続く機能語列が、`担った` や `七日` のような内容語候補に食われるケースも抑制します。たとえば `彼` を確定してから `になった` や `なのか` と入力した場合、`彼担った` / `彼七日` ではなく、`彼になった` / `彼なのか` を優先しやすくします。
+さらに、名詞相当の確定済み左文脈の直後では、現在入力の先頭にある機能語 prefix や、`なのか`、`なのだ`、`なんです`、`なら`、`ならば`、`ならでは` のような名詞述語・条件表現に続く機能語列が、`担った`、`七日`、`奈良` のような内容語候補に食われるケースも抑制します。たとえば `彼` を確定してから `になった` や `なのか` と入力した場合、`彼担った` / `彼七日` ではなく、`彼になった` / `彼なのか` を優先しやすくします。また、`練習` を確定してから `なら` と入力した場合、`練習奈良` ではなく `練習なら` を優先しやすくします。
 
 また、名詞や数量表現の後に続く `しか + 否定表現` のような機能表現も保護します。たとえば `2めいしかいない` では、途中の `2名司会...`、`2名視界...`、`2名士会内` のような同音漢字経路よりも、`2名しかいない` を優先しやすくします。
 
@@ -869,7 +869,9 @@ instead of `github二は`.
 It also protects functional-prefix and whole functional-chain paths immediately
 after noun-like committed context. For example, after committing `彼`, typing
 `になった` or `なのか` is biased toward `彼になった` / `彼なのか` instead of
-content-node hijacks such as `彼担った` / `彼七日`.
+content-node hijacks such as `彼担った` / `彼七日`. Conditional chains such as
+`なら`, `ならば`, and `ならでは` are also protected, so after committing
+`練習`, typing `なら` is biased toward `練習なら` instead of `練習奈良`.
 
 It also protects common functional expressions such as `しか` followed by a
 negative expression after a noun or quantity-like context. For example,

--- a/src/converter/immutable_converter.cc
+++ b/src/converter/immutable_converter.cc
@@ -598,15 +598,20 @@ bool IsSupportedWholeFunctionalChainForRecomposition(absl::string_view key) {
     return false;
   }
 
-  // Copular/adnominal functional chains after a closed nominal history.
+  if (StartsWithStringView(key, "なの") ||
+      StartsWithStringView(key, "なん")) {
+    return true;
+  }
+
+  // Conditional "なら" after a noun-like committed context should remain a
+  // functional chain, not be consumed as the proper noun "奈良".
   //
-  // Examples:
-  //   彼 | なのか   -> 彼なのか, not 彼七日
-  //   彼 | なのだ   -> 彼なのだ
-  //   彼 | なんです -> 彼なんです
-  //
-  // Do not accept bare "な" to avoid broad lexical demotion such as ななめ.
-  return StartsWithStringView(key, "なの") || StartsWithStringView(key, "なん");
+  // Keep this deliberately narrower than a bare "な" prefix:
+  //   練習 | なら   -> 練習なら, not 練習奈良
+  //   練習 | ならば -> 練習ならば
+  //   彼   | ならでは -> 彼ならでは
+  return key == "なら" || StartsWithStringView(key, "ならば") ||
+         StartsWithStringView(key, "ならでは");
 }
 
 bool HasContinuationNodeFrom(const Lattice& lattice, size_t begin_pos,
@@ -697,6 +702,39 @@ std::optional<FunctionalPrefixEvidence> FindFunctionalPrefixEvidence(
   return std::nullopt;
 }
 
+bool IsNaraContentNodeForRecomposition(const Node& node,
+                                       size_t conversion_begin_pos) {
+  if (node.node_type != Node::NOR_NODE) {
+    return false;
+  }
+
+  if ((node.attributes & Node::USER_DICTIONARY) != 0) {
+    return false;
+  }
+
+  if (node.begin_pos != conversion_begin_pos) {
+    return false;
+  }
+
+  if (node.key.empty() || node.value.empty() || node.key == node.value) {
+    return false;
+  }
+
+  if (!StartsWithStringView(node.key, "なら")) {
+    return false;
+  }
+
+  if (!StartsWithStringView(node.value, "奈良")) {
+    return false;
+  }
+
+  if (Util::GetScriptType(node.key) != Util::HIRAGANA) {
+    return false;
+  }
+
+  return true;
+}
+
 bool IsPrefixConsumingContentNodeForRecomposition(
     const dictionary::PosMatcher& pos_matcher, const Node& node,
     size_t conversion_begin_pos) {
@@ -723,7 +761,9 @@ bool IsPrefixConsumingContentNodeForRecomposition(
   if (pos_matcher.IsFunctional(node.lid) || pos_matcher.IsFunctional(node.rid)) {
     return false;
   }
-  if (pos_matcher.IsUniqueNoun(node.lid) || pos_matcher.IsUniqueNoun(node.rid)) {
+  if ((pos_matcher.IsUniqueNoun(node.lid) ||
+       pos_matcher.IsUniqueNoun(node.rid)) &&
+      !IsNaraContentNodeForRecomposition(node, conversion_begin_pos)) {
     return false;
   }
 
@@ -3106,7 +3146,11 @@ void ImmutableConverter::ApplyContextualRecompositionScorer(
       continue;
     }
 
-    node->wcost += kContextualRecompositionPenalty;
+    const int penalty =
+        IsNaraContentNodeForRecomposition(*node, conversion_begin_pos)
+            ? 2600
+            : kContextualRecompositionPenalty;
+    node->wcost += penalty;
   }
 }
 


### PR DESCRIPTION
## 概要

この PR では、名詞相当の確定済み左文脈の直後に `なら` / `ならば` / `ならでは` を入力した場合、`奈良` のような固有名詞候補へ寄りすぎる挙動を抑制しました。

たとえば、以下のような分割入力で起きる誤変換を軽減します。

* `練習 | なら` → `練習奈良`
* `実行 | なら` → `実行奈良`
* `彼 | なら` → `彼奈良`

今回の変更では、`な` を一般的な prefix として広げるのではなく、`なら` / `ならば` / `ならでは` の whole functional chain だけを対象にします。

## 背景

既存の contextual recomposition scorer では、名詞相当の確定済み左文脈の直後で、`になった` や `なのか` のような機能語列が内容語候補に食われるケースを抑制していました。

一方で、条件表現の `なら` は対象外だったため、`練習` を先に確定してから `なら` と入力した場合に、条件表現ではなく地名の `奈良` として結合されることがありました。

## 実装方針

`IsSupportedWholeFunctionalChainForRecomposition` に、以下の条件表現を追加しました。

* `なら`
* `ならば`
* `ならでは`

ただし、bare `な` は引き続き対象外です。これにより、`ななめ` などの一般語を広く demote しないようにしています。

また、`奈良` は固有名詞候補として通常は `UniqueNoun` 除外により保護されますが、今回のケースでは `なら` functional chain と競合している場合だけ、狭く例外的に penalty 対象にしました。

## 変更内容

* `なら` / `ならば` / `ならでは` を supported whole functional chain に追加
* `なら...` → `奈良...` の competing node を判定する `IsNaraContentNodeForRecomposition` を追加
* contextual recomposition scorer で、`奈良` 系 content node に限り `UniqueNoun` 除外の例外として扱うように変更
* `奈良` 系 content-node hijack には通常よりやや強めの penalty を付与
* README の文脈補正説明に `なら` / `ならば` / `ならでは` 系の救済を追記

## 意図的に対象外にしたもの

今回の変更は、すべての `な` 始まりの入力を補正するものではありません。

特に、以下は対象外です。

* bare `な`
* `ならない`
* `ならん`
* 単独の `奈良`
* 単独の `奈良県`
* ユーザー辞書由来候補

`旅行 | 奈良` や `関西 | 奈良` のような分割入力では、`旅行なら` / `関西なら` も文法的に自然なため、今回の scorer では条件表現側に寄ることを許容しています。

## テスト

以下のテストが通ることを確認しました。

```powershell
bazelisk --output_user_root=C:/bzl test `
  --config oss_windows `
  //converter:immutable_converter_test `
  //converter:nbest_generator_test `
  //engine:contextual_candidate_reranker_test `
  --verbose_failures
```

また、以下の server build が成功することを確認しました。

```powershell
bazelisk --output_user_root=C:/bzl build `
  --config oss_windows `
  --config release_build `
  //server:mozc_server `
  --verbose_failures
```

## 実機確認

`mozc_server.exe` を直接差し替えて、以下の入力を確認しました。

Positive:

* `練習 | なら`
* `実行 | なら`
* `修正 | なら`
* `彼 | なら`
* `学生 | なら`
* `東京 | なら`
* `練習 | ならば`
* `彼 | ならでは`

Negative / 許容確認:

* `奈良`
* `奈良県`
* `奈良 | に行く`
* `なら`
* `ならば`

`練習奈良` に寄っていたケースが、期待どおり `練習なら` 側へ改善することを確認しました。
