### PR TITLE
Add middle dot to direct commit punctuation targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,12 +311,15 @@ Zenz ライブ補正では、Zenzai v3/v3.2 の特殊トークン形式に沿っ
 - `tesuto.` → `てすと。`
 - `tesuto?` → `てすと？`
 - `kakko(` → `かっこ（`
+- `tesuto/` → `てすと・`（記号スタイルで `/` が中黒になる場合）
 
 のように動作します。
 
+対象は、句点、読点、疑問符、感嘆符、丸括弧、鉤括弧、中黒から選択できます。`「`、`」` はそれぞれ独立した設定で扱います。中黒 `・` は、語や句を並列・区切りとしてつなぐ日本語の約物として独立した設定で扱います。
+
 ローマ字テーブルで句読点・記号を出すように設定している場合も、出力された文字が単打確定の対象に含まれていれば、その時点で確定されます。
 
-たとえば、ローマ字テーブルで `zz -> 。` や `qq -> ？` のように設定している場合でも、句点や疑問符を単打確定の対象にしていれば、`tesutozz` → `てすと。`、`tesutoqq` → `てすと？` のように確定されます。
+たとえば、ローマ字テーブルで `zz -> 。`、`qq -> ？`、`md -> ・` のように設定している場合でも、出力先の記号を単打確定の対象にしていれば、`tesutozz` → `てすと。`、`tesutoqq` → `てすと？`、`tesutomd` → `てすと・` のように確定されます。
 
 どの句読点・記号を単打確定の対象にするかは、設定画面のチェックボックスで選択できます。
 
@@ -895,6 +898,9 @@ Examples:
 - `tesuto.` → `てすと。`
 - `tesuto?` → `てすと？`
 - `kakko(` → `かっこ（`
+- `tesuto/` → `てすと・` when the symbol style maps `/` to the middle dot
+
+The selectable targets include periods, commas, question marks, exclamation marks, parentheses, corner brackets, and the middle dot. `「` and `」` are configured independently. The middle dot `・` is handled as an independent Japanese separator symbol.
 
 You can choose which punctuations/symbols are committed directly in the config dialog.
 

--- a/src/gui/config_dialog/config_dialog.cc
+++ b/src/gui/config_dialog/config_dialog.cc
@@ -2334,6 +2334,9 @@ void ConfigDialog::ConvertFromProto(const config::Config &config) {
   directCommitCloseBracketCheckBox->setChecked(
       config.direct_commit_key() &
       config::Config::DIRECT_COMMIT_CLOSE_BRACKET);
+  directCommitMiddleDotCheckBox->setChecked(
+      config.direct_commit_key() &
+      config::Config::DIRECT_COMMIT_MIDDLE_DOT);
 
   SET_COMBOBOX(shiftKeyModeSwitchComboBox, ShiftKeyModeSwitch,
                shift_key_mode_switch);
@@ -2578,6 +2581,9 @@ void ConfigDialog::ConvertToProto(config::Config *config) const {
   }
   if (directCommitCloseBracketCheckBox->isChecked()) {
     direct_commit_key |= config::Config::DIRECT_COMMIT_CLOSE_BRACKET;
+  }
+  if (directCommitMiddleDotCheckBox->isChecked()) {
+    direct_commit_key |= config::Config::DIRECT_COMMIT_MIDDLE_DOT;
   }
   config->set_direct_commit_key(direct_commit_key);
 
@@ -3302,6 +3308,7 @@ void ConfigDialog::SelectDirectCommitSetting(int state) {
   directCommitCloseParenthesisCheckBox->setEnabled(enabled);
   directCommitOpenBracketCheckBox->setEnabled(enabled);
   directCommitCloseBracketCheckBox->setEnabled(enabled);
+  directCommitMiddleDotCheckBox->setEnabled(enabled);
 
   if (enabled && useAutoConversion->isChecked()) {
     useAutoConversion->setChecked(false);

--- a/src/gui/config_dialog/config_dialog.ui
+++ b/src/gui/config_dialog/config_dialog.ui
@@ -1166,7 +1166,7 @@
           <widget class="QCheckBox" name="directCommitOpenBracketCheckBox">
            <property name="maximumSize">
             <size>
-             <width>55</width>
+             <width>45</width>
              <height>16777215</height>
             </size>
            </property>
@@ -1179,12 +1179,25 @@
           <widget class="QCheckBox" name="directCommitCloseBracketCheckBox">
            <property name="maximumSize">
             <size>
-             <width>55</width>
+             <width>45</width>
              <height>16777215</height>
             </size>
            </property>
            <property name="text">
             <string>」</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="7">
+          <widget class="QCheckBox" name="directCommitMiddleDotCheckBox">
+           <property name="maximumSize">
+            <size>
+             <width>45</width>
+             <height>16777215</height>
+            </size>
+           </property>
+           <property name="text">
+            <string>・</string>
            </property>
           </widget>
          </item>
@@ -2757,6 +2770,7 @@
   <tabstop>directCommitCloseParenthesisCheckBox</tabstop>
   <tabstop>directCommitOpenBracketCheckBox</tabstop>
   <tabstop>directCommitCloseBracketCheckBox</tabstop>
+  <tabstop>directCommitMiddleDotCheckBox</tabstop>
   <tabstop>shiftKeyModeSwitchComboBox</tabstop>
   <tabstop>useJapaneseLayout</tabstop>
   <tabstop>useModeIndicator</tabstop>

--- a/src/protocol/config.proto
+++ b/src/protocol/config.proto
@@ -264,6 +264,7 @@ message Config {
     DIRECT_COMMIT_CLOSE_PARENTHESIS = 32;
     DIRECT_COMMIT_OPEN_BRACKET = 64;
     DIRECT_COMMIT_CLOSE_BRACKET = 128;
+    DIRECT_COMMIT_MIDDLE_DOT = 256;
   }
   optional bool use_direct_commit = 1001 [default = false];
 

--- a/src/session/session.cc
+++ b/src/session/session.cc
@@ -7142,6 +7142,7 @@ bool Session::InsertCharacter(commands::Command* command) {
   }
 
   const bool was_live_conversion = live_conversion_active_;
+  const bool was_pending_live_conversion = live_conversion_pending_;
 
   // Preserve the visible zenz correction before editing cancels the temporary
   // live conversion state.
@@ -7286,6 +7287,11 @@ bool Session::InsertCharacter(commands::Command* command) {
       return true;
     }
 
+    if (!learned_reranked_preedit_after_cancel &&
+        (live_conversion_pending_ || was_pending_live_conversion)) {
+      return CommitPendingLiveConversionDisplayDirectly(command);
+    }
+
     if (!learned_reranked_preedit_after_cancel && was_live_conversion &&
         CommitLiveConversionResult(command)) {
       return true;
@@ -7301,6 +7307,18 @@ bool Session::InsertCharacter(commands::Command* command) {
       SetPendingDirectCommitLearningFromCommittedResult(
           *command,
           "normal_conversion_direct_commit_punctuation");
+    }
+
+    // Most direct-commit punctuation paths can commit the current Composer
+    // contents as-is.  However,
+    // GetDirectCommitStringsWithDirectCommitSuffixFallback() may explicitly
+    // append a suffix derived from the key event when Composer has not yet
+    // reflected the trigger.  Use the rewritten strings only when they differ
+    // from the current Composer contents, keeping the ordinary path unchanged.
+    if (direct_commit_key != context_->composer().GetQueryForConversion() ||
+        direct_commit_value != context_->composer().GetStringForSubmission()) {
+      CommitStringDirectly(direct_commit_key, direct_commit_value, command);
+      return true;
     }
 
     CommitCompositionDirectly(command);
@@ -8823,11 +8841,16 @@ bool MatchesString(absl::string_view value,
   return false;
 }
 
+bool SymbolMethodUsesMiddleDot(const config::Config& config) {
+  return config.symbol_method() == config::Config::CORNER_BRACKET_MIDDLE_DOT ||
+         config.symbol_method() == config::Config::SQUARE_BRACKET_MIDDLE_DOT;
+}
+
 std::string DirectCommitFallbackSuffixFromKeyEvent(
-    const commands::KeyEvent& key_event) {
+    const config::Config& config, const commands::KeyEvent& key_event) {
   if (MatchesString(key_event.key_string(),
                     {"。", "｡", "．", "、", "､", "，", "？", "！",
-                     "（", "）", "「", "」", "［", "］"})) {
+                     "（", "）", "「", "」", "［", "］", "・", "･"})) {
     return key_event.key_string();
   }
 
@@ -8855,6 +8878,10 @@ std::string DirectCommitFallbackSuffixFromKeyEvent(
   if (MatchesString(key_event.key_string(), {"]", "］"})) {
     return "」";
   }
+  if (SymbolMethodUsesMiddleDot(config) &&
+      MatchesString(key_event.key_string(), {"/", "／"})) {
+    return "・";
+  }
 
   switch (key_event.key_code()) {
     case static_cast<uint32_t>('.'):
@@ -8873,6 +8900,11 @@ std::string DirectCommitFallbackSuffixFromKeyEvent(
       return "「";
     case static_cast<uint32_t>(']'):
       return "」";
+    case static_cast<uint32_t>('/'):
+      if (SymbolMethodUsesMiddleDot(config)) {
+        return "・";
+      }
+      break;
     default:
       break;
   }
@@ -8938,7 +8970,13 @@ bool IsValidDirectCommitTriggerKey(const config::Config& config,
          (MatchesKeyEvent(key_event, static_cast<uint32_t>(']'),
                           {"]", "］", "」"}) &&
           (config.direct_commit_key() &
-           config::Config::DIRECT_COMMIT_CLOSE_BRACKET));
+           config::Config::DIRECT_COMMIT_CLOSE_BRACKET)) ||
+         ((MatchesString(key_event.key_string(), {"・", "･"}) ||
+           (SymbolMethodUsesMiddleDot(config) &&
+            MatchesKeyEvent(key_event, static_cast<uint32_t>('/'),
+                            {"/", "／"}))) &&
+          (config.direct_commit_key() &
+           config::Config::DIRECT_COMMIT_MIDDLE_DOT));
 }
 
 bool IsValidDirectCommitChar(const config::Config& config,
@@ -8974,7 +9012,11 @@ bool IsValidDirectCommitChar(const config::Config& config,
 
       (MatchesString(last_char, {"]", "］", "」"}) &&
        (config.direct_commit_key() &
-        config::Config::DIRECT_COMMIT_CLOSE_BRACKET));
+        config::Config::DIRECT_COMMIT_CLOSE_BRACKET)) ||
+
+      (MatchesString(last_char, {"・", "･"}) &&
+       (config.direct_commit_key() &
+        config::Config::DIRECT_COMMIT_MIDDLE_DOT));
 }
 
 }  // namespace
@@ -8991,13 +9033,15 @@ Session::GetDirectCommitStringsWithDirectCommitSuffixFallback(
   std::string key_to_commit = context_->composer().GetQueryForConversion();
   std::string value_to_commit = context_->composer().GetStringForSubmission();
 
+  const std::string suffix = DirectCommitFallbackSuffixFromKeyEvent(
+      context_->GetConfig(), key);
+
   // Some test and client paths provide the direct-commit trigger as the key
   // event itself while leaving the restored preedit unchanged in Composer.
   // In that case, explicitly append the trigger suffix so that the visible
   // commit remains `きょう。`, while the strong learning target remains the
   // suffix-free `きょう` captured before insertion.
   if (value_to_commit == value_before_insert) {
-    const std::string suffix = DirectCommitFallbackSuffixFromKeyEvent(key);
     if (!suffix.empty()) {
       key_to_commit = absl::StrCat(key_before_insert, suffix);
       value_to_commit = absl::StrCat(value_before_insert, suffix);

--- a/src/session/session_test.cc
+++ b/src/session/session_test.cc
@@ -11483,7 +11483,10 @@ TEST_F(SessionTest, DirectCommitAfterCustomRomajiPunctuation) {
       config::Config::DIRECT_COMMIT_KUTEN |
       config::Config::DIRECT_COMMIT_TOUTEN |
       config::Config::DIRECT_COMMIT_QUESTION_MARK |
-      config::Config::DIRECT_COMMIT_EXCLAMATION_MARK);
+      config::Config::DIRECT_COMMIT_EXCLAMATION_MARK |
+      config::Config::DIRECT_COMMIT_OPEN_BRACKET |
+      config::Config::DIRECT_COMMIT_CLOSE_BRACKET |
+      config::Config::DIRECT_COMMIT_MIDDLE_DOT);
 
   auto table = std::make_shared<composer::Table>();
   table->AddRule("te", "て", "");
@@ -11493,6 +11496,7 @@ TEST_F(SessionTest, DirectCommitAfterCustomRomajiPunctuation) {
   table->AddRule("cc", "、", "");
   table->AddRule("qq", "？", "");
   table->AddRule("ee", "！", "");
+  table->AddRule("md", "・", "");
 
   {
     Session session(engine);
@@ -11549,6 +11553,21 @@ TEST_F(SessionTest, DirectCommitAfterCustomRomajiPunctuation) {
     EXPECT_FALSE(command.output().has_preedit());
     EXPECT_EQ(session.context().state(), ImeContext::PRECOMPOSITION);
   }
+
+  {
+    Session session(engine);
+    session.SetConfig(config);
+    InitSessionToPrecomposition(&session);
+    session.get_internal_composer_only_for_unittest()->SetTable(table);
+
+    commands::Command command;
+    InsertCharacterChars("tesutomd", &session, &command);
+
+    EXPECT_RESULT("てすと・", command);
+    EXPECT_FALSE(command.output().has_preedit());
+    EXPECT_EQ(session.context().state(), ImeContext::PRECOMPOSITION);
+  }
+
 }
 
 TEST_F(SessionTest, DirectCommitAfterCustomRomajiPunctuationRespectsConfig) {
@@ -11566,6 +11585,7 @@ TEST_F(SessionTest, DirectCommitAfterCustomRomajiPunctuationRespectsConfig) {
   table->AddRule("to", "と", "");
   table->AddRule("zz", "。", "");
   table->AddRule("cc", "、", "");
+  table->AddRule("md", "・", "");
 
   {
     Session session(engine);
@@ -11593,6 +11613,107 @@ TEST_F(SessionTest, DirectCommitAfterCustomRomajiPunctuationRespectsConfig) {
     EXPECT_RESULT("てすと、", command);
     EXPECT_FALSE(command.output().has_preedit());
     EXPECT_EQ(session.context().state(), ImeContext::PRECOMPOSITION);
+  }
+
+  {
+    Session session(engine);
+    session.SetConfig(config);
+    InitSessionToPrecomposition(&session);
+    session.get_internal_composer_only_for_unittest()->SetTable(table);
+
+    commands::Command command;
+    InsertCharacterChars("tesutomd", &session, &command);
+
+    EXPECT_SINGLE_SEGMENT("てすと・", command);
+    EXPECT_FALSE(command.output().has_result());
+    EXPECT_EQ(session.context().state(), ImeContext::COMPOSITION);
+  }
+}
+
+TEST_F(SessionTest,
+       PendingLiveConversionMiddleDotSlashTriggerFollowsSymbolMethod) {
+  MockEngine engine;
+  std::shared_ptr<MockConverter> converter = CreateEngineConverterMock(&engine);
+
+  auto setup_pending_live_conversion = [](SessionTestPeer* session_peer) {
+    session_peer->context_()->set_state(ImeContext::COMPOSITION);
+    session_peer->live_conversion_pending_() = true;
+    session_peer->live_conversion_key_() = "きょうは";
+    session_peer->live_conversion_preedit_() = "きょうは";
+    session_peer->live_conversion_value_() = "今日は";
+
+    commands::Preedit& live_preedit =
+        session_peer->live_conversion_preedit_output_();
+    live_preedit.Clear();
+
+    commands::Preedit::Segment* segment = live_preedit.add_segment();
+    segment->set_key("きょうは");
+    segment->set_value("今日は");
+    segment->set_value_length(Util::CharsLen("今日は"));
+  };
+
+  {
+    SCOPED_TRACE("symbol method uses middle dot");
+    Session session(engine);
+    SessionTestPeer session_peer(session);
+    InitSessionToPrecomposition(&session);
+
+    config::Config config;
+    config::ConfigHandler::GetDefaultConfig(&config);
+    config.set_use_live_conversion(true);
+    config.set_use_direct_commit(true);
+    config.set_symbol_method(config::Config::CORNER_BRACKET_MIDDLE_DOT);
+    config.set_direct_commit_key(config::Config::DIRECT_COMMIT_MIDDLE_DOT);
+    session.SetConfig(config);
+
+    auto table = std::make_shared<composer::Table>();
+    table->InitializeWithRequestAndConfig(
+        commands::Request::default_instance(), config);
+    session.SetTable(table);
+
+    commands::Command command;
+    InsertCharacterChars("kyouha", &session, &command);
+    ASSERT_EQ(session.context().composer().GetQueryForConversion(), "きょうは");
+    setup_pending_live_conversion(&session_peer);
+
+    command.Clear();
+    ASSERT_TRUE(SendKey("/", &session, &command));
+
+    EXPECT_RESULT("今日は・", command);
+    EXPECT_FALSE(command.output().has_preedit());
+    EXPECT_EQ(session.context().state(), ImeContext::PRECOMPOSITION);
+  }
+
+  {
+    SCOPED_TRACE("symbol method uses slash");
+    Session session(engine);
+    SessionTestPeer session_peer(session);
+    InitSessionToPrecomposition(&session);
+
+    config::Config config;
+    config::ConfigHandler::GetDefaultConfig(&config);
+    config.set_use_live_conversion(true);
+    config.set_use_direct_commit(true);
+    config.set_symbol_method(config::Config::SQUARE_BRACKET_SLASH);
+    config.set_direct_commit_key(config::Config::DIRECT_COMMIT_MIDDLE_DOT);
+    session.SetConfig(config);
+
+    auto table = std::make_shared<composer::Table>();
+    table->InitializeWithRequestAndConfig(
+        commands::Request::default_instance(), config);
+    session.SetTable(table);
+
+    commands::Command command;
+    InsertCharacterChars("kyouha", &session, &command);
+    ASSERT_EQ(session.context().composer().GetQueryForConversion(), "きょうは");
+    setup_pending_live_conversion(&session_peer);
+
+    command.Clear();
+    ASSERT_TRUE(SendKey("/", &session, &command));
+
+    EXPECT_FALSE(command.output().has_result());
+    EXPECT_TRUE(command.output().has_preedit());
+    EXPECT_EQ(session.context().state(), ImeContext::COMPOSITION);
   }
 }
 


### PR DESCRIPTION
## 概要

句読点・記号の単打確定対象に、中黒 `・` を追加しました。

これにより、ローマ字テーブルで `vb -> ・` のように中黒を出す設定をしている場合でも、`・` が単打確定対象として有効であれば、`tesutovb` → `てすと・` のようにその場で確定されます。

## 背景

既存の句読点・記号単打確定では、句点、読点、疑問符、感嘆符、丸括弧、鉤括弧などを対象にしていました。

一方、日本語では中黒 `・` も、語や句を並列・区切りとしてつなぐ約物としてよく使われます。特にカタカナ語、固有名詞、並列語句などで使う頻度が高いため、句読点・記号の単打確定対象として独立して扱えるようにしました。

## 変更内容

* `DIRECT_COMMIT_MIDDLE_DOT` を追加
* 設定画面に `・` の checkbox を追加
* `・` / `･` を direct commit 対象として判定
* 記号スタイルが middle dot 系の場合のみ、`/` を `・` の direct commit trigger として扱うように調整
* ローマ字テーブルで `md -> ・` のように出力された中黒も、設定が有効なら単打確定されるようにテストを追加
* live conversion pending 中でも、middle dot 系の記号スタイルでは `/` によって `・` を確定できることをテスト

## 挙動

例:

* `tesutovb` → `てすと・`
* `tesuto/` → `てすと・`
  ※ 記号スタイルで `/` が中黒に対応する場合

`/` については `symbol_method` に連動させています。そのため、slash 系の記号スタイルでは `/` を `・` の direct commit trigger として扱いません。

## 対象外

当初検討していた二重鉤括弧 `『` / `』` は、実入力経路での扱いがやや複雑だったため、今回の PR では対象外としました。

この PR では中黒 `・` のみを追加対象にしています。

## テスト

以下を確認済みです。

* `//session:session_test`
* `//session:key_event_transformer_test`

また、実機で以下を確認しました。

* 設定画面に `・` の checkbox が表示される
* `vb -> ・` のローマ字テーブル設定で `tesutovb` → `てすと・` になる
* middle dot 系の記号スタイルで `/` が `・` として単打確定される
* slash 系の記号スタイルでは `/` が勝手に `・` として単打確定されない
