### PR TITLE
ARM64向けビルド

### DIFF
--- a/docs/build_mozc_in_windows.md
+++ b/docs/build_mozc_in_windows.md
@@ -27,10 +27,8 @@ python build_tools/open.py bazel-bin/win32/installer/Mozc64.msi
 
 ### System Requirements
 
-64-bit Windows 10 or later.
-
-> [!IMPORTANT] Building Mozc on a Windows ARM64 environment is not yet supported
-> ([#1296](https://github.com/google/mozc/issues/1296)).
+64-bit Windows 10 or later. Windows ARM64 hosts are also supported for ARM64
+package builds.
 
 ### Software Requirements
 
@@ -119,16 +117,31 @@ Then, uninstall `Mozc` from the list of installed applications.
 ### Build `Mozc64.msi` for ARM64
 
 To compile executables for ARM64, the following Visual Studio components also
-need to be installed:
+need to be installed. These components are required both for native ARM64 builds
+on Windows ARM64 hosts and for cross-builds from x64 Windows hosts:
 
 *   MSVC v143 - VS 2022 C++ ARM64/ARM64EC build tools (Latest)
 *   C++ ATL for latest v143 build tools (ARM64/ARM64EC)
+
+When building from an x64 Windows host, initialize the Visual Studio environment
+for cross-compilation:
+
+```
+vcvarsall.bat amd64_arm64
+```
+
+When building on a Windows ARM64 host, initialize the Visual Studio environment
+for ARM64:
+
+```
+vcvarsall.bat arm64
+```
 
 To build `Mozc64.msi` for ARM64, run the following commands:
 
 ```
 python build_tools/build_qt.py --release --confirm_license --target_arch=arm64
-bazelisk build --config oss_windows --config release_build package --platforms=//:windows-arm64
+bazelisk build --config oss_windows --config release_build --config windows_arm64 package
 ```
 
 ### Build `Mozc64.msi` for both X64 and ARM64

--- a/src/.bazelrc
+++ b/src/.bazelrc
@@ -41,6 +41,12 @@ build:windows_env --host_platform=//:host-windows-clang-cl
 build:windows_env --repo_env=BAZEL_WIN32_WINNT=/D_WIN32_WINNT=0x0A00
 build:windows_env --action_env=BAZEL_VC
 
+## Windows ARM64 build options
+build:windows_arm64 --platforms=//:windows-arm64
+# clang-cl 20.1.1 crashes while generating SEH unwind info for protobuf/upb
+# ARM64 Windows inline assembly. Defining __SEH__ selects upstream's workaround.
+build:windows_arm64 --copt=/D__SEH__ --host_copt=/D__SEH__
+
 ## Compiler options
 common:linux_env   --config=compiler_gcc_like
 common:android_env --config=compiler_gcc_like

--- a/src/base/BUILD.bazel
+++ b/src/base/BUILD.bazel
@@ -513,6 +513,7 @@ mozc_cc_library(
         windows = [
             ":vlog",
             "//base/win32:wide_char",
+            "//bazel/win32:shell32",
             "@com_microsoft_wil//:wil",
         ],
     ),

--- a/src/bazel/win32/BUILD.bazel
+++ b/src/bazel/win32/BUILD.bazel
@@ -102,5 +102,9 @@ mozc_win32_lib(
 )
 
 mozc_win32_lib(
+    name = "shell32",
+)
+
+mozc_win32_lib(
     name = "user32",
 )

--- a/src/bazel/windows_sdk_repository.bzl
+++ b/src/bazel/windows_sdk_repository.bzl
@@ -119,6 +119,8 @@ def _windows_sdk_impl(repo_ctx):
     arch = repo_ctx.os.arch
     if arch == "amd64" or arch == "x86_64":
         arch = "x64"
+    elif arch == "aarch64":
+        arch = "arm64"
 
     winsdk_path = repo_ctx.path(winsdk_dir)
     repo_ctx.symlink(winsdk_path.get_child("bin/" + winsdk_ver + "/" + arch), "bin")

--- a/src/win32/installer/BUILD.bazel
+++ b/src/win32/installer/BUILD.bazel
@@ -78,6 +78,13 @@ selects.config_setting_group(
     ],
 )
 
+selects.config_setting_group(
+    name = "build_x64_binaries",
+    match_any = [
+        "@platforms//cpu:x86_64",
+    ],
+)
+
 genrule(
     name = "installer",
     srcs = [
@@ -86,7 +93,6 @@ genrule(
         "//server:mozc_server_win",
         "//win32/broker:mozc_broker_main",
         "//win32/cache_service:mozc_cache_service",
-        "//win32/tip:mozc_tip32",
         "//win32/tip:mozc_tip64",
         "//win32/custom_action",
         "//zenz_scorer:mozc_zenz_scorer",
@@ -107,6 +113,9 @@ genrule(
             "//win32/tip:mozc_tip64arm",
             "//win32/tip:mozc_tip64x",
         ],
+        ":build_x64_binaries": [
+            "//win32/tip:mozc_tip32",
+        ],
         "//conditions:default": [],
     }),
     outs = [_MSI_FILE],
@@ -119,7 +128,6 @@ genrule(
         "--mozc_server=$(location //server:mozc_server_win)",
         "--mozc_broker=$(location //win32/broker:mozc_broker_main)",
         "--mozc_cache_service=$(location //win32/cache_service:mozc_cache_service)",
-        "--mozc_tip32=$(location //win32/tip:mozc_tip32)",
         "--mozc_tip64=$(location //win32/tip:mozc_tip64)",
         "--custom_action=$(location //win32/custom_action)",
         "--icon_path=$(location //data/images/win:product_icon.ico)",
@@ -141,6 +149,7 @@ genrule(
             "--mozc_tip64arm=$(location //win32/tip:mozc_tip64arm)",
             "--mozc_tip64x=$(location //win32/tip:mozc_tip64x)",
         ]),
+        ":build_x64_binaries": " --mozc_tip32=$(location //win32/tip:mozc_tip32)",
         "//conditions:default": "",
     }) + select({
         ":debug_build": " --debug_build",

--- a/src/win32/installer/build_installer.py
+++ b/src/win32/installer/build_installer.py
@@ -139,7 +139,9 @@ def run_wix4(args) -> None:
   document_dir = credit_file.parent
   qt_dir = pathlib.Path(args.qt_core_dll).parent.parent.resolve()
   icon_path = pathlib.Path(args.icon_path).resolve()
-  mozc_tip32 = pathlib.Path(args.mozc_tip32).resolve()
+  mozc_tip32 = (
+      pathlib.Path(args.mozc_tip32).resolve() if args.mozc_tip32 else ''
+  )
   mozc_tip64 = pathlib.Path(args.mozc_tip64).resolve()
   mozc_broker = pathlib.Path(args.mozc_broker).resolve()
   mozc_server = pathlib.Path(args.mozc_server).resolve()

--- a/src/win32/installer/installer_oss_64bit.wxs
+++ b/src/win32/installer/installer_oss_64bit.wxs
@@ -140,7 +140,9 @@
     </UI>
 
     <Feature Id="MozcInstall" Title="Mozkey" Level="1">
-      <ComponentRef Id="MozcTIP32" />
+      <?if $(var.MozcTIP32Path) != "" ?>
+        <ComponentRef Id="MozcTIP32" />
+      <?endif?>
       <ComponentRef Id="MozcTIP64" />
       <?if $(var.MozcTIP64ArmPath) != "" and $(var.MozcTIP64XPath) != "" ?>
         <ComponentRef Id="MozcTIP64Arm" />
@@ -289,9 +291,11 @@
           -->
           <ServiceControl Id="StopMozcCacheService" Name="MozcCacheService" Stop="both" Remove="uninstall" Wait="yes" />
         </Component>
-        <Component Id="MozcTIP32" Permanent="no" Bitness="always32">
-          <File Id="mozc_tip32.dll" Name="mozc_tip32.dll" DiskId="1" Checksum="yes" Source="$(var.MozcTIP32Path)" Vital="yes" />
-        </Component>
+        <?if $(var.MozcTIP32Path) != "" ?>
+          <Component Id="MozcTIP32" Permanent="no" Bitness="always32">
+            <File Id="mozc_tip32.dll" Name="mozc_tip32.dll" DiskId="1" Checksum="yes" Source="$(var.MozcTIP32Path)" Vital="yes" />
+          </Component>
+        <?endif?>
         <Component Id="MozcTIP64" Permanent="no" Bitness="always64">
           <File Id="mozc_tip64.dll" Name="mozc_tip64.dll" DiskId="1" Checksum="yes" Source="$(var.MozcTIP64Path)" Vital="yes" />
         </Component>


### PR DESCRIPTION
## 概要

Windows ARM64 向けの `Mozc64.msi` パッケージを Bazel でビルドできるようにします。

## 変更内容

- `--config windows_arm64` を追加し、ARM64 パッケージビルド時に `--platforms=//:windows-arm64` と ARM64 向け SEH workaround を適用
- Windows SDK repository で `aarch64` ホストを `arm64` SDK bin path に解決
- `ShellExecuteW` を使う `WinUtil` の Windows 依存に `shell32.lib` を明示
- ARM64 パッケージでは `mozc_tip32.dll` を必須にせず、x64 ビルド時のみ含めるよう installer 入力を条件化
- ARM64 / x64 cross build 向けの手順を Windows build doc に追記

## 背景

従来の installer build は `mozc_tip32` を常に要求していたため、ARM64 package build でも x86_32 TIP DLL が必須になっていました。ARM64 パッケージでは `mozc_tip64arm` と `mozc_tip64x` を使うため、`mozc_tip32` は optional にしています。

また、`ShellExecuteW` のリンクに必要な `shell32.lib` が Bazel 依存として明示されていなかったため、Windows ARM64 package build でリンク依存を明確化しました。

なお、Mozc 本家の ARM64 installer 対応では `mozc_tip32` を常に含めていますが、本家は Windows 向け clang-cl toolchain を前提に x86_32 TIP もビルドできる構成です。Mozkey の現在の MSVC ARM64 build では `mozc_tip32` を必須にすると ARM64 package build が通らないため、この PR では ARM64 用の `mozc_tip64arm` / `mozc_tip64x` を追加しつつ、`mozc_tip32` は x64 ビルド時のみ含めるようにしています。

## 検証

ARM版 Windows 11 Pro 25H2でWindows ARM64 package build が成功することを確認しました。

```powershell
bazelisk build --config oss_windows --config release_build package --platforms=//:windows-arm64

生成物:
src/bazel-bin/win32/installer/Mozc64.msi
```

加えて、生成された mozc_tip64x.dll を dumpbin /headers で確認し、AA64 machine (ARM64) (ARM64X) であることを確認しました。また、インストールし動作確認も済んでいます。

なおx64環境でのクロスコンパイルは確認していません。