### PR TITLE
Fix/ruby suggestion transition safe layout

### DIFF
--- a/src/renderer/win32/candidate_window.cc
+++ b/src/renderer/win32/candidate_window.cc
@@ -760,7 +760,13 @@ void CandidateWindow::UpdateLayout(
   if (m_hWnd != nullptr) {
     UpdateRoundedWindowRegion(m_hWnd, table_layout_->GetTotalSize(), dpi_,
                               GetRendererStyleType(*candidate_window_));
-    UpdateEffectWindows();
+  }
+}
+
+void CandidateWindow::RedrawImmediately() {
+  if (m_hWnd != nullptr && ::IsWindow(m_hWnd)) {
+    ::RedrawWindow(m_hWnd, nullptr, nullptr,
+                   RDW_INVALIDATE | RDW_UPDATENOW | RDW_NOERASE);
   }
 }
 

--- a/src/renderer/win32/candidate_window.cc
+++ b/src/renderer/win32/candidate_window.cc
@@ -552,6 +552,13 @@ void CandidateWindow::OnShowWindow(BOOL shown, UINT /*status*/) {
   }
 }
 
+void CandidateWindow::HideWithEffects() {
+  shadow_window_.Hide();
+  if (m_hWnd != nullptr && ::IsWindow(m_hWnd)) {
+    ShowWindow(SW_HIDE);
+  }
+}
+
 void CandidateWindow::OnSettingChange(UINT uFlags, LPCTSTR /*lpszSection*/) {
   // Since TextRenderer uses dialog font to render,
   // we monitor font-related parameters to know when the font style is changed.

--- a/src/renderer/win32/candidate_window.h
+++ b/src/renderer/win32/candidate_window.h
@@ -111,6 +111,10 @@ class CandidateWindow : public ATL::CWindowImpl<CandidateWindow, ATL::CWindow,
 
   void UpdateLayout(const commands::CandidateWindow& candidate_window);
   void UpdateEffectWindows();
+  // Hides both the candidate window and its renderer-owned visual effects.
+  // This avoids one-frame shadow remnants when WindowManager suppresses or
+  // relocates candidate UI during live-conversion ruby updates.
+  void HideWithEffects();
   void SetSendCommandInterface(
       client::SendCommandInterface* send_command_interface);
 

--- a/src/renderer/win32/candidate_window.h
+++ b/src/renderer/win32/candidate_window.h
@@ -111,6 +111,7 @@ class CandidateWindow : public ATL::CWindowImpl<CandidateWindow, ATL::CWindow,
 
   void UpdateLayout(const commands::CandidateWindow& candidate_window);
   void UpdateEffectWindows();
+  void RedrawImmediately();
   // Hides both the candidate window and its renderer-owned visual effects.
   // This avoids one-frame shadow remnants when WindowManager suppresses or
   // relocates candidate UI during live-conversion ruby updates.

--- a/src/renderer/win32/ruby_window.cc
+++ b/src/renderer/win32/ruby_window.cc
@@ -30,6 +30,12 @@ constexpr uint32_t kDefaultDpi = 96;
 
 // Keep the overlay close to the preedit, but do not let it cover the glyphs.
 constexpr int kFallbackLineHeight = 22;
+constexpr int kMaxReasonableLineHeight = 512;
+constexpr int kGeometryMargin = 64;
+constexpr int kNearOriginTolerance = 2;
+constexpr int kLargeJumpMinX = 320;
+constexpr int kLargeJumpMinY = 240;
+constexpr int kTransientGeometryRejectLimit = 2;
 
 COLORREF ToColorRef(uint32_t rgb) {
   return RGB(static_cast<int>((rgb >> 16) & 0xff),
@@ -158,6 +164,14 @@ bool IsUsableRubyRect(const RECT& rect, const RECT& work_area,
   return true;
 }
 
+bool IsReasonableWorkArea(const RECT& work_area) {
+  return work_area.left < work_area.right && work_area.top < work_area.bottom;
+}
+
+int RectCenterX(const RECT& rect) { return (rect.left + rect.right) / 2; }
+
+int RectCenterY(const RECT& rect) { return (rect.top + rect.bottom) / 2; }
+
 }  // namespace
 
 RubyWindow::RubyWindow() = default;
@@ -184,11 +198,24 @@ void RubyWindow::Destroy() {
   }
 }
 
-void RubyWindow::Hide() {
+void RubyWindow::HideWindowOnly() {
   shadow_window_.Hide();
   if (IsWindow()) {
     ShowWindow(SW_HIDE);
   }
+}
+
+void RubyWindow::ClearPlacementTracking() {
+  has_last_target_identity_ = false;
+  has_last_valid_geometry_ = false;
+  transient_geometry_reject_count_ = 0;
+  last_target_identity_ = TargetIdentity();
+  last_valid_window_rect_ = {};
+}
+
+void RubyWindow::Hide() {
+  ClearPlacementTracking();
+  HideWindowOnly();
 }
 
 bool RubyWindow::BuildReadingText(
@@ -235,8 +262,8 @@ bool RubyWindow::BuildReadingText(
 }
 
 bool RubyWindow::GetBasePosition(const commands::RendererCommand& command,
-                                 POINT* point,
-                                 int* line_height) const {
+                                 POINT* point, int* line_height,
+                                 bool* from_preedit_rectangle) const {
   // Prefer the preedit rectangle. This is usually closer to the actual
   // composition text than composition_target, which tends to follow the caret.
   if (command.has_preedit_rectangle()) {
@@ -248,6 +275,9 @@ bool RubyWindow::GetBasePosition(const commands::RendererCommand& command,
       point->x = rect.left();
       point->y = rect.top();
       *line_height = height;
+      if (from_preedit_rectangle != nullptr) {
+        *from_preedit_rectangle = true;
+      }
       return true;
     }
   }
@@ -262,11 +292,98 @@ bool RubyWindow::GetBasePosition(const commands::RendererCommand& command,
       const commands::RendererCommand::CharacterPosition& target =
           app_info.composition_target();
 
+      const int target_line_height =
+          target.has_line_height() ? static_cast<int>(target.line_height())
+                                   : kFallbackLineHeight;
+      if (target_line_height <= 0) {
+        return false;
+      }
+
       point->x = target.top_left().x();
       point->y = target.top_left().y();
-      *line_height = target.has_line_height()
-                         ? static_cast<int>(target.line_height())
-                         : kFallbackLineHeight;
+      *line_height = target_line_height;
+      if (from_preedit_rectangle != nullptr) {
+        *from_preedit_rectangle = false;
+      }
+      return true;
+    }
+  }
+
+  return false;
+}
+
+bool RubyWindow::GetTargetIdentity(const commands::RendererCommand& command,
+                                   TargetIdentity* identity) {
+  if (identity == nullptr || !command.has_application_info()) {
+    return false;
+  }
+
+  const commands::RendererCommand::ApplicationInfo& app_info =
+      command.application_info();
+  if (!app_info.has_target_window_handle() ||
+      app_info.target_window_handle() == 0) {
+    return false;
+  }
+
+  identity->process_id =
+      app_info.has_process_id() ? app_info.process_id() : 0;
+  identity->thread_id = app_info.has_thread_id() ? app_info.thread_id() : 0;
+  identity->target_window_handle = app_info.target_window_handle();
+  return true;
+}
+
+bool RubyWindow::IsSameTargetIdentity(const TargetIdentity& lhs,
+                                      const TargetIdentity& rhs) {
+  return lhs.process_id == rhs.process_id &&
+         lhs.thread_id == rhs.thread_id &&
+         lhs.target_window_handle == rhs.target_window_handle;
+}
+
+bool RubyWindow::KeepCurrentPlacement() const {
+  return has_last_valid_geometry_ && m_hWnd != nullptr && ::IsWindow(m_hWnd) &&
+         ::IsWindowVisible(m_hWnd);
+}
+
+bool RubyWindow::ShouldRejectTransientGeometry(
+    const POINT& base_point, int line_height, const RECT& window_rect,
+    const RECT& work_area, bool from_preedit_rectangle,
+    bool target_changed) const {
+  if (!IsReasonableWorkArea(work_area)) {
+    return false;
+  }
+
+  if (line_height <= 0 || line_height > kMaxReasonableLineHeight) {
+    return true;
+  }
+
+  if (base_point.x < work_area.left - kGeometryMargin ||
+      base_point.x > work_area.right + kGeometryMargin ||
+      base_point.y < work_area.top - kGeometryMargin ||
+      base_point.y > work_area.bottom + kGeometryMargin) {
+    return true;
+  }
+
+  const bool base_near_work_area_origin =
+      base_point.x <= work_area.left + kNearOriginTolerance &&
+      base_point.y <= work_area.top + kNearOriginTolerance;
+  const bool window_near_work_area_origin =
+      window_rect.left <= work_area.left + kNearOriginTolerance &&
+      window_rect.top <= work_area.top + kNearOriginTolerance;
+  if ((base_near_work_area_origin || window_near_work_area_origin) &&
+      (!from_preedit_rectangle || target_changed || has_last_valid_geometry_)) {
+    return true;
+  }
+
+  if (!target_changed && has_last_valid_geometry_) {
+    const int work_width = work_area.right - work_area.left;
+    const int work_height = work_area.bottom - work_area.top;
+    const int max_jump_x = std::max(kLargeJumpMinX, work_width / 2);
+    const int max_jump_y = std::max(kLargeJumpMinY, work_height / 2);
+    const int dx = std::abs(RectCenterX(window_rect) -
+                            RectCenterX(last_valid_window_rect_));
+    const int dy = std::abs(RectCenterY(window_rect) -
+                            RectCenterY(last_valid_window_rect_));
+    if (dx > max_jump_x || dy > max_jump_y) {
       return true;
     }
   }
@@ -381,10 +498,38 @@ void RubyWindow::OnUpdate(const commands::RendererCommand& command,
     return;
   }
 
+  TargetIdentity current_target_identity;
+  const bool has_current_target_identity =
+      GetTargetIdentity(command, &current_target_identity);
+  const bool target_changed =
+      has_current_target_identity &&
+      (!has_last_target_identity_ ||
+       !IsSameTargetIdentity(last_target_identity_, current_target_identity));
+  if (target_changed) {
+    last_target_identity_ = current_target_identity;
+    has_last_target_identity_ = true;
+    has_last_valid_geometry_ = false;
+    transient_geometry_reject_count_ = 0;
+    HideWindowOnly();
+  } else if (has_current_target_identity) {
+    last_target_identity_ = current_target_identity;
+    has_last_target_identity_ = true;
+  } else {
+    has_last_target_identity_ = false;
+    has_last_valid_geometry_ = false;
+    transient_geometry_reject_count_ = 0;
+  }
+
   POINT base_point = {};
   int line_height = kFallbackLineHeight;
-  if (!GetBasePosition(command, &base_point, &line_height)) {
-    Hide();
+  bool from_preedit_rectangle = false;
+  if (!GetBasePosition(command, &base_point, &line_height,
+                       &from_preedit_rectangle)) {
+    if (KeepCurrentPlacement()) {
+      return;
+    }
+    has_last_valid_geometry_ = false;
+    HideWindowOnly();
     return;
   }
 
@@ -392,9 +537,17 @@ void RubyWindow::OnUpdate(const commands::RendererCommand& command,
   UpdateFont(dc);
   ::ReleaseDC(nullptr, dc);
 
+  const std::wstring previous_text = text_;
+  const SIZE previous_window_size = window_size_;
+  const auto restore_previous_content = [&]() {
+    text_ = previous_text;
+    window_size_ = previous_window_size;
+  };
+
   text_ = ToWide(reading);
   window_size_ = MeasureText();
   if (window_size_.cx <= 0 || window_size_.cy <= 0) {
+    restore_previous_content();
     Hide();
     return;
   }
@@ -434,12 +587,38 @@ void RubyWindow::OnUpdate(const commands::RendererCommand& command,
   int top = 0;
   // Prefer the conventional ruby-like placement above the preedit.  Use below
   // only when the above side is unavailable or occupied by candidate/suggestion
-  // UI.  If neither side is usable, hide the ruby window rather than overlapping
-  // other renderer UI.
+  // UI.  If neither side is usable, keep the last stable placement when this
+  // looks like a transient geometry frame.
+  const RECT preferred_window_rect = ruby_rect_at(above_top);
+  const bool looks_like_transient_geometry = ShouldRejectTransientGeometry(
+      base_point, line_height, preferred_window_rect, work_area,
+      from_preedit_rectangle, target_changed);
   if (!try_place(above_top, &top) && !try_place(below_top, &top)) {
-    Hide();
+    restore_previous_content();
+    if (looks_like_transient_geometry && KeepCurrentPlacement()) {
+      return;
+    }
+    has_last_valid_geometry_ = false;
+    HideWindowOnly();
     return;
   }
+
+  RECT window_rect = {left, top, left + window_size_.cx,
+                      top + window_size_.cy};
+  if (ShouldRejectTransientGeometry(base_point, line_height, window_rect,
+                                    work_area, from_preedit_rectangle,
+                                    target_changed)) {
+    restore_previous_content();
+    ++transient_geometry_reject_count_;
+    if (transient_geometry_reject_count_ <= kTransientGeometryRejectLimit) {
+      if (KeepCurrentPlacement()) {
+        return;
+      }
+      HideWindowOnly();
+      return;
+    }
+  }
+  transient_geometry_reject_count_ = 0;
 
   const int radius = ScaleCornerRadius(
       RendererStyleHandler::GetRubyWindowStyle().corner_radius,
@@ -457,7 +636,6 @@ void RubyWindow::OnUpdate(const commands::RendererCommand& command,
   SetWindowPos(HWND_TOPMOST, left, top, window_size_.cx, window_size_.cy,
                SWP_NOACTIVATE | SWP_SHOWWINDOW);
   ApplyRendererWindowOpacity(m_hWnd, GetRubyWindowTheme().opacity_percent);
-  RECT window_rect = {left, top, left + window_size_.cx, top + window_size_.cy};
   RendererWindowShadowStyle shadow_style;
   shadow_style.size = GetRubyWindowTheme().shadow.size;
   shadow_style.opacity_percent = GetRubyWindowTheme().shadow.opacity_percent;
@@ -465,6 +643,14 @@ void RubyWindow::OnUpdate(const commands::RendererCommand& command,
   shadow_style.distance = GetRubyWindowTheme().shadow.distance;
   shadow_window_.Update(m_hWnd, window_rect, GetWindowDpi(m_hWnd),
                         GetRubyWindowTheme().corner_radius, shadow_style);
+
+  last_valid_window_rect_ = window_rect;
+
+  has_last_valid_geometry_ = true;
+  if (has_current_target_identity) {
+    last_target_identity_ = current_target_identity;
+    has_last_target_identity_ = true;
+  }
 
   ShowWindow(SW_SHOWNOACTIVATE);
   Invalidate(FALSE);

--- a/src/renderer/win32/ruby_window.h
+++ b/src/renderer/win32/ruby_window.h
@@ -3,6 +3,7 @@
 
 #include <windows.h>
 
+#include <cstdint>
 #include <string>
 
 #include <atlbase.h>
@@ -55,8 +56,28 @@ class RubyWindow
   SIZE MeasureText() const;
   bool BuildReadingText(const commands::RendererCommand& command,
                         std::string* reading) const;
-  bool GetBasePosition(const commands::RendererCommand& command,
-                       POINT* point, int* line_height) const;
+  struct TargetIdentity {
+    uint32_t process_id = 0;
+    uint32_t thread_id = 0;
+    uint32_t target_window_handle = 0;
+  };
+
+  static bool GetTargetIdentity(const commands::RendererCommand& command,
+                                TargetIdentity* identity);
+  static bool IsSameTargetIdentity(const TargetIdentity& lhs,
+                                   const TargetIdentity& rhs);
+
+  void HideWindowOnly();
+  void ClearPlacementTracking();
+  bool KeepCurrentPlacement() const;
+  bool ShouldRejectTransientGeometry(const POINT& base_point, int line_height,
+                                     const RECT& window_rect,
+                                     const RECT& work_area,
+                                     bool from_preedit_rectangle,
+                                     bool target_changed) const;
+  bool GetBasePosition(const commands::RendererCommand& command, POINT* point,
+                       int* line_height,
+                       bool* from_preedit_rectangle) const;
 
   HFONT font_ = nullptr;
   std::wstring font_face_name_;
@@ -67,6 +88,13 @@ class RubyWindow
   std::wstring text_;
   SIZE window_size_ = {};
   RendererShadowWindow shadow_window_;
+
+  TargetIdentity last_target_identity_;
+  bool has_last_target_identity_ = false;
+  RECT last_valid_window_rect_ = {};
+
+  bool has_last_valid_geometry_ = false;
+  int transient_geometry_reject_count_ = 0;
 };
 
 }  // namespace win32

--- a/src/renderer/win32/window_manager.cc
+++ b/src/renderer/win32/window_manager.cc
@@ -419,6 +419,9 @@ void WindowManager::UpdateLayout(const commands::RendererCommand& command) {
   main_window_->SetWindowPos(HWND_TOPMOST, main_window_rect.Left(),
                              main_window_rect.Top(), main_window_rect.Width(),
                              main_window_rect.Height(), set_windows_pos_flags);
+  if (is_live_conversion_passive_suggestion) {
+    main_window_->RedrawImmediately();
+  }
   main_window_->UpdateEffectWindows();
   if (is_live_conversion_passive_suggestion) {
     last_live_conversion_passive_suggestion_visible_ = true;

--- a/src/renderer/win32/window_manager.cc
+++ b/src/renderer/win32/window_manager.cc
@@ -57,6 +57,39 @@ namespace {
 constexpr uint32_t kHideWindowDelay = 500;  // msec
 const POINT kInvalidMousePosition = {-65535, -65535};
 
+RECT ToWinRect(const Rect& rect) {
+  return RECT{rect.Left(), rect.Top(), rect.Right(), rect.Bottom()};
+}
+
+enum class VerticalRelationToPreedit {
+  kAbove,
+  kBelow,
+  kOverlapping,
+};
+
+VerticalRelationToPreedit GetVerticalRelationToPreedit(
+    const RECT& rect, const Rect& preedit_rect) {
+  if (rect.bottom <= preedit_rect.Top()) {
+    return VerticalRelationToPreedit::kAbove;
+  }
+  if (rect.top >= preedit_rect.Bottom()) {
+    return VerticalRelationToPreedit::kBelow;
+  }
+  return VerticalRelationToPreedit::kOverlapping;
+}
+
+bool IsOppositeSideOfPreedit(const RECT& lhs, const RECT& rhs,
+                             const Rect& preedit_rect) {
+  const VerticalRelationToPreedit lhs_relation =
+      GetVerticalRelationToPreedit(lhs, preedit_rect);
+  const VerticalRelationToPreedit rhs_relation =
+      GetVerticalRelationToPreedit(rhs, preedit_rect);
+  return (lhs_relation == VerticalRelationToPreedit::kAbove &&
+          rhs_relation == VerticalRelationToPreedit::kBelow) ||
+         (lhs_relation == VerticalRelationToPreedit::kBelow &&
+          rhs_relation == VerticalRelationToPreedit::kAbove);
+}
+
 }  // namespace
 
 WindowManager::WindowManager()
@@ -82,9 +115,9 @@ void WindowManager::Initialize() {
   DCHECK(!infolist_window_->IsWindow());
 
   main_window_->Create(nullptr);
-  main_window_->ShowWindow(SW_HIDE);
+  main_window_->HideWithEffects();
   cascading_window_->Create(nullptr);
-  cascading_window_->ShowWindow(SW_HIDE);
+  cascading_window_->HideWithEffects();
   indicator_window_->Initialize();
   infolist_window_->Create(nullptr);
   infolist_window_->ShowWindow(SW_HIDE);
@@ -128,8 +161,8 @@ void WindowManager::DestroyAllWindows() {
 void WindowManager::HideAllWindows() {
   last_live_conversion_passive_suggestion_visible_ = false;
   has_last_live_conversion_passive_suggestion_rect_ = false;
-  main_window_->ShowWindow(SW_HIDE);
-  cascading_window_->ShowWindow(SW_HIDE);
+  main_window_->HideWithEffects();
+  cascading_window_->HideWithEffects();
   indicator_window_->Hide();
   infolist_window_->DelayHide(0);
   ruby_window_->Hide();
@@ -145,8 +178,8 @@ void WindowManager::UpdateLayout(const commands::RendererCommand& command) {
   if (!command.visible()) {
     last_live_conversion_passive_suggestion_visible_ = false;
     has_last_live_conversion_passive_suggestion_rect_ = false;
-    cascading_window_->ShowWindow(SW_HIDE);
-    main_window_->ShowWindow(SW_HIDE);
+    cascading_window_->HideWithEffects();
+    main_window_->HideWithEffects();
     indicator_window_->Hide();
     infolist_window_->DelayHide(0);
     ruby_window_->Hide();
@@ -190,9 +223,9 @@ void WindowManager::UpdateLayout(const commands::RendererCommand& command) {
   }
 
   if (output.live_conversion() && !is_live_conversion_passive_suggestion) {
-    cascading_window_->ShowWindow(SW_HIDE);
+    cascading_window_->HideWithEffects();
     if (!should_keep_previous_live_conversion_passive_suggestion) {
-      main_window_->ShowWindow(SW_HIDE);
+      main_window_->HideWithEffects();
       last_live_conversion_passive_suggestion_visible_ = false;
       has_last_live_conversion_passive_suggestion_rect_ = false;
     }
@@ -251,16 +284,16 @@ void WindowManager::UpdateLayout(const commands::RendererCommand& command) {
 
   if (!output.has_candidate_window()) {
     // Hide candidate windows because there is no candidate to be displayed.
-    cascading_window_->ShowWindow(SW_HIDE);
-    main_window_->ShowWindow(SW_HIDE);
+    cascading_window_->HideWithEffects();
+    main_window_->HideWithEffects();
     infolist_window_->DelayHide(0);
     return;
   }
 
   if (is_suggest && !show_suggest) {
     // The candidate list is for suggestion but the visibility bit is off.
-    cascading_window_->ShowWindow(SW_HIDE);
-    main_window_->ShowWindow(SW_HIDE);
+    cascading_window_->HideWithEffects();
+    main_window_->HideWithEffects();
     infolist_window_->DelayHide(0);
     return;
   }
@@ -268,16 +301,16 @@ void WindowManager::UpdateLayout(const commands::RendererCommand& command) {
   if (is_convert_or_predict && !show_candidate) {
     // The candidate list is for conversion or prediction but the visibility
     // bit is off.
-    cascading_window_->ShowWindow(SW_HIDE);
-    main_window_->ShowWindow(SW_HIDE);
+    cascading_window_->HideWithEffects();
+    main_window_->HideWithEffects();
     infolist_window_->DelayHide(0);
     return;
   }
 
   const commands::CandidateWindow& candidate_window = output.candidate_window();
   if (candidate_window.candidate_size() == 0) {
-    cascading_window_->ShowWindow(SW_HIDE);
-    main_window_->ShowWindow(SW_HIDE);
+    cascading_window_->HideWithEffects();
+    main_window_->HideWithEffects();
     infolist_window_->DelayHide(0);
     return;
   }
@@ -288,9 +321,11 @@ void WindowManager::UpdateLayout(const commands::RendererCommand& command) {
   }
 
   if (!candidate_layout.initialized()) {
-    cascading_window_->ShowWindow(SW_HIDE);
-    main_window_->ShowWindow(SW_HIDE);
+    cascading_window_->HideWithEffects();
+    main_window_->HideWithEffects();
     infolist_window_->DelayHide(0);
+    last_live_conversion_passive_suggestion_visible_ = false;
+    has_last_live_conversion_passive_suggestion_rect_ = false;
     if (should_defer_ruby_update) {
       ruby_window_->OnUpdate(command);
     }
@@ -306,7 +341,7 @@ void WindowManager::UpdateLayout(const commands::RendererCommand& command) {
   // Sync both windows to the DPI of the monitor where the candidate window
   // is about to be placed. This makes their first-frame layout correct when
   // the target app is on a different-DPI monitor than where the windows were
-  // last shown — WM_DPICHANGED would otherwise fire only during the
+  // last shown - WM_DPICHANGED would otherwise fire only during the
   // subsequent SetWindowPos, after the size has already been computed at
   // the stale DPI.
   const uint32_t target_dpi = GetDpiForPoint(target_point.x, target_point.y);
@@ -335,11 +370,13 @@ void WindowManager::UpdateLayout(const commands::RendererCommand& command) {
       main_window_->GetCandidateColumnInClientCord().Left(), 0);
 
   Rect main_window_rect;
+  Rect preedit_rect_for_transition;
   {
     // Equating |exclusion_area| with |preedit_rect| generally works well and
     // makes most of users happy.
     const CRect rect(candidate_layout.exclude_region());
     const Rect preedit_rect(rect.left, rect.top, rect.Width(), rect.Height());
+    preedit_rect_for_transition = preedit_rect;
     const bool vertical = (LayoutManager::GetWritingDirection(app_info) ==
                            LayoutManager::VERTICAL_WRITING);
     // Sometimes |target_point| is set to the top-left of the exclusion area
@@ -358,13 +395,24 @@ void WindowManager::UpdateLayout(const commands::RendererCommand& command) {
             main_window_zero_point, working_area, vertical);
   }
 
+  RECT next_live_conversion_passive_suggestion_rect = {};
   if (should_defer_ruby_update) {
-    last_live_conversion_passive_suggestion_rect_ = {
-        main_window_rect.Left(), main_window_rect.Top(),
-        main_window_rect.Right(), main_window_rect.Bottom()};
-    has_last_live_conversion_passive_suggestion_rect_ = true;
+    next_live_conversion_passive_suggestion_rect = ToWinRect(main_window_rect);
+
+    // If the passive suggestion flips across the preedit line, the old
+    // suggestion window can still occupy the side where ruby should stay.
+    // Hide the old passive suggestion first and keep ruby visible instead of
+    // expanding ruby's avoidance area to old+new rectangles.
+    if (last_live_conversion_passive_suggestion_visible_ &&
+        has_last_live_conversion_passive_suggestion_rect_ &&
+        IsOppositeSideOfPreedit(
+            last_live_conversion_passive_suggestion_rect_,
+            next_live_conversion_passive_suggestion_rect,
+            preedit_rect_for_transition)) {
+      main_window_->HideWithEffects();
+    }
     ruby_window_->OnUpdate(command,
-                           &last_live_conversion_passive_suggestion_rect_);
+                           &next_live_conversion_passive_suggestion_rect);
   }
 
   const DWORD set_windows_pos_flags = SWP_NOACTIVATE | SWP_SHOWWINDOW;
@@ -374,6 +422,9 @@ void WindowManager::UpdateLayout(const commands::RendererCommand& command) {
   main_window_->UpdateEffectWindows();
   if (is_live_conversion_passive_suggestion) {
     last_live_conversion_passive_suggestion_visible_ = true;
+    last_live_conversion_passive_suggestion_rect_ =
+        next_live_conversion_passive_suggestion_rect;
+    has_last_live_conversion_passive_suggestion_rect_ = true;
   }
   // This trick ensures that the window is certainly shown as 'inactivated'
   // in terms of visual effect on DWM-enabled desktop.
@@ -479,7 +530,7 @@ void WindowManager::UpdateLayout(const commands::RendererCommand& command) {
     if (candidate_changed) {
       main_window_->Invalidate();
     }
-    cascading_window_->ShowWindow(SW_HIDE);
+    cascading_window_->HideWithEffects();
   }
 }
 


### PR DESCRIPTION
## 概要

この PR では、ライブ変換中の Ruby overlay と passive suggestion window の表示遷移を安定化しました。

主に以下の問題を修正しています。

* passive suggestion が上下に切り替わるタイミングで、Ruby overlay と suggestion window が重なることがある
* focus を別アプリに移して戻した後、Ruby overlay が入力ごとにちらつくことがある
* 入力欄の行高変化などで、一時的に不正な geometry が渡された際、Ruby overlay が画面左上に一瞬表示されることがある
* passive suggestion の内容切替時に、旧 window / shadow / 背景の中間状態が一瞬見えることがある

## 変更内容

### 1. candidate window の shadow 付き hide を追加

`CandidateWindow::HideWithEffects()` を追加し、candidate window を隠す際に renderer-owned shadow も同時に隠すようにしました。

これにより、WindowManager 側で candidate UI を抑制・移動・再配置するタイミングで、shadow だけが 1 frame 残る状況を減らしています。

### 2. passive suggestion と Ruby overlay の遷移順を調整

ライブ変換中に passive suggestion が表示される場合、Ruby overlay の更新を suggestion の次回表示位置が確定した後に行うようにしました。

また、passive suggestion が preedit line の上下で反転する場合は、古い suggestion window を先に `HideWithEffects()` で退避してから Ruby overlay を更新します。

これにより、Ruby が旧 suggestion と新 suggestion の両方を避けようとして不自然に消える挙動や、逆に suggestion と重なる挙動を抑制しています。

### 3. Ruby overlay の transient geometry guard を追加

`RubyWindow` に target identity と last valid geometry の追跡を追加しました。

同一 target で一時的に不自然な geometry が渡された場合は、すぐに左上などへ移動せず、短時間だけ前回の安定位置を維持します。一方で、target が変わった場合は旧 target の位置を再利用しないようにしています。

主な guard 対象は以下です。

* line height が不正または極端に大きい
* base point が work area から大きく外れている
* preedit / window が work area 左上付近に急に現れる
* 同一 target 内で window 位置が大きくジャンプする

これにより、focus 復帰直後や入力欄の行高変化時に Ruby overlay がちらついたり、画面左上に一瞬表示されたりする問題を抑制します。

### 4. passive suggestion の layout 後 redraw を追加

`CandidateWindow::UpdateLayout()` では layout / window region の更新までに留め、shadow / opacity などの effect 更新は `WindowManager` 側の `SetWindowPos()` 後に行うようにしました。

さらに、live conversion passive suggestion の場合は `SetWindowPos()` 後に `RedrawImmediately()` を挟み、表示位置・サイズが確定した状態で同期 repaint してから shadow/effect を更新します。

これにより、candidate window の内容切替時に旧背景や shadow の中間状態が一瞬見える問題を軽減しています。

## 確認内容

* `bazelisk build //:package` 成功
* 実機で以下を確認

  * Cursor など別アプリに focus した後、Floorp / ChatGPT 入力欄へ戻っても Ruby overlay が入力ごとにちらつきにくい
  * 入力中の行高変化時に Ruby overlay が画面左上へ一瞬飛びにくい
  * passive suggestion の上下反転時に Ruby overlay と suggestion window が重なりにくい
  * passive suggestion の内容切替時の中間表示が軽減されている
  * fingerprint 変更ごとに hide/show する試行案と異なり、suggestion window の強いちらつきは発生しにくい

## 備考

この PR では、candidate / suggestion の内容生成ロジックや変換結果そのものは変更していません。変更対象は Windows renderer 側の Ruby overlay / candidate window / passive suggestion の表示更新順序と geometry 安定化に限定しています。
