### PR TITLE
Keep live conversion pending for transient sokuon prefixes

### DIFF
--- a/src/session/session.cc
+++ b/src/session/session.cc
@@ -1395,6 +1395,73 @@ bool ShouldSkipLiveConversionForCompositionKey(
   return Util::IsScriptType(core, Util::HIRAGANA);
 }
 
+bool ShouldKeepPendingLiveConversionForTransientSokuon(absl::string_view key) {
+  if (key.empty() || !Util::IsScriptType(key, Util::HIRAGANA)) {
+    return false;
+  }
+
+  absl::string_view rest;
+  char32_t last = 0;
+  if (!Util::SplitLastChar32(key, &rest, &last) || last != U'っ') {
+    return false;
+  }
+
+  if (Util::CharsLen(rest) < 2) {
+    return false;
+  }
+
+  absl::string_view before_rest;
+  char32_t previous = 0;
+  if (Util::SplitLastChar32(rest, &before_rest, &previous) &&
+      previous == U'っ') {
+    return false;
+  }
+
+  // This is aimed at transient sokuon forms that commonly recover on the
+  // next kana, e.g. 「おもっ」→「おもって」 and 「くさっ」→「くさって」.
+  // Keep this list narrow so expressive atoms such as 「やっっ」 and 「ふんっ」
+  // continue to use the existing composition-only behavior.
+  const auto has_transient_stem_suffix = [&](absl::string_view stem) {
+    if (!absl::EndsWith(rest, stem)) {
+      return false;
+    }
+
+    const absl::string_view prefix = rest.substr(0, rest.size() - stem.size());
+    if (prefix.empty()) {
+      return true;
+    }
+
+    // Allow common short functional prefixes within the same composition,
+    // e.g. 「とおもっ」→「と思って」 and 「をさわっ」→「を触って」.
+    return ContainsStringView({
+        "と", "を", "に", "が", "は", "も", "で", "へ",
+        "から", "まで", "より",
+    }, prefix);
+  };
+
+  return has_transient_stem_suffix("おも") ||  // 思っ...
+         has_transient_stem_suffix("くさ") ||  // 腐っ...
+         has_transient_stem_suffix("さわ") ||  // 触っ...
+         has_transient_stem_suffix("かえ") ||  // 帰っ...
+         has_transient_stem_suffix("わら") ||  // 笑っ...
+         has_transient_stem_suffix("おこ") ||  // 怒っ...
+         has_transient_stem_suffix("まよ") ||  // 迷っ...
+         has_transient_stem_suffix("のこ") ||  // 残っ...
+         has_transient_stem_suffix("ひろ") ||  // 拾っ...
+         has_transient_stem_suffix("ふと") ||  // 太っ...
+         has_transient_stem_suffix("あた") ||  // 当たっ...
+         has_transient_stem_suffix("あら") ||  // 洗っ...
+         has_transient_stem_suffix("うつ") ||  // 打っ...
+         has_transient_stem_suffix("うた") ||  // 歌っ...
+         has_transient_stem_suffix("けず") ||  // 削っ...
+         has_transient_stem_suffix("しぼ") ||  // 絞っ...
+         has_transient_stem_suffix("すわ") ||  // 座っ...
+         has_transient_stem_suffix("とま") ||  // 止まっ...
+         has_transient_stem_suffix("なお") ||  // 直っ...
+         has_transient_stem_suffix("のぼ") ||  // 登っ...
+         has_transient_stem_suffix("はし") ||  // 走っ...
+         has_transient_stem_suffix("まわ");    // 回っ...
+}
 
 bool CandidateWordHasAttribute(const commands::CandidateWord& candidate,
                                commands::CandidateAttribute attribute) {
@@ -4722,6 +4789,12 @@ bool Session::MaybeStartLiveConversion(commands::Command* command) {
   pending_live_conversion_suggestion_candidate_window_.Clear();
 
   if (!context_->mutable_converter()->Convert(context_->composer())) {
+    if (ShouldKeepPendingLiveConversionForTransientSokuon(live_conversion_key) &&
+        OutputPendingLiveConversion(command)) {
+      ClearZenzLiveCorrectionState();
+      return true;
+    }
+
     OutputComposition(command);
     return true;
   }
@@ -4906,11 +4979,35 @@ bool Session::MaybeScheduleLiveConversion(commands::Command* command) {
   const size_t length = context_->composer().GetLength();
   const std::string key = context_->composer().GetQueryForConversion();
 
-  if (ShouldSkipLiveConversionForCompositionKey(
+  const bool should_skip_live_conversion =
+      ShouldSkipLiveConversionForCompositionKey(
           key,
           GetLiveConversionCommittedLeftBoundary(*context_),
-          GetLiveConversionMinKeyLength(context_->GetConfig())) ||
-      length != context_->composer().GetCursor()) {
+          GetLiveConversionMinKeyLength(context_->GetConfig()));
+  const bool cursor_at_end = length == context_->composer().GetCursor();
+
+  if (should_skip_live_conversion || !cursor_at_end) {
+    if (should_skip_live_conversion && cursor_at_end &&
+        ShouldKeepPendingLiveConversionForTransientSokuon(key)) {
+      // Inputs such as 「おもっ」 and 「くさっ」 can be transient sokuon
+      // prefixes before 「て」/「た」.  They may be skipped before Convert()
+      // is attempted, so keep the live conversion overlay as pending instead
+      // of falling back to plain composition output.
+      ++live_conversion_generation_;
+      live_conversion_pending_ = true;
+      pending_live_conversion_generation_ = live_conversion_generation_;
+      pending_live_conversion_key_ = key;
+      pending_live_conversion_input_ = command->input();
+      pending_live_conversion_suggestion_candidate_window_.Clear();
+
+      if (OutputPendingLiveConversion(command)) {
+        AttachDelayedLiveConversionCallback(command);
+        return true;
+      }
+
+      CancelPendingLiveConversion();
+    }
+
     CancelPendingLiveConversion();
     return false;
   }
@@ -5010,11 +5107,22 @@ bool Session::ApplyDelayedLiveConversion(commands::Command* command) {
   }
 
   const size_t length = context_->composer().GetLength();
-  if (ShouldSkipLiveConversionForCompositionKey(
+  const bool should_skip_live_conversion =
+      ShouldSkipLiveConversionForCompositionKey(
           current_key,
           GetLiveConversionCommittedLeftBoundary(*context_),
-          GetLiveConversionMinKeyLength(context_->GetConfig())) ||
-      length != context_->composer().GetCursor()) {
+          GetLiveConversionMinKeyLength(context_->GetConfig()));
+  const bool cursor_at_end = length == context_->composer().GetCursor();
+
+  if (should_skip_live_conversion || !cursor_at_end) {
+    if (should_skip_live_conversion && cursor_at_end &&
+        ShouldKeepPendingLiveConversionForTransientSokuon(current_key)) {
+      OutputPendingLiveConversion(command);
+      AttachCachedLiveConversionSuggestionCandidateWindow(
+          command->mutable_output());
+      return true;
+    }
+
     CancelPendingLiveConversion();
     OutputFromState(command);
     return true;

--- a/src/session/session_test.cc
+++ b/src/session/session_test.cc
@@ -115,6 +115,7 @@ class SessionTestPeer : testing::TestPeer<Session> {
   PEER_VARIABLE(undo_contexts_);
   PEER_VARIABLE(live_conversion_active_);
   PEER_VARIABLE(live_conversion_pending_);
+  PEER_VARIABLE(pending_live_conversion_key_);
   PEER_VARIABLE(live_conversion_key_);
   PEER_VARIABLE(live_conversion_preedit_);
   PEER_VARIABLE(live_conversion_value_);
@@ -2152,6 +2153,167 @@ TEST_F(SessionTest, LiveConversionAllowsSingleCharacterWhenMinKeyLengthIsOne) {
   EXPECT_EQ(session.context().state(), ImeContext::CONVERSION);
   EXPECT_TRUE(command.output().live_conversion());
   EXPECT_TRUE(EnsurePreedit("亜", command));
+}
+
+TEST_F(SessionTest,
+       LiveConversionKeepsPendingOverlayForTransientSokuonPrefix) {
+  MockEngine engine;
+  std::shared_ptr<MockConverter> converter = CreateEngineConverterMock(&engine);
+
+  Session session(engine);
+  SessionTestPeer session_peer(session);
+  InitSessionToPrecomposition(&session);
+
+  config::Config config;
+  config::ConfigHandler::GetDefaultConfig(&config);
+  config.set_use_live_conversion(true);
+  config.set_live_conversion_delay_msec(0);
+  session.SetConfig(config);
+
+  EXPECT_CALL(*converter, StartConversion(_, _))
+      .Times(::testing::AnyNumber())
+      .WillRepeatedly(Return(false));
+
+  commands::Command command;
+  InsertCharacterString("おもっ", "aaa", &session, &command);
+
+  EXPECT_EQ(session.context().composer().GetQueryForConversion(), "おもっ");
+  EXPECT_EQ(session.context().state(), ImeContext::COMPOSITION);
+  EXPECT_FALSE(session_peer.live_conversion_active_());
+  EXPECT_TRUE(session_peer.live_conversion_pending_());
+  EXPECT_EQ(session_peer.pending_live_conversion_key_(), "おもっ");
+  EXPECT_TRUE(command.output().live_conversion());
+  EXPECT_TRUE(command.output().live_conversion_pending());
+  ASSERT_TRUE(command.output().has_callback());
+  ASSERT_TRUE(command.output().callback().has_session_command());
+  EXPECT_EQ(command.output().callback().session_command().type(),
+            commands::SessionCommand::APPLY_LIVE_CONVERSION);
+  const commands::SessionCommand delayed_command =
+      command.output().callback().session_command();
+  EXPECT_PREEDIT("おもっ", command);
+
+  command.Clear();
+  command.mutable_input()->set_type(commands::Input::SEND_COMMAND);
+  *command.mutable_input()->mutable_command() = delayed_command;
+
+  EXPECT_TRUE(session.SendCommand(&command));
+  EXPECT_TRUE(session_peer.live_conversion_pending_());
+  EXPECT_EQ(session_peer.pending_live_conversion_key_(), "おもっ");
+  EXPECT_TRUE(command.output().live_conversion());
+  EXPECT_TRUE(command.output().live_conversion_pending());
+  EXPECT_PREEDIT("おもっ", command);
+}
+
+TEST_F(SessionTest,
+       LiveConversionKeepsPendingOverlayForParticlePlusTransientSokuonPrefix) {
+  MockEngine engine;
+  std::shared_ptr<MockConverter> converter = CreateEngineConverterMock(&engine);
+
+  Session session(engine);
+  SessionTestPeer session_peer(session);
+  InitSessionToPrecomposition(&session);
+
+  config::Config config;
+  config::ConfigHandler::GetDefaultConfig(&config);
+  config.set_use_live_conversion(true);
+  config.set_live_conversion_delay_msec(0);
+  session.SetConfig(config);
+
+  EXPECT_CALL(*converter, StartConversion(_, _))
+      .Times(::testing::AnyNumber())
+      .WillRepeatedly(Return(false));
+
+  commands::Command command;
+  InsertCharacterString("とおもっ", "aaaa", &session, &command);
+
+  EXPECT_EQ(session.context().composer().GetQueryForConversion(), "とおもっ");
+  EXPECT_EQ(session.context().state(), ImeContext::COMPOSITION);
+  EXPECT_FALSE(session_peer.live_conversion_active_());
+  EXPECT_TRUE(session_peer.live_conversion_pending_());
+  EXPECT_EQ(session_peer.pending_live_conversion_key_(), "とおもっ");
+  EXPECT_TRUE(command.output().live_conversion());
+  EXPECT_TRUE(command.output().live_conversion_pending());
+  EXPECT_PREEDIT("とおもっ", command);
+}
+
+TEST_F(SessionTest,
+       LiveConversionDoesNotKeepPendingOverlayForShortSokuonInterjection) {
+  MockEngine engine;
+  std::shared_ptr<MockConverter> converter = CreateEngineConverterMock(&engine);
+
+  Session session(engine);
+  InitSessionToPrecomposition(&session);
+
+  config::Config config;
+  config::ConfigHandler::GetDefaultConfig(&config);
+  config.set_use_live_conversion(true);
+  config.set_live_conversion_delay_msec(0);
+  session.SetConfig(config);
+
+  EXPECT_CALL(*converter, StartConversion(_, _))
+      .Times(::testing::AnyNumber())
+      .WillRepeatedly(Return(false));
+
+  commands::Command command;
+  InsertCharacterString("あっ", "aa", &session, &command);
+
+  EXPECT_EQ(session.context().composer().GetQueryForConversion(), "あっ");
+  EXPECT_EQ(session.context().state(), ImeContext::COMPOSITION);
+  EXPECT_FALSE(command.output().live_conversion());
+  EXPECT_FALSE(command.output().live_conversion_pending());
+  EXPECT_PREEDIT("あっ", command);
+}
+
+TEST_F(SessionTest, LiveConversionRecoversAfterTransientSokuonPrefix) {
+  MockEngine engine;
+  std::shared_ptr<MockConverter> converter = CreateEngineConverterMock(&engine);
+
+  Session session(engine);
+  SessionTestPeer session_peer(session);
+  InitSessionToPrecomposition(&session);
+
+  config::Config config;
+  config::ConfigHandler::GetDefaultConfig(&config);
+  config.set_use_live_conversion(true);
+  config.set_live_conversion_delay_msec(0);
+  session.SetConfig(config);
+
+  EXPECT_CALL(*converter, StartConversion(_, _))
+      .Times(::testing::AnyNumber())
+      .WillRepeatedly(Return(false));
+
+  commands::Command command;
+  InsertCharacterString("くさっ", "aaa", &session, &command);
+
+  EXPECT_EQ(session.context().composer().GetQueryForConversion(), "くさっ");
+  EXPECT_EQ(session.context().state(), ImeContext::COMPOSITION);
+  EXPECT_TRUE(command.output().live_conversion());
+  EXPECT_TRUE(command.output().live_conversion_pending());
+  EXPECT_PREEDIT("くさっ", command);
+
+  Mock::VerifyAndClearExpectations(converter.get());
+
+  Segments segments;
+  Segment* segment = segments.add_segment();
+  segment->set_key("くさって");
+  converter::Candidate* candidate = segment->add_candidate();
+  candidate->key = "くさって";
+  candidate->content_key = "くさって";
+  candidate->value = "腐って";
+
+  EXPECT_CALL(*converter, StartConversion(_, _))
+      .Times(AtLeast(1))
+      .WillRepeatedly(DoAll(SetArgPointee<1>(segments), Return(true)));
+
+  command.Clear();
+  InsertCharacterString("て", "a", &session, &command);
+
+  EXPECT_EQ(session.context().composer().GetQueryForConversion(), "くさって");
+  EXPECT_EQ(session.context().state(), ImeContext::CONVERSION);
+  EXPECT_TRUE(session_peer.live_conversion_active_());
+  EXPECT_TRUE(command.output().live_conversion());
+  EXPECT_FALSE(command.output().live_conversion_pending());
+  EXPECT_PREEDIT("腐って", command);
 }
 
 TEST_F(SessionTest, LiveConversionAttachesPassiveSuggestionCandidateWindow) {


### PR DESCRIPTION
## 概要

ライブ変換中に、促音便の入力途中形でルビウィンドウが消える問題を修正しました。

たとえば `おもっている`、`腐っている`、`と思っている` などを入力する際、途中の `おもっ` / `くさっ` / `とおもっ` の時点で live conversion が通常 composition 表示へ落ち、ルビ overlay が消えることがありました。

この PR では、これらの入力途中形を transient sokuon prefix として扱い、変換対象から一時的に skip される場合でも live conversion pending 表示を維持するようにしました。

## 変更内容

- 末尾が `っ` の促音便途中形のうち、`おも` / `くさ` / `さわ` / `かえ` などの限定した stem を pending live conversion 維持対象に追加
- `とおもっ`、`をさわっ` のように、短い機能語 prefix が同一 composition 内に付くケースも対象化
- `MaybeScheduleLiveConversion()` の skip 分岐で、対象の transient sokuon prefix では pending live conversion state と callback を作成
- `ApplyDelayedLiveConversion()` 側でも、callback 発火時に対象 prefix を cancel せず pending overlay を維持
- `あっ` / `おっ` / `やっっ` / `ふんっ` などの expressive / interjection 寄りの入力は従来通り対象外

## 確認

- `//session:session_test`
- 実機確認
  - `おもっている`
  - `腐っている`
  - `と思っている`
  - `を触っている`
  - `に帰っている`
  