### PR TITLE
Feature/zenz feedback rejection policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Windows 用のビルド済み MSI は [Releases](https://github.com/koyasi777/mo
 - Zenz 補正開始の最小文字数を設定画面から変更可能
 - Zenz 補正結果のローカル feedback learning を追加。設定画面から ON/OFF 可能
 - Zenz 補正結果と異なる値で確定した回数が指定回数に達した場合、同じ読み全体・同じ文脈クラス・同じ補正結果の Zenz 補正を自動ブロックする opt-in 設定を追加。自動ブロックは TSV に hard reject を固定保存せず、現在の ON/OFF と拒否回数しきい値から既存データを動的に再評価します。
+- 同じ読み全体・同じ文脈クラス・同じ補正結果で通常却下回数が採用回数を上回る場合は、auto-block 無効時でも Zenz feedback による優先候補・保存済み feedback による即時補正としては使わず、「却下数優勢」の中立状態として扱います。これは hard block ではなく、Zenz が新しく同じ補正を返すことや通常 Mozc 候補を削除することはありません。
 - Zenz feedback は、Zenz 補正結果が表示されただけでは保存されません。Enter や句読点・記号の単打確定などで表示中の Zenz 結果が明示的に確定された場合だけ、accepted feedback の候補として保留されます。
 - 保留された accepted feedback は、次の実テキスト入力まで Backspace / Escape / Revert / Undo などで取り消されなかった場合にローカル TSV へ保存。IMEOff / MakeSureIMEOff は取り消しではなく確定後のモード変更として扱う
 - Zenz 補正表示後に Space や候補移動など通常変換操作へ移った場合、その Zenz 候補は rejected feedback として扱う。ただし Space などの通常操作による rejected feedback は候補を殺す hard reject ではなく、順位調整用の弱い negative signal として扱う
@@ -655,6 +656,7 @@ Main features added in this fork
 - Allows configuring the minimum number of characters to start Zenz correction
 - Adds optional local feedback learning for Zenz correction results
 - Adds an opt-in auto-block setting for Zenz corrections repeatedly committed as a different value. Auto-blocking does not persist irreversible hard-reject rows; it dynamically re-evaluates existing feedback data from the current ON/OFF state and rejection-count threshold.
+- Stops reusing a Zenz feedback entry as a preferred candidate or live-correction fast path when ordinary rejected observations outnumber accepted observations for the same full reading, context class, and correction value. This is a neutral reject-count-dominant state, not a hard block, so it does not delete ordinary Mozc candidates or prevent newly produced Zenz corrections by itself.
 - Does not store Zenz feedback just because a Zenz correction was displayed. A visible Zenz result becomes pending accepted feedback only when the user explicitly commits it, such as with Enter or a direct-commit punctuation/symbol
 - Writes pending accepted feedback to the local TSV only if it is not canceled by Backspace, Escape, Revert, Undo, or similar correction actions before the next real text input. IMEOff / MakeSureIMEOff are treated as post-commit mode changes rather than cancellation
 - Treats a visible Zenz correction as rejected feedback when the user moves to normal conversion operations such as Space or candidate movement. Ordinary rejected feedback from these operations is used as a negative ranking signal rather than as a hard command to suppress the candidate

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Windows 用のビルド済み MSI は [Releases](https://github.com/koyasi777/mo
 - Zenz 補正開始までの遅延時間を設定画面から変更可能。デフォルトは 1000 ms
 - Zenz 補正開始の最小文字数を設定画面から変更可能
 - Zenz 補正結果のローカル feedback learning を追加。設定画面から ON/OFF 可能
+- Zenz 補正結果と異なる値で確定した回数が指定回数に達した場合、同じ読み全体・同じ文脈クラス・同じ補正結果の Zenz 補正を自動ブロックする opt-in 設定を追加。自動ブロックは TSV に hard reject を固定保存せず、現在の ON/OFF と拒否回数しきい値から既存データを動的に再評価します。
 - Zenz feedback は、Zenz 補正結果が表示されただけでは保存されません。Enter や句読点・記号の単打確定などで表示中の Zenz 結果が明示的に確定された場合だけ、accepted feedback の候補として保留されます。
 - 保留された accepted feedback は、次の実テキスト入力まで Backspace / Escape / Revert / Undo などで取り消されなかった場合にローカル TSV へ保存。IMEOff / MakeSureIMEOff は取り消しではなく確定後のモード変更として扱う
 - Zenz 補正表示後に Space や候補移動など通常変換操作へ移った場合、その Zenz 候補は rejected feedback として扱う。ただし Space などの通常操作による rejected feedback は候補を殺す hard reject ではなく、順位調整用の弱い negative signal として扱う
@@ -653,6 +654,7 @@ Main features added in this fork
 - Allows configuring the Zenz correction debounce delay from the config dialog. The default is 1000 ms
 - Allows configuring the minimum number of characters to start Zenz correction
 - Adds optional local feedback learning for Zenz correction results
+- Adds an opt-in auto-block setting for Zenz corrections repeatedly committed as a different value. Auto-blocking does not persist irreversible hard-reject rows; it dynamically re-evaluates existing feedback data from the current ON/OFF state and rejection-count threshold.
 - Does not store Zenz feedback just because a Zenz correction was displayed. A visible Zenz result becomes pending accepted feedback only when the user explicitly commits it, such as with Enter or a direct-commit punctuation/symbol
 - Writes pending accepted feedback to the local TSV only if it is not canceled by Backspace, Escape, Revert, Undo, or similar correction actions before the next real text input. IMEOff / MakeSureIMEOff are treated as post-commit mode changes rather than cancellation
 - Treats a visible Zenz correction as rejected feedback when the user moves to normal conversion operations such as Space or candidate movement. Ordinary rejected feedback from these operations is used as a negative ranking signal rather than as a hard command to suppress the candidate

--- a/src/gui/config_dialog/config_dialog.cc
+++ b/src/gui/config_dialog/config_dialog.cc
@@ -351,6 +351,11 @@ ConfigDialog::ConfigDialog()
   zenzLiveCorrectionRightContextLengthSpinBox->setSpecialValueText(
       QString::fromUtf8("使わない"));
 
+  zenzFeedbackAutoBlockRejectThresholdSpinBox->setRange(1, 999);
+  zenzFeedbackAutoBlockRejectThresholdSpinBox->setSingleStep(1);
+  zenzFeedbackAutoBlockRejectThresholdSpinBox->setSuffix(
+      QString::fromUtf8(" 回"));
+
   punctuationsSettingComboBox->addItem(QString::fromUtf8("、。"));
   punctuationsSettingComboBox->addItem(QString::fromUtf8("，．"));
   punctuationsSettingComboBox->addItem(QString::fromUtf8("、．"));
@@ -466,6 +471,12 @@ ConfigDialog::ConfigDialog()
   QObject::connect(zenzLiveCorrectionRightContextCheckBox,
                    SIGNAL(stateChanged(int)), this,
                    SLOT(SelectZenzRightContextSetting(int)));
+  QObject::connect(zenzFeedbackLearningCheckBox,
+                   SIGNAL(stateChanged(int)), this,
+                   SLOT(SelectZenzFeedbackLearningSetting(int)));
+  QObject::connect(zenzFeedbackAutoBlockCheckBox,
+                   SIGNAL(stateChanged(int)), this,
+                   SLOT(SelectZenzFeedbackLearningSetting(int)));
   QObject::connect(useAutoConversion, SIGNAL(stateChanged(int)), this,
                    SLOT(SelectAutoConversionSetting(int)));
   QObject::connect(useDirectCommit, SIGNAL(stateChanged(int)), this,
@@ -849,6 +860,9 @@ constexpr uint32_t kMinZenzLiveCorrectionMinKeyLength = 2;
 constexpr uint32_t kMaxZenzLiveCorrectionMinKeyLength = 20;
 constexpr uint32_t kDefaultZenzLiveCorrectionRightContextLength = 10;
 constexpr uint32_t kMaxZenzLiveCorrectionRightContextLength = 128;
+constexpr uint32_t kDefaultZenzAutoBlockRejectThreshold = 3;
+constexpr uint32_t kMinZenzAutoBlockRejectThreshold = 1;
+constexpr uint32_t kMaxZenzAutoBlockRejectThreshold = 999;
 
 constexpr uint32_t kDefaultInputPreeditTextColor = 0xff5000;
 constexpr uint32_t kDefaultInputPreeditBackgroundColor = 0xffffcc;
@@ -1119,9 +1133,12 @@ QString FeedbackReasonLabel(absl::string_view reason) {
     return QString::fromUtf8("優先");
   }
   if (reason == "feedback_hard_rejected") {
-    return QString::fromUtf8("ブロック中");
+    return QString::fromUtf8("手動ブロック中");
   }
-  if (reason == "feedback_rejected") {
+  if (reason == "feedback_auto_blocked") {
+    return QString::fromUtf8("自動ブロック中");
+  }
+  if (reason == "feedback_rejected" || reason == "feedback_downgraded") {
     return QString::fromUtf8("却下優勢");
   }
   return QString::fromUtf8("中立");
@@ -1313,12 +1330,19 @@ std::wstring BuildRestoreDefaultImeScript() {
 }
 #endif  // _WIN32
 
-void ShowZenzFeedbackManagementDialog(QWidget* parent) {
+void ShowZenzFeedbackManagementDialog(QWidget* parent,
+                                      const config::Config& current_config) {
   QDialog dialog(parent);
   dialog.setWindowTitle(QString::fromUtf8("Zenz 学習データの管理"));
   dialog.resize(760, 440);
 
   session::ZenzFeedbackStore store;
+
+  session::ZenzFeedbackAutoBlockPolicy auto_block_policy;
+  auto_block_policy.enabled =
+      current_config.use_zenz_auto_block_rejected_correction();
+  auto_block_policy.reject_threshold =
+      static_cast<int>(current_config.zenz_auto_block_reject_threshold());
 
   QVBoxLayout* root_layout = new QVBoxLayout(&dialog);
 
@@ -1464,7 +1488,7 @@ void ShowZenzFeedbackManagementDialog(QWidget* parent) {
   auto reload_table = [&]() {
     const QString filter = search_edit->text();
     const std::vector<session::ZenzFeedbackEntry> entries =
-        store.ListEntries();
+        store.ListEntries(auto_block_policy);
 
     table->setRowCount(0);
 
@@ -1501,10 +1525,16 @@ void ShowZenzFeedbackManagementDialog(QWidget* parent) {
 
     table->resizeColumnsToContents();
 
+    const QString auto_block_status =
+        auto_block_policy.enabled
+            ? QString::fromUtf8(" / 自動ブロックしきい値 %1 回")
+                  .arg(auto_block_policy.reject_threshold)
+            : QString::fromUtf8(" / 自動ブロック OFF");
     status_label->setText(
-        QString::fromUtf8("表示 %1 件 / 全 %2 件")
+        QString::fromUtf8("表示 %1 件 / 全 %2 件%3")
             .arg(visible_count)
-            .arg(static_cast<int>(entries.size())));
+            .arg(static_cast<int>(entries.size()))
+            .arg(auto_block_status));
 
     export_button->setEnabled(!entries.empty());
     clear_button->setEnabled(!entries.empty());
@@ -2786,6 +2816,20 @@ void ConfigDialog::ConvertFromProto(const config::Config &config) {
 
   SET_CHECKBOX(zenzFeedbackLearningCheckBox, use_zenz_feedback_learning);
 
+  SET_CHECKBOX(zenzFeedbackAutoBlockCheckBox,
+               use_zenz_auto_block_rejected_correction);
+  const uint32_t zenz_auto_block_reject_threshold =
+      config.has_zenz_auto_block_reject_threshold()
+          ? config.zenz_auto_block_reject_threshold()
+          : kDefaultZenzAutoBlockRejectThreshold;
+  zenzFeedbackAutoBlockRejectThresholdSpinBox->setValue(
+      static_cast<int>(
+          std::clamp(zenz_auto_block_reject_threshold,
+                     kMinZenzAutoBlockRejectThreshold,
+                     kMaxZenzAutoBlockRejectThreshold)));
+  SelectZenzFeedbackLearningSetting(
+      static_cast<int>(zenzFeedbackLearningCheckBox->isChecked()));
+
   SET_CHECKBOX(useAutoConversion, use_auto_conversion);
   kutenCheckBox->setChecked(config.auto_conversion_key() &
                             config::Config::AUTO_CONVERSION_KUTEN);
@@ -2981,6 +3025,11 @@ void ConfigDialog::ConvertToProto(config::Config *config) const {
           zenzLiveCorrectionRightContextLengthSpinBox->value()));
 
   GET_CHECKBOX(zenzFeedbackLearningCheckBox, use_zenz_feedback_learning);
+  GET_CHECKBOX(zenzFeedbackAutoBlockCheckBox,
+               use_zenz_auto_block_rejected_correction);
+  config->set_zenz_auto_block_reject_threshold(
+      static_cast<uint32_t>(
+          zenzFeedbackAutoBlockRejectThresholdSpinBox->value()));
 
   GET_CHECKBOX(useAutoConversion, use_auto_conversion);
   GET_CHECKBOX(useDirectCommit, use_direct_commit);
@@ -3690,7 +3739,7 @@ void ConfigDialog::ClearUnusedUserPrediction() {
 }
 
 void ConfigDialog::EditZenzFeedback() {
-  ShowZenzFeedbackManagementDialog(this);
+  ShowZenzFeedbackManagementDialog(this, base_config_);
 }
 
 void ConfigDialog::EditUserDictionary() {
@@ -3774,6 +3823,22 @@ void ConfigDialog::SelectZenzLiveCorrectionSetting(int state) {
                     zenzLiveCorrectionRightContextCheckBox->isChecked())
               : 0);
   zenzFeedbackLearningCheckBox->setEnabled(enabled);
+  SelectZenzFeedbackLearningSetting(
+      enabled ? static_cast<int>(zenzFeedbackLearningCheckBox->isChecked()) : 0);
+}
+
+void ConfigDialog::SelectZenzFeedbackLearningSetting(int state) {
+  const bool enabled =
+      liveConversionCheckBox->isChecked() &&
+      zenzLiveCorrectionCheckBox->isChecked() &&
+      static_cast<bool>(state);
+
+  zenzFeedbackAutoBlockCheckBox->setEnabled(enabled);
+
+  const bool auto_block_enabled =
+      enabled && zenzFeedbackAutoBlockCheckBox->isChecked();
+  zenzFeedbackAutoBlockRejectThresholdLabel->setEnabled(auto_block_enabled);
+  zenzFeedbackAutoBlockRejectThresholdSpinBox->setEnabled(auto_block_enabled);
 }
 
 void ConfigDialog::SelectZenzRightContextSetting(int state) {

--- a/src/gui/config_dialog/config_dialog.cc
+++ b/src/gui/config_dialog/config_dialog.cc
@@ -1130,7 +1130,7 @@ QString ToQString(absl::string_view s) {
 
 QString FeedbackReasonLabel(absl::string_view reason) {
   if (reason == "feedback_preferred") {
-    return QString::fromUtf8("優先");
+    return QString::fromUtf8("優先スコアあり");
   }
   if (reason == "feedback_hard_rejected") {
     return QString::fromUtf8("手動ブロック中");
@@ -1138,8 +1138,11 @@ QString FeedbackReasonLabel(absl::string_view reason) {
   if (reason == "feedback_auto_blocked") {
     return QString::fromUtf8("自動ブロック中");
   }
+  if (reason == "feedback_reject_count_dominant") {
+    return QString::fromUtf8("却下数優勢");
+  }
   if (reason == "feedback_rejected" || reason == "feedback_downgraded") {
-    return QString::fromUtf8("却下優勢");
+    return QString::fromUtf8("却下スコアあり");
   }
   return QString::fromUtf8("中立");
 }
@@ -1363,7 +1366,7 @@ void ShowZenzFeedbackManagementDialog(QWidget* parent,
       new QPushButton(QString::fromUtf8("詳しく..."), &dialog);
   details_button->setFixedWidth(84);
   details_button->setToolTip(QString::fromUtf8(
-      "Zenz 学習データと通常の変換履歴の違いを表示します"));
+      "状態ラベル、Zenz 学習の記録条件、通常の変換履歴との違いを表示します"));
 
   description_layout->addWidget(description_label, 1);
   description_layout->addWidget(details_button, 0, Qt::AlignTop);
@@ -1374,18 +1377,69 @@ void ShowZenzFeedbackManagementDialog(QWidget* parent,
                      ShowJapaneseInformation(
                          &dialog, dialog.windowTitle(),
                          QString::fromUtf8(
-                             "この画面で扱うのは、Zenz が補正した入力全体の読みと"
-                             "補正後の候補の記録です。\n\n"
-                             "Zenz の結果を確定した場合、条件によっては通常の"
-                             "変換履歴にも反映されます。また、安全に判断できる場合は、"
-                             "直前の通常 Mozc ライブ変換文節列へ逆投影し、"
-                             "文節列全体を通常変換履歴に近い形で反映します。"
-                             "このとき、Zenz が実際に直した文節だけを"
+                             "【この画面で扱うデータ】\n"
+                             "この画面で扱うのは、Zenz 補正が実際に表示・反映されたときの"
+                             "読み全体、補正後の候補、文脈クラス、採用/却下の記録です。"
+                             "通常変換だけを操作した履歴は、この Zenz 学習データの"
+                             "採用数・却下数・スコアには入りません。\n\n"
+                             "Zenz 学習データは full-sequence 単位です。"
+                             "単語や文節ごとの学習ではなく、同じ読み全体、同じ文脈クラス、"
+                             "同じ補正結果の組み合わせごとに集計します。"
+                             "左文脈そのものは保存せず、empty / japanese_only / "
+                             "mixed_japanese_ascii / sensitive_like などの"
+                             "非可逆な文脈クラスだけを保存します。\n\n"
+                             "【いつ採用として記録されるか】\n"
+                             "Zenz 補正が表示され、その補正結果を Enter や"
+                             "句読点・記号の単打確定などでそのまま確定した場合、"
+                             "採用候補として一時保留されます。"
+                             "その後、次の実テキスト入力までに Backspace / Escape / "
+                             "Revert / Undo などで取り消されなかった場合だけ、"
+                             "採用として保存されます。"
+                             "Zenz 補正が表示されただけでは保存されません。\n\n"
+                             "【いつ却下として記録されるか】\n"
+                             "Zenz 補正が表示された後に Space や候補移動などで"
+                             "通常変換へ戻り、最終的に Zenz 補正とは異なる値で"
+                             "確定された場合、その Zenz 補正は却下として保存されます。"
+                             "これは通常候補を削除する命令ではなく、次回以降の"
+                             "候補順位や保存済み Zenz feedback による即時補正を調整するための"
+                             "弱いマイナス信号です。\n\n"
+                             "【記録されない操作】\n"
+                             "Zenz 補正が走っていないときの通常変換、通常候補の選択、"
+                             "通常変換の確定は、この画面の Zenz 学習スコアには影響しません。"
+                             "また、Zenz が通常 Mozc と同じ値を返した場合、"
+                             "出力検証や採用ポリシーで不採用になった場合、"
+                             "password / privacy gate で止められた場合も、"
+                             "表示済み Zenz 補正としては扱われません。\n\n"
+                             "【状態ラベルの意味】\n"
+                             "優先スコアあり: 採用・却下を重み付きで見た結果、"
+                             "この Zenz 補正を優先候補や保存済み feedback による即時補正として"
+                             "再利用できる状態です。\n"
+                             "却下スコアあり: 却下履歴により順位を下げる信号があります。"
+                             "ただし、手動ブロックや自動ブロックではありません。\n"
+                             "却下数優勢: 同じ読み全体・同じ文脈クラス・同じ補正結果で、"
+                             "通常却下回数が採用回数を上回っています。"
+                             "この場合、auto-block が OFF でも、Zenz feedback による"
+                             "優先候補や保存済み feedback による即時補正としては使いません。"
+                             "ただし hard block ではないため、Zenz が新しく同じ補正を"
+                             "返すこと自体や、通常 Mozc 候補を消すことはありません。\n"
+                             "自動ブロック中: auto-block が ON で、通常却下回数が"
+                             "設定したしきい値に達しています。TSV に hard reject を"
+                             "固定保存するのではなく、現在の ON/OFF としきい値から"
+                             "動的に判定します。\n"
+                             "手動ブロック中: この画面で明示的にブロックされた状態です。"
+                             "解除したい場合は、該当エントリを削除して必要に応じて"
+                             "再学習してください。\n"
+                             "中立: 優先にもブロックにも使うだけの有効な信号がない状態です。\n\n"
+                             "【通常の変換履歴との違い】\n"
+                             "Zenz の結果を確定した場合、条件によっては通常の変換履歴にも"
+                             "反映されます。また、安全に判断できる場合は、直前の通常 Mozc "
+                             "ライブ変換文節列へ逆投影し、文節列全体を通常変換履歴に近い形で"
+                             "反映します。このとき、Zenz が実際に直した文節だけを"
                              "強い選択履歴として扱います。\n\n"
                              "そのため、この画面で Zenz 学習データを削除しても、"
                              "通常の変換履歴にすでに反映された内容は削除されません。"
-                             "通常の変換履歴を消したい場合は、設定画面の辞書タブ内にある学習履歴のクリアを"
-                             "使用してください。"));
+                             "通常の変換履歴を消したい場合は、設定画面の辞書タブ内にある"
+                             "学習履歴のクリアを使用してください。"));
                    });
 
   QHBoxLayout* search_layout = new QHBoxLayout;
@@ -1405,7 +1459,7 @@ void ShowZenzFeedbackManagementDialog(QWidget* parent,
                                    << QString::fromUtf8("文脈クラス")
                                    << QString::fromUtf8("採用")
                                    << QString::fromUtf8("却下")
-                                   << QString::fromUtf8("判定"));
+                                   << QString::fromUtf8("状態"));
   table->setSelectionBehavior(QAbstractItemView::SelectRows);
   table->setSelectionMode(QAbstractItemView::SingleSelection);
   table->setEditTriggers(QAbstractItemView::NoEditTriggers);

--- a/src/gui/config_dialog/config_dialog.h
+++ b/src/gui/config_dialog/config_dialog.h
@@ -76,6 +76,7 @@ class ConfigDialog : public QDialog, private Ui::ConfigDialog {
   virtual void SelectLiveConversionSetting(int state);
   virtual void SelectZenzLiveCorrectionSetting(int state);
   virtual void SelectZenzRightContextSetting(int state);
+  virtual void SelectZenzFeedbackLearningSetting(int state);
   virtual void SelectAutoConversionSetting(int state);
   virtual void SelectDirectCommitSetting(int state);
   virtual void SelectSuggestionSetting(int state);

--- a/src/gui/config_dialog/config_dialog.ui
+++ b/src/gui/config_dialog/config_dialog.ui
@@ -1515,14 +1515,58 @@
           </widget>
          </item>
 
-         <item row="28" column="0" colspan="3">
+         <item row="28" column="0" colspan="8">
+          <widget class="QCheckBox" name="zenzFeedbackAutoBlockCheckBox">
+           <property name="toolTip">
+            <string>Zenz 補正を通常変換などで別の文字列に確定した回数が指定回数に達した場合、同じ読み・同じ文脈クラス・同じ補正結果を次回以降の Zenz 補正として表示しないようにします。通常の Mozc 候補から削除する機能ではありません。</string>
+           </property>
+           <property name="text">
+            <string>Zenz 補正と異なる結果で確定した場合、その補正を自動ブロックする</string>
+           </property>
+          </widget>
+         </item>
+
+         <item row="29" column="0" colspan="3">
+          <widget class="QLabel" name="zenzFeedbackAutoBlockRejectThresholdLabel">
+           <property name="toolTip">
+            <string>同じ Zenz 補正を何回異なる結果で確定したら自動ブロックするかを指定します。設定変更は既存の Zenz 学習データにも動的に反映されます。</string>
+           </property>
+           <property name="text">
+            <string>自動ブロックまでの拒否回数</string>
+           </property>
+          </widget>
+         </item>
+         <item row="29" column="3" colspan="5">
+          <widget class="QSpinBox" name="zenzFeedbackAutoBlockRejectThresholdSpinBox">
+           <property name="toolTip">
+            <string>同じ Zenz 補正を何回異なる結果で確定したら自動ブロックするかを指定します。</string>
+           </property>
+           <property name="minimum">
+            <number>1</number>
+           </property>
+           <property name="maximum">
+            <number>999</number>
+           </property>
+           <property name="singleStep">
+            <number>1</number>
+           </property>
+           <property name="value">
+            <number>3</number>
+           </property>
+           <property name="suffix">
+            <string> 回</string>
+           </property>
+          </widget>
+         </item>
+
+         <item row="30" column="0" colspan="3">
           <widget class="QLabel" name="zenzFeedbackDataLabel">
            <property name="text">
             <string>Zenz 学習データ</string>
            </property>
           </widget>
          </item>
-         <item row="28" column="3" colspan="5">
+         <item row="30" column="3" colspan="5">
           <widget class="QPushButton" name="editZenzFeedbackButton">
            <property name="toolTip">
             <string>保存された Zenz 学習データを確認、検索、インポート、エクスポート、削除します。通常の変換履歴に反映済みの学習は、この画面の削除対象には含まれません。</string>
@@ -2792,6 +2836,8 @@
   <tabstop>zenzLiveCorrectionRightContextCheckBox</tabstop>
   <tabstop>zenzLiveCorrectionRightContextLengthSpinBox</tabstop>
   <tabstop>zenzFeedbackLearningCheckBox</tabstop>
+  <tabstop>zenzFeedbackAutoBlockCheckBox</tabstop>
+  <tabstop>zenzFeedbackAutoBlockRejectThresholdSpinBox</tabstop>
   <tabstop>editZenzFeedbackButton</tabstop>
   <tabstop>characterFormEditor</tabstop>
   <tabstop>inputPreeditTextColorCheckBox</tabstop>

--- a/src/protocol/config.proto
+++ b/src/protocol/config.proto
@@ -370,6 +370,17 @@ message Config {
   // Raw left context is not stored.
   optional bool use_zenz_feedback_learning = 1011 [default = false];
 
+  // When enabled, repeated divergent commits of the same full-sequence Zenz
+  // correction dynamically suppress that correction as an effective block.
+  // This does not write an irreversible hard-reject record; changing this
+  // setting or the threshold re-evaluates existing feedback data.
+  optional bool use_zenz_auto_block_rejected_correction = 1018
+      [default = false];
+
+  // Number of ordinary rejected observations required before the auto-block
+  // policy suppresses the same key/context/value correction.
+  optional uint32 zenz_auto_block_reject_threshold = 1019 [default = 3];
+
   // Zenzai v3/v3.2 condition fields. Empty values are omitted from the prompt.
   // These are not chat prompts; they are mapped to zenz special-token fields:
   // U+EE03 profile, U+EE04 topic, U+EE05 style, U+EE06 settings.

--- a/src/rewriter/zenz_feedback_candidate_rewriter.cc
+++ b/src/rewriter/zenz_feedback_candidate_rewriter.cc
@@ -173,6 +173,15 @@ void FillSyntheticCandidate(const converter::Candidate& base_candidate,
   candidate->display_value.clear();
 }
 
+session::ZenzFeedbackAutoBlockPolicy GetZenzFeedbackAutoBlockPolicy(
+    const config::Config& config) {
+  session::ZenzFeedbackAutoBlockPolicy policy;
+  policy.enabled = config.use_zenz_auto_block_rejected_correction();
+  policy.reject_threshold =
+      static_cast<int>(config.zenz_auto_block_reject_threshold());
+  return policy;
+}
+
 }  // namespace
 
 int ZenzFeedbackCandidateRewriter::capability(
@@ -234,7 +243,9 @@ bool ZenzFeedbackCandidateRewriter::Rewrite(
 
   session::ZenzFeedbackStore store;
   const std::vector<session::ZenzFeedbackCandidate> ranked_candidates =
-      store.GetRankedCandidates(full_key, kContextClass);
+      store.GetRankedCandidates(
+          full_key, kContextClass,
+          GetZenzFeedbackAutoBlockPolicy(request.config()));
 
   if (ranked_candidates.empty()) {
     return false;

--- a/src/rewriter/zenz_feedback_candidate_rewriter_test.cc
+++ b/src/rewriter/zenz_feedback_candidate_rewriter_test.cc
@@ -414,6 +414,8 @@ TEST(ZenzFeedbackCandidateRewriterTest,
 
   session::ZenzFeedbackStore store;
   store.RecordAccepted("かれはてんてきです", "empty", "彼は天敵です");
+  store.RecordAccepted("かれはてんてきです", "empty", "彼は天敵です");
+  store.RecordAccepted("かれはてんてきです", "empty", "彼は天敵です");
   store.RecordRejected("かれはてんてきです", "empty", "彼は天敵です",
                        "space_revert_zenz_to_mozc");
   store.RecordRejected("かれはてんてきです", "empty", "彼は天敵です",
@@ -440,6 +442,34 @@ TEST(ZenzFeedbackCandidateRewriterTest,
           .SetRequestType(ConversionRequest::CONVERSION)
           .SetKey("かれはてんてきです")
           .Build();
+
+  ZenzFeedbackCandidateRewriter rewriter;
+  EXPECT_FALSE(rewriter.Rewrite(request, &segments));
+
+  ASSERT_EQ(segments.conversion_segments_size(), 1);
+  const Segment& segment = segments.conversion_segment(0);
+  ASSERT_EQ(segment.candidates_size(), 1);
+  EXPECT_EQ(segment.candidate(0).value, "彼は点滴です");
+  EXPECT_TRUE(segment.candidate(0).attributes &
+              converter::Attribute::BEST_CANDIDATE);
+}
+
+TEST(ZenzFeedbackCandidateRewriterTest,
+     DoesNotInsertOrPromoteRejectDominantFeedbackCandidate) {
+  ScopedUserProfileForZenzFeedbackCandidateRewriterTest profile;
+  ASSERT_TRUE(profile.ok());
+
+  session::ZenzFeedbackStore store;
+  store.RecordAccepted("かれはてんてきです", "empty", "彼は天敵です");
+  store.RecordRejected("かれはてんてきです", "empty", "彼は天敵です",
+                       "space_revert_zenz_to_mozc");
+  store.RecordRejected("かれはてんてきです", "empty", "彼は天敵です",
+                       "space_revert_zenz_to_mozc");
+
+  Segments segments;
+  AddSegment("かれはてんてきです", "彼は点滴です", &segments);
+
+  const ConversionRequest request = CreateZenzFeedbackConversionRequest();
 
   ZenzFeedbackCandidateRewriter rewriter;
   EXPECT_FALSE(rewriter.Rewrite(request, &segments));

--- a/src/rewriter/zenz_feedback_candidate_rewriter_test.cc
+++ b/src/rewriter/zenz_feedback_candidate_rewriter_test.cc
@@ -408,6 +408,51 @@ TEST(ZenzFeedbackCandidateRewriterTest,
 }
 
 TEST(ZenzFeedbackCandidateRewriterTest,
+     DoesNotInsertOrPromoteAutoBlockedFeedbackCandidate) {
+  ScopedUserProfileForZenzFeedbackCandidateRewriterTest profile;
+  ASSERT_TRUE(profile.ok());
+
+  session::ZenzFeedbackStore store;
+  store.RecordAccepted("かれはてんてきです", "empty", "彼は天敵です");
+  store.RecordRejected("かれはてんてきです", "empty", "彼は天敵です",
+                       "space_revert_zenz_to_mozc");
+  store.RecordRejected("かれはてんてきです", "empty", "彼は天敵です",
+                       "space_revert_zenz_to_mozc");
+
+  Segments segments;
+  AddSegment("かれはてんてきです", "彼は点滴です", &segments);
+
+  config::Config config;
+  config.set_use_zenz_feedback_learning(true);
+  config.set_history_learning_level(config::Config::DEFAULT_HISTORY);
+  config.set_use_zenz_auto_block_rejected_correction(true);
+  config.set_zenz_auto_block_reject_threshold(2);
+
+  ConversionRequest::Options options;
+  options.request_type = ConversionRequest::CONVERSION;
+  options.enable_user_history_for_conversion = true;
+  options.incognito_mode = false;
+
+  const ConversionRequest request =
+      ConversionRequestBuilder()
+          .SetConfig(config)
+          .SetOptions(std::move(options))
+          .SetRequestType(ConversionRequest::CONVERSION)
+          .SetKey("かれはてんてきです")
+          .Build();
+
+  ZenzFeedbackCandidateRewriter rewriter;
+  EXPECT_FALSE(rewriter.Rewrite(request, &segments));
+
+  ASSERT_EQ(segments.conversion_segments_size(), 1);
+  const Segment& segment = segments.conversion_segment(0);
+  ASSERT_EQ(segment.candidates_size(), 1);
+  EXPECT_EQ(segment.candidate(0).value, "彼は点滴です");
+  EXPECT_TRUE(segment.candidate(0).attributes &
+              converter::Attribute::BEST_CANDIDATE);
+}
+
+TEST(ZenzFeedbackCandidateRewriterTest,
      DoesNotDuplicateFeedbackWhenMozcTopAlreadyMatches) {
   ScopedUserProfileForZenzFeedbackCandidateRewriterTest profile;
   ASSERT_TRUE(profile.ok());

--- a/src/session/session.cc
+++ b/src/session/session.cc
@@ -2066,6 +2066,15 @@ bool UseZenzFeedbackLearning(const config::Config& config) {
   return config.use_zenz_feedback_learning();
 }
 
+ZenzFeedbackAutoBlockPolicy GetZenzFeedbackAutoBlockPolicy(
+    const config::Config& config) {
+  ZenzFeedbackAutoBlockPolicy policy;
+  policy.enabled = config.use_zenz_auto_block_rejected_correction();
+  policy.reject_threshold =
+      static_cast<int>(config.zenz_auto_block_reject_threshold());
+  return policy;
+}
+
 bool IsExplicitZenzHardRejectReason(absl::string_view reason) {
   return reason == "hard_reject" ||
          reason == "user_hard_reject" ||
@@ -5941,7 +5950,8 @@ bool Session::MaybeApplyZenzFeedbackLiveCorrection(
 
   const std::vector<ZenzFeedbackCandidate> feedback_candidates =
       zenz_feedback_store_.GetAcceptedCandidates(
-          live_conversion_key_, context_class);
+          live_conversion_key_, context_class,
+          GetZenzFeedbackAutoBlockPolicy(config));
 
   if (feedback_candidates.empty()) {
     return false;
@@ -6810,7 +6820,8 @@ bool Session::ApplyZenzLiveCorrectionResult(
   if (UseZenzFeedbackLearning(config)) {
     const ZenzFeedbackDecision feedback_decision =
         zenz_feedback_store_.Decide(
-            pending_zenz_live_.key, context_class, zenz_value);
+            pending_zenz_live_.key, context_class, zenz_value,
+            GetZenzFeedbackAutoBlockPolicy(config));
 
     feedback_reason = feedback_decision.reason;
 

--- a/src/session/session_test.cc
+++ b/src/session/session_test.cc
@@ -1801,6 +1801,68 @@ TEST_F(SessionTest,
   EXPECT_EQ(session_peer.zenz_live_context_class_(), "empty");
 }
 
+TEST_F(SessionTest, ZenzFeedbackFastPathSkipsAutoBlockedCandidate) {
+  MockEngine engine;
+  std::shared_ptr<MockConverter> converter = CreateEngineConverterMock(&engine);
+
+  ScopedUserProfileForZenzFeedbackSessionTest profile;
+  ASSERT_TRUE(profile.ok());
+
+  Session session(engine);
+  SessionTestPeer session_peer(session);
+  InitSessionToPrecomposition(&session);
+
+  config::Config config;
+  config::ConfigHandler::GetDefaultConfig(&config);
+  config.set_use_live_conversion(true);
+  config.set_use_zenz_live_correction(true);
+  config.set_use_zenz_feedback_learning(true);
+  config.set_use_zenz_synthetic_candidate(true);
+  config.set_zenz_live_correction_min_key_length(2);
+  config.set_use_zenz_auto_block_rejected_correction(true);
+  config.set_zenz_auto_block_reject_threshold(2);
+  session.SetConfig(config);
+
+  session_peer.zenz_feedback_store_().RecordAccepted(
+      "かれはてんてきです",
+      "japanese_only",
+      "彼は天敵です");
+  session_peer.zenz_feedback_store_().RecordRejected(
+      "かれはてんてきです",
+      "empty",
+      "彼は天敵です",
+      "space_revert_zenz_to_mozc");
+  session_peer.zenz_feedback_store_().RecordRejected(
+      "かれはてんてきです",
+      "empty",
+      "彼は天敵です",
+      "space_revert_zenz_to_mozc");
+
+  session_peer.context_()->set_state(ImeContext::CONVERSION);
+  session_peer.live_conversion_active_() = true;
+  session_peer.live_conversion_key_() = "かれはてんてきです";
+  session_peer.live_conversion_value_() = "彼は点滴です";
+
+  commands::Preedit& live_preedit =
+      session_peer.live_conversion_preedit_output_();
+  live_preedit.Clear();
+
+  commands::Preedit::Segment* segment = live_preedit.add_segment();
+  segment->set_key("かれは");
+  segment->set_value("彼は");
+  segment->set_value_length(Util::CharsLen("彼は"));
+
+  segment = live_preedit.add_segment();
+  segment->set_key("てんてきです");
+  segment->set_value("点滴です");
+  segment->set_value_length(Util::CharsLen("点滴です"));
+
+  commands::Command command;
+  EXPECT_FALSE(session_peer.MaybeApplyZenzFeedbackLiveCorrection(&command));
+  EXPECT_TRUE(session_peer.zenz_live_key_().empty());
+  EXPECT_TRUE(session_peer.zenz_live_value_().empty());
+}
+
 TEST_F(SessionTest,
        SpaceWhileZenzLiveCorrectionVisibleRevertsToMozcNormalConversion) {
   MockEngine engine;

--- a/src/session/session_test.cc
+++ b/src/session/session_test.cc
@@ -1863,6 +1863,68 @@ TEST_F(SessionTest, ZenzFeedbackFastPathSkipsAutoBlockedCandidate) {
   EXPECT_TRUE(session_peer.zenz_live_value_().empty());
 }
 
+TEST_F(SessionTest, ZenzFeedbackFastPathSkipsRejectDominantCandidate) {
+  MockEngine engine;
+  std::shared_ptr<MockConverter> converter = CreateEngineConverterMock(&engine);
+
+  ScopedUserProfileForZenzFeedbackSessionTest profile;
+  ASSERT_TRUE(profile.ok());
+
+  Session session(engine);
+  SessionTestPeer session_peer(session);
+  InitSessionToPrecomposition(&session);
+
+  config::Config config;
+  config::ConfigHandler::GetDefaultConfig(&config);
+  config.set_use_live_conversion(true);
+  config.set_use_zenz_live_correction(true);
+  config.set_use_zenz_feedback_learning(true);
+  config.set_use_zenz_synthetic_candidate(true);
+  config.set_zenz_live_correction_min_key_length(2);
+  config.set_use_zenz_auto_block_rejected_correction(false);
+  config.set_zenz_auto_block_reject_threshold(2);
+  session.SetConfig(config);
+
+  session_peer.zenz_feedback_store_().RecordAccepted(
+      "かれはてんてきです",
+      "japanese_only",
+      "彼は天敵です");
+  session_peer.zenz_feedback_store_().RecordRejected(
+      "かれはてんてきです",
+      "empty",
+      "彼は天敵です",
+      "space_revert_zenz_to_mozc");
+  session_peer.zenz_feedback_store_().RecordRejected(
+      "かれはてんてきです",
+      "empty",
+      "彼は天敵です",
+      "space_revert_zenz_to_mozc");
+
+  session_peer.context_()->set_state(ImeContext::CONVERSION);
+  session_peer.live_conversion_active_() = true;
+  session_peer.live_conversion_key_() = "かれはてんてきです";
+  session_peer.live_conversion_value_() = "彼は点滴です";
+
+  commands::Preedit& live_preedit =
+      session_peer.live_conversion_preedit_output_();
+  live_preedit.Clear();
+
+  commands::Preedit::Segment* segment = live_preedit.add_segment();
+  segment->set_key("かれは");
+  segment->set_value("彼は");
+  segment->set_value_length(Util::CharsLen("彼は"));
+
+  segment = live_preedit.add_segment();
+  segment->set_key("てんてきです");
+  segment->set_value("点滴です");
+  segment->set_value_length(Util::CharsLen("点滴です"));
+
+  commands::Command command;
+  EXPECT_FALSE(session_peer.MaybeApplyZenzFeedbackLiveCorrection(&command));
+  EXPECT_TRUE(session_peer.zenz_live_key_().empty());
+  EXPECT_TRUE(session_peer.zenz_live_value_().empty());
+}
+
 TEST_F(SessionTest,
        SpaceWhileZenzLiveCorrectionVisibleRevertsToMozcNormalConversion) {
   MockEngine engine;

--- a/src/session/zenz_feedback_store.cc
+++ b/src/session/zenz_feedback_store.cc
@@ -577,6 +577,27 @@ bool IsAutoBlockedByPolicy(
          c.auto_block_rejected >= policy.reject_threshold;
 }
 
+bool IsRejectCountDominant(const Counts& c) {
+  return c.auto_block_rejected > c.accepted;
+}
+
+void ApplyRejectDominanceDecision(const Counts& exact_counts,
+                                  ZenzFeedbackDecision* decision) {
+  if (decision == nullptr || decision->hard_rejected ||
+      decision->auto_blocked ||
+      decision->action != ZenzFeedbackAction::kPrefer) {
+    return;
+  }
+
+  decision->auto_block_reject_count = exact_counts.auto_block_rejected;
+  if (!IsRejectCountDominant(exact_counts)) {
+    return;
+  }
+
+  decision->action = ZenzFeedbackAction::kNeutral;
+  decision->reason = "feedback_reject_count_dominant";
+}
+
 void ApplyAutoBlockDecision(
     const Counts& exact_counts,
     const ZenzFeedbackAutoBlockPolicy& auto_block_policy,
@@ -1104,6 +1125,7 @@ ZenzFeedbackDecision ZenzFeedbackStore::Decide(
   }
 
   ZenzFeedbackDecision decision = BuildDecisionFromCounts(aggregated);
+  ApplyRejectDominanceDecision(exact, &decision);
   ApplyAutoBlockDecision(exact, auto_block_policy, &decision);
   return decision;
 }
@@ -1166,6 +1188,7 @@ std::vector<ZenzFeedbackCandidate> ZenzFeedbackStore::GetRankedCandidates(
 
     if (c.hard_rejected ||
         IsAutoBlockedByPolicy(exact_counts, auto_block_policy) ||
+        IsRejectCountDominant(exact_counts) ||
         c.accepted < kAcceptThreshold ||
         TotalScore(c) <= 0) {
       continue;
@@ -1231,6 +1254,7 @@ std::vector<ZenzFeedbackEntry> ZenzFeedbackStore::ListEntries(
     const FeedbackKey& feedback_key = item.first;
     const Counts& c = item.second;
     ZenzFeedbackDecision decision = BuildDecisionFromCounts(c);
+    ApplyRejectDominanceDecision(c, &decision);
     ApplyAutoBlockDecision(c, auto_block_policy, &decision);
 
     ZenzFeedbackEntry entry;

--- a/src/session/zenz_feedback_store.cc
+++ b/src/session/zenz_feedback_store.cc
@@ -504,6 +504,7 @@ bool ParseFeedbackRecord(const std::vector<std::string>& fields,
 struct Counts {
   int accepted = 0;
   int rejected = 0;
+  int auto_block_rejected = 0;
   int positive_score = 0;
   int negative_score = 0;
   bool hard_rejected = false;
@@ -544,15 +545,54 @@ void AddAccepted(Counts* c) {
 void AddRejected(absl::string_view reason, Counts* c) {
   ++c->rejected;
   c->negative_score += RejectWeightForReason(reason);
+  if (!IsHardRejectReason(reason)) {
+    ++c->auto_block_rejected;
+  }
   c->hard_rejected |= IsHardRejectReason(reason);
 }
 
 void MergeCounts(const Counts& src, Counts* dest) {
   dest->accepted += src.accepted;
   dest->rejected += src.rejected;
+  dest->auto_block_rejected += src.auto_block_rejected;
   dest->positive_score += src.positive_score;
   dest->negative_score += src.negative_score;
   dest->hard_rejected |= src.hard_rejected;
+}
+
+ZenzFeedbackAutoBlockPolicy NormalizeAutoBlockPolicy(
+    ZenzFeedbackAutoBlockPolicy policy) {
+  if (!policy.enabled || policy.reject_threshold <= 0) {
+    return ZenzFeedbackAutoBlockPolicy();
+  }
+  return policy;
+}
+
+bool IsAutoBlockedByPolicy(
+    const Counts& c,
+    const ZenzFeedbackAutoBlockPolicy& auto_block_policy) {
+  const ZenzFeedbackAutoBlockPolicy policy =
+      NormalizeAutoBlockPolicy(auto_block_policy);
+  return policy.enabled &&
+         c.auto_block_rejected >= policy.reject_threshold;
+}
+
+void ApplyAutoBlockDecision(
+    const Counts& exact_counts,
+    const ZenzFeedbackAutoBlockPolicy& auto_block_policy,
+    ZenzFeedbackDecision* decision) {
+  if (decision == nullptr || decision->hard_rejected) {
+    return;
+  }
+
+  decision->auto_block_reject_count = exact_counts.auto_block_rejected;
+  if (!IsAutoBlockedByPolicy(exact_counts, auto_block_policy)) {
+    return;
+  }
+
+  decision->action = ZenzFeedbackAction::kReject;
+  decision->reason = "feedback_auto_blocked";
+  decision->auto_blocked = true;
 }
 
 using FeedbackKey = std::tuple<std::string, std::string, std::string>;
@@ -690,6 +730,7 @@ ZenzFeedbackDecision BuildDecisionFromCounts(const Counts& c) {
   ZenzFeedbackDecision decision;
   decision.accepted_count = c.accepted;
   decision.rejected_count = c.rejected;
+  decision.auto_block_reject_count = c.auto_block_rejected;
   decision.positive_score = c.positive_score;
   decision.negative_score = c.negative_score;
   decision.total_score = TotalScore(c);
@@ -1020,6 +1061,14 @@ ZenzFeedbackDecision ZenzFeedbackStore::Decide(
     absl::string_view key,
     absl::string_view context_class,
     absl::string_view value) const {
+  return Decide(key, context_class, value, ZenzFeedbackAutoBlockPolicy());
+}
+
+ZenzFeedbackDecision ZenzFeedbackStore::Decide(
+    absl::string_view key,
+    absl::string_view context_class,
+    absl::string_view value,
+    const ZenzFeedbackAutoBlockPolicy& auto_block_policy) const {
   const std::map<FeedbackKey, Counts> counts = LoadCounts();
 
   const std::string normalized_key(key);
@@ -1028,6 +1077,7 @@ ZenzFeedbackDecision ZenzFeedbackStore::Decide(
   const std::string normalized_value(value);
 
   Counts aggregated;
+  Counts exact;
 
   for (const auto& item : counts) {
     const FeedbackKey& feedback_key = item.first;
@@ -1041,6 +1091,10 @@ ZenzFeedbackDecision ZenzFeedbackStore::Decide(
       continue;
     }
 
+    if (record_context_class == normalized_context_class) {
+      MergeCounts(c, &exact);
+    }
+
     if (!IsDecisionCompatibleContextClass(
             normalized_context_class, record_context_class)) {
       continue;
@@ -1049,12 +1103,22 @@ ZenzFeedbackDecision ZenzFeedbackStore::Decide(
     MergeCounts(c, &aggregated);
   }
 
-  return BuildDecisionFromCounts(aggregated);
+  ZenzFeedbackDecision decision = BuildDecisionFromCounts(aggregated);
+  ApplyAutoBlockDecision(exact, auto_block_policy, &decision);
+  return decision;
 }
 
 std::vector<ZenzFeedbackCandidate> ZenzFeedbackStore::GetRankedCandidates(
     absl::string_view key,
     absl::string_view context_class) const {
+  return GetRankedCandidates(key, context_class,
+                             ZenzFeedbackAutoBlockPolicy());
+}
+
+std::vector<ZenzFeedbackCandidate> ZenzFeedbackStore::GetRankedCandidates(
+    absl::string_view key,
+    absl::string_view context_class,
+    const ZenzFeedbackAutoBlockPolicy& auto_block_policy) const {
   const std::map<FeedbackKey, Counts> counts = LoadCounts();
 
   const std::string normalized_key(key);
@@ -1062,6 +1126,7 @@ std::vector<ZenzFeedbackCandidate> ZenzFeedbackStore::GetRankedCandidates(
       NormalizeContextClass(context_class);
 
   std::map<std::string, Counts> value_counts;
+  std::map<std::string, Counts> exact_value_counts;
 
   for (const auto& item : counts) {
     const FeedbackKey& feedback_key = item.first;
@@ -1073,6 +1138,11 @@ std::vector<ZenzFeedbackCandidate> ZenzFeedbackStore::GetRankedCandidates(
 
     if (record_key != normalized_key) {
       continue;
+    }
+
+    if (record_context_class == normalized_context_class) {
+      Counts& exact = exact_value_counts[record_value];
+      MergeCounts(c, &exact);
     }
 
     if (!IsPromotionCompatibleContextClass(
@@ -1090,7 +1160,13 @@ std::vector<ZenzFeedbackCandidate> ZenzFeedbackStore::GetRankedCandidates(
     const std::string& value = item.first;
     const Counts& c = item.second;
 
-    if (c.hard_rejected || c.accepted < kAcceptThreshold ||
+    const auto exact_it = exact_value_counts.find(value);
+    const Counts exact_counts =
+        exact_it == exact_value_counts.end() ? Counts() : exact_it->second;
+
+    if (c.hard_rejected ||
+        IsAutoBlockedByPolicy(exact_counts, auto_block_policy) ||
+        c.accepted < kAcceptThreshold ||
         TotalScore(c) <= 0) {
       continue;
     }
@@ -1102,7 +1178,9 @@ std::vector<ZenzFeedbackCandidate> ZenzFeedbackStore::GetRankedCandidates(
     candidate.positive_score = c.positive_score;
     candidate.negative_score = c.negative_score;
     candidate.total_score = TotalScore(c);
+    candidate.auto_block_reject_count = exact_counts.auto_block_rejected;
     candidate.hard_rejected = c.hard_rejected;
+    candidate.auto_blocked = false;
     candidate.reason = "feedback_preferred";
     candidates.push_back(std::move(candidate));
   }
@@ -1131,7 +1209,19 @@ std::vector<ZenzFeedbackCandidate> ZenzFeedbackStore::GetAcceptedCandidates(
   return GetRankedCandidates(key, context_class);
 }
 
+std::vector<ZenzFeedbackCandidate> ZenzFeedbackStore::GetAcceptedCandidates(
+    absl::string_view key,
+    absl::string_view context_class,
+    const ZenzFeedbackAutoBlockPolicy& auto_block_policy) const {
+  return GetRankedCandidates(key, context_class, auto_block_policy);
+}
+
 std::vector<ZenzFeedbackEntry> ZenzFeedbackStore::ListEntries() const {
+  return ListEntries(ZenzFeedbackAutoBlockPolicy());
+}
+
+std::vector<ZenzFeedbackEntry> ZenzFeedbackStore::ListEntries(
+    const ZenzFeedbackAutoBlockPolicy& auto_block_policy) const {
   const std::map<FeedbackKey, Counts> counts = LoadCounts();
 
   std::vector<ZenzFeedbackEntry> entries;
@@ -1140,7 +1230,8 @@ std::vector<ZenzFeedbackEntry> ZenzFeedbackStore::ListEntries() const {
   for (const auto& item : counts) {
     const FeedbackKey& feedback_key = item.first;
     const Counts& c = item.second;
-    const ZenzFeedbackDecision decision = BuildDecisionFromCounts(c);
+    ZenzFeedbackDecision decision = BuildDecisionFromCounts(c);
+    ApplyAutoBlockDecision(c, auto_block_policy, &decision);
 
     ZenzFeedbackEntry entry;
     entry.key = std::get<0>(feedback_key);
@@ -1148,6 +1239,9 @@ std::vector<ZenzFeedbackEntry> ZenzFeedbackStore::ListEntries() const {
     entry.value = std::get<2>(feedback_key);
     entry.accepted_count = c.accepted;
     entry.rejected_count = c.rejected;
+    entry.auto_block_reject_count = c.auto_block_rejected;
+    entry.hard_rejected = decision.hard_rejected;
+    entry.auto_blocked = decision.auto_blocked;
     entry.reason = decision.reason;
     entries.push_back(std::move(entry));
   }

--- a/src/session/zenz_feedback_store.h
+++ b/src/session/zenz_feedback_store.h
@@ -21,6 +21,11 @@ enum class ZenzFeedbackImportMode {
   kReplace = 1,
 };
 
+struct ZenzFeedbackAutoBlockPolicy {
+  bool enabled = false;
+  int reject_threshold = 0;
+};
+
 struct ZenzFeedbackDecision {
   ZenzFeedbackAction action = ZenzFeedbackAction::kNeutral;
   std::string reason = "feedback_neutral";
@@ -29,7 +34,9 @@ struct ZenzFeedbackDecision {
   int positive_score = 0;
   int negative_score = 0;
   int total_score = 0;
+  int auto_block_reject_count = 0;
   bool hard_rejected = false;
+  bool auto_blocked = false;
 };
 
 struct ZenzFeedbackCandidate {
@@ -39,7 +46,9 @@ struct ZenzFeedbackCandidate {
   int positive_score = 0;
   int negative_score = 0;
   int total_score = 0;
+  int auto_block_reject_count = 0;
   bool hard_rejected = false;
+  bool auto_blocked = false;
   std::string reason = "feedback_neutral";
 };
 
@@ -49,6 +58,9 @@ struct ZenzFeedbackEntry {
   std::string value;
   int accepted_count = 0;
   int rejected_count = 0;
+  int auto_block_reject_count = 0;
+  bool hard_rejected = false;
+  bool auto_blocked = false;
   std::string reason = "feedback_neutral";
 };
 
@@ -69,6 +81,12 @@ class ZenzFeedbackStore {
                               absl::string_view context_class,
                               absl::string_view value) const;
 
+  ZenzFeedbackDecision Decide(
+      absl::string_view key,
+      absl::string_view context_class,
+      absl::string_view value,
+      const ZenzFeedbackAutoBlockPolicy& auto_block_policy) const;
+
   // Returns feedback-scored values for the given key/context_class.
   //
   // Compatible non-sensitive context classes are aggregated, as in Decide().
@@ -87,16 +105,29 @@ class ZenzFeedbackStore {
       absl::string_view key,
       absl::string_view context_class) const;
 
+  std::vector<ZenzFeedbackCandidate> GetRankedCandidates(
+      absl::string_view key,
+      absl::string_view context_class,
+      const ZenzFeedbackAutoBlockPolicy& auto_block_policy) const;
+
   // Compatibility wrapper for older call sites.  Prefer GetRankedCandidates()
   // for new code so rejected feedback can be used as a cost/ranking signal.
   std::vector<ZenzFeedbackCandidate> GetAcceptedCandidates(
       absl::string_view key,
       absl::string_view context_class) const;
 
+  std::vector<ZenzFeedbackCandidate> GetAcceptedCandidates(
+      absl::string_view key,
+      absl::string_view context_class,
+      const ZenzFeedbackAutoBlockPolicy& auto_block_policy) const;
+
   // Returns exact persisted feedback entries aggregated by
   // key/context_class/value.  Unlike ranked candidate lookup, this method does
   // not merge compatible context classes.  It is intended for management UI.
   std::vector<ZenzFeedbackEntry> ListEntries() const;
+
+  std::vector<ZenzFeedbackEntry> ListEntries(
+      const ZenzFeedbackAutoBlockPolicy& auto_block_policy) const;
 
   // Exports the raw feedback history as normalized v2 UTF-8 TSV.
   [[nodiscard]]

--- a/src/session/zenz_feedback_store_test.cc
+++ b/src/session/zenz_feedback_store_test.cc
@@ -204,6 +204,8 @@ TEST(ZenzFeedbackStoreTest,
 
   ZenzFeedbackStore store;
   store.RecordAccepted("k", "empty", "v");
+  store.RecordAccepted("k", "empty", "v");
+  store.RecordAccepted("k", "empty", "v");
   store.RecordRejected("k", "empty", "v", "space_revert_zenz_to_mozc");
   store.RecordRejected("k", "empty", "v", "space_revert_zenz_to_mozc");
 
@@ -216,7 +218,7 @@ TEST(ZenzFeedbackStoreTest,
   EXPECT_EQ(decision.reason, "feedback_auto_blocked");
   EXPECT_TRUE(decision.auto_blocked);
   EXPECT_FALSE(decision.hard_rejected);
-  EXPECT_EQ(decision.accepted_count, 1);
+  EXPECT_EQ(decision.accepted_count, 3);
   EXPECT_EQ(decision.rejected_count, 2);
   EXPECT_EQ(decision.auto_block_reject_count, 2);
 
@@ -232,6 +234,33 @@ TEST(ZenzFeedbackStoreTest,
   EXPECT_EQ(decision.action, ZenzFeedbackAction::kPrefer);
   EXPECT_EQ(decision.reason, "feedback_preferred");
   EXPECT_FALSE(decision.auto_blocked);
+}
+
+TEST(ZenzFeedbackStoreTest,
+     DecideStopsPreferenceWhenOrdinaryRejectCountDominates) {
+  ScopedUserProfileForZenzFeedbackStoreTest profile;
+  ASSERT_TRUE(profile.ok());
+
+  ZenzFeedbackStore store;
+  store.RecordAccepted("k", "empty", "v");
+  store.RecordRejected("k", "empty", "v", "space_revert_zenz_to_mozc");
+  store.RecordRejected("k", "empty", "v", "space_revert_zenz_to_mozc");
+
+  ZenzFeedbackDecision decision = store.Decide("k", "empty", "v");
+  EXPECT_EQ(decision.action, ZenzFeedbackAction::kNeutral);
+  EXPECT_EQ(decision.reason, "feedback_reject_count_dominant");
+  EXPECT_FALSE(decision.auto_blocked);
+  EXPECT_FALSE(decision.hard_rejected);
+  EXPECT_EQ(decision.accepted_count, 1);
+  EXPECT_EQ(decision.rejected_count, 2);
+  EXPECT_EQ(decision.auto_block_reject_count, 2);
+  EXPECT_GT(decision.total_score, 0);
+
+  EXPECT_TRUE(store.GetRankedCandidates("k", "empty").empty());
+
+  const std::vector<ZenzFeedbackEntry> entries = store.ListEntries();
+  ASSERT_EQ(entries.size(), 1);
+  EXPECT_EQ(entries[0].reason, "feedback_reject_count_dominant");
 }
 
 TEST(ZenzFeedbackStoreTest, AutoBlockPolicyUsesExactContextClass) {
@@ -319,6 +348,8 @@ TEST(ZenzFeedbackStoreTest,
   ZenzFeedbackStore store;
   store.RecordAccepted("k", "empty", "kept");
   store.RecordAccepted("k", "empty", "blocked");
+  store.RecordAccepted("k", "empty", "blocked");
+  store.RecordAccepted("k", "empty", "blocked");
   store.RecordRejected("k", "empty", "blocked",
                        "space_revert_zenz_to_mozc");
   store.RecordRejected("k", "empty", "blocked",
@@ -338,8 +369,32 @@ TEST(ZenzFeedbackStoreTest,
   candidates = store.GetRankedCandidates("k", "empty", policy);
 
   ASSERT_EQ(candidates.size(), 2);
+  EXPECT_EQ(candidates[0].value, "blocked");
+  EXPECT_EQ(candidates[1].value, "kept");
+}
+
+TEST(ZenzFeedbackStoreTest,
+     GetRankedCandidatesExcludesRejectDominantValueWithoutAutoBlock) {
+  ScopedUserProfileForZenzFeedbackStoreTest profile;
+  ASSERT_TRUE(profile.ok());
+
+  ZenzFeedbackStore store;
+  store.RecordAccepted("k", "empty", "kept");
+  store.RecordAccepted("k", "empty", "dominant");
+  store.RecordRejected("k", "empty", "dominant",
+                       "space_revert_zenz_to_mozc");
+  store.RecordRejected("k", "empty", "dominant",
+                       "space_revert_zenz_to_mozc");
+
+  ZenzFeedbackAutoBlockPolicy policy;
+  policy.enabled = false;
+  policy.reject_threshold = 1;
+
+  const std::vector<ZenzFeedbackCandidate> candidates =
+      store.GetRankedCandidates("k", "empty", policy);
+
+  ASSERT_EQ(candidates.size(), 1);
   EXPECT_EQ(candidates[0].value, "kept");
-  EXPECT_EQ(candidates[1].value, "blocked");
 }
 
 TEST(ZenzFeedbackStoreTest,

--- a/src/session/zenz_feedback_store_test.cc
+++ b/src/session/zenz_feedback_store_test.cc
@@ -197,6 +197,71 @@ TEST(ZenzFeedbackStoreTest, DecideTreatsOrdinaryRejectedAsSoftSignal) {
   EXPECT_GT(decision.total_score, 0);
 }
 
+TEST(ZenzFeedbackStoreTest,
+     DecideAutoBlockPolicySuppressesAfterThresholdDynamically) {
+  ScopedUserProfileForZenzFeedbackStoreTest profile;
+  ASSERT_TRUE(profile.ok());
+
+  ZenzFeedbackStore store;
+  store.RecordAccepted("k", "empty", "v");
+  store.RecordRejected("k", "empty", "v", "space_revert_zenz_to_mozc");
+  store.RecordRejected("k", "empty", "v", "space_revert_zenz_to_mozc");
+
+  ZenzFeedbackAutoBlockPolicy policy;
+  policy.enabled = true;
+  policy.reject_threshold = 2;
+
+  ZenzFeedbackDecision decision = store.Decide("k", "empty", "v", policy);
+  EXPECT_EQ(decision.action, ZenzFeedbackAction::kReject);
+  EXPECT_EQ(decision.reason, "feedback_auto_blocked");
+  EXPECT_TRUE(decision.auto_blocked);
+  EXPECT_FALSE(decision.hard_rejected);
+  EXPECT_EQ(decision.accepted_count, 1);
+  EXPECT_EQ(decision.rejected_count, 2);
+  EXPECT_EQ(decision.auto_block_reject_count, 2);
+
+  policy.reject_threshold = 3;
+  decision = store.Decide("k", "empty", "v", policy);
+  EXPECT_EQ(decision.action, ZenzFeedbackAction::kPrefer);
+  EXPECT_EQ(decision.reason, "feedback_preferred");
+  EXPECT_FALSE(decision.auto_blocked);
+
+  policy.enabled = false;
+  policy.reject_threshold = 1;
+  decision = store.Decide("k", "empty", "v", policy);
+  EXPECT_EQ(decision.action, ZenzFeedbackAction::kPrefer);
+  EXPECT_EQ(decision.reason, "feedback_preferred");
+  EXPECT_FALSE(decision.auto_blocked);
+}
+
+TEST(ZenzFeedbackStoreTest, AutoBlockPolicyUsesExactContextClass) {
+  ScopedUserProfileForZenzFeedbackStoreTest profile;
+  ASSERT_TRUE(profile.ok());
+
+  ZenzFeedbackStore store;
+  store.RecordAccepted("k", "japanese_only", "v");
+  store.RecordRejected("k", "japanese_only", "v",
+                       "space_revert_zenz_to_mozc");
+  store.RecordRejected("k", "japanese_only", "v",
+                       "space_revert_zenz_to_mozc");
+
+  ZenzFeedbackAutoBlockPolicy policy;
+  policy.enabled = true;
+  policy.reject_threshold = 2;
+
+  ZenzFeedbackDecision decision = store.Decide("k", "empty", "v", policy);
+  EXPECT_EQ(decision.action, ZenzFeedbackAction::kPrefer);
+  EXPECT_EQ(decision.reason, "feedback_preferred");
+  EXPECT_FALSE(decision.auto_blocked);
+  EXPECT_EQ(decision.auto_block_reject_count, 0);
+
+  decision = store.Decide("k", "japanese_only", "v", policy);
+  EXPECT_EQ(decision.action, ZenzFeedbackAction::kReject);
+  EXPECT_EQ(decision.reason, "feedback_auto_blocked");
+  EXPECT_TRUE(decision.auto_blocked);
+  EXPECT_EQ(decision.auto_block_reject_count, 2);
+}
+
 TEST(ZenzFeedbackStoreTest, DecideAllowsFutureHardRejectReason) {
   ScopedUserProfileForZenzFeedbackStoreTest profile;
   ASSERT_TRUE(profile.ok());
@@ -244,6 +309,37 @@ TEST(ZenzFeedbackStoreTest, GetRankedCandidatesExcludesHardRejectedValue) {
   ASSERT_EQ(candidates.size(), 1);
   EXPECT_EQ(candidates[0].value, "kept");
   EXPECT_FALSE(candidates[0].hard_rejected);
+}
+
+TEST(ZenzFeedbackStoreTest,
+     GetRankedCandidatesExcludesAutoBlockedValueOnlyWhenPolicyEnabled) {
+  ScopedUserProfileForZenzFeedbackStoreTest profile;
+  ASSERT_TRUE(profile.ok());
+
+  ZenzFeedbackStore store;
+  store.RecordAccepted("k", "empty", "kept");
+  store.RecordAccepted("k", "empty", "blocked");
+  store.RecordRejected("k", "empty", "blocked",
+                       "space_revert_zenz_to_mozc");
+  store.RecordRejected("k", "empty", "blocked",
+                       "space_revert_zenz_to_mozc");
+
+  ZenzFeedbackAutoBlockPolicy policy;
+  policy.enabled = true;
+  policy.reject_threshold = 2;
+
+  std::vector<ZenzFeedbackCandidate> candidates =
+      store.GetRankedCandidates("k", "empty", policy);
+
+  ASSERT_EQ(candidates.size(), 1);
+  EXPECT_EQ(candidates[0].value, "kept");
+
+  policy.enabled = false;
+  candidates = store.GetRankedCandidates("k", "empty", policy);
+
+  ASSERT_EQ(candidates.size(), 2);
+  EXPECT_EQ(candidates[0].value, "kept");
+  EXPECT_EQ(candidates[1].value, "blocked");
 }
 
 TEST(ZenzFeedbackStoreTest,


### PR DESCRIPTION
## 概要

Zenz feedback learning に、通常却下が優勢になった補正を再利用しないポリシーと、設定可能な自動ブロック機能を追加しました。

主な変更点は以下です。

- Zenz 補正結果と異なる値で確定した回数がしきい値に達した場合、同じ読み全体・同じ文脈クラス・同じ補正結果を動的に自動ブロックできる設定を追加
- 通常却下回数が採用回数を上回る場合、auto-block が無効でも Zenz feedback の優先候補・保存済み feedback による即時補正として再利用しないように変更
- 管理 UI の状態表示を「優先スコアあり」「却下スコアあり」「却下数優勢」「自動ブロック中」「手動ブロック中」に整理
- 既存の「詳しく...」説明を拡充し、Zenz 学習データと通常変換履歴の違い、採用/却下の記録条件、各状態ラベルの意味を説明
- store / rewriter / session fast path のテストを追加

## 背景

従来は accepted feedback の重みが強いため、同じ補正に対して通常却下が複数回発生しても、過去の accepted feedback により優先候補や live correction fast path として再利用され続ける場合がありました。

今回の変更では、同じ読み全体・同じ文脈クラス・同じ補正結果について、通常却下回数が採用回数を上回った場合は「却下数優勢」の中立状態として扱います。

これは hard block ではないため、Zenz が新しく同じ補正を返すことや、通常 Mozc 候補を削除することはありません。

## 動作

- `feedback_preferred`
  - 採用・却下を重み付きで見た結果、優先再利用できる状態
- `feedback_downgraded` / `feedback_rejected`
  - 却下履歴により順位を下げる信号がある状態
- `feedback_reject_count_dominant`
  - 通常却下回数が採用回数を上回り、優先候補・保存済み feedback による即時補正としては使わない状態
- `feedback_auto_blocked`
  - auto-block が ON で、通常却下回数が設定しきい値に達している状態
- `feedback_hard_rejected`
  - 管理 UI などで明示的にブロックされた状態

auto-block は TSV に irreversible な hard reject を固定保存せず、現在の ON/OFF としきい値から既存 feedback を動的に再評価します。

## 確認

- `//session:zenz_feedback_store_test`
- `//rewriter:zenz_feedback_candidate_rewriter_test`
- `//session:session_test --test_filter=*ZenzFeedback*`
- `//gui/tool:mozc_tool_win`
- `package`

加えて、Windows 実機で以下を確認しました。

- clean uninstall → reboot → normal install
- MSI payload の `mozc_server.exe` / `mozc_tool.exe` hash とインストール後 hash の一致
- TIP registry の存在
- `Get-WinUserLanguageList` に Mozkey TIP が存在
- Zenz 学習データ管理 UI の状態表示
- 「詳しく...」説明文の表示
- accepted 1 / rejected 2 の entry が「却下数優勢」として表示されること
- auto-block OFF でも、却下数優勢 entry が保存済み feedback による即時補正として再利用されないこと