### PR TITLE
Hide empty live passive suggestion windows

### DIFF
--- a/src/renderer/win32/window_manager.cc
+++ b/src/renderer/win32/window_manager.cc
@@ -90,6 +90,28 @@ bool IsOppositeSideOfPreedit(const RECT& lhs, const RECT& rhs,
           rhs_relation == VerticalRelationToPreedit::kAbove);
 }
 
+bool HasRenderableCandidateMainText(
+    const commands::CandidateWindow& candidate_window) {
+  for (int i = 0; i < candidate_window.candidate_size(); ++i) {
+    const commands::CandidateWindow::Candidate& candidate =
+        candidate_window.candidate(i);
+
+    if (candidate.has_value() && !candidate.value().empty()) {
+      return true;
+    }
+
+    if (!candidate.has_annotation()) {
+      continue;
+    }
+    const commands::Annotation& annotation = candidate.annotation();
+    if ((annotation.has_prefix() && !annotation.prefix().empty()) ||
+        (annotation.has_suffix() && !annotation.suffix().empty())) {
+      return true;
+    }
+  }
+  return false;
+}
+
 }  // namespace
 
 WindowManager::WindowManager()
@@ -201,6 +223,7 @@ void WindowManager::UpdateLayout(const commands::RendererCommand& command) {
       output.has_candidate_window() && output.candidate_window().has_category() &&
       output.candidate_window().category() == commands::SUGGESTION &&
       output.candidate_window().candidate_size() > 0 &&
+      HasRenderableCandidateMainText(output.candidate_window()) &&
       !output.candidate_window().has_focused_index();
   const bool is_live_conversion_passive_suggestion =
       output.live_conversion() && has_passive_suggestion_window;


### PR DESCRIPTION
## Summary

ライブ変換中の passive suggestion window について、表示可能な候補本文がない場合は Windows renderer 側で表示対象にしないようにしました。

これまでは passive suggestion window の判定で以下を見ていました。

- `category == SUGGESTION`
- `candidate_size() > 0`
- `focused_index` なし

ただし、candidate entry が構造上は存在していても、実際に candidate window の本文として描画される文字列が空の場合がありました。その場合、白い空の候補ウィンドウだけが一瞬表示される可能性があります。

この変更では、少なくとも1件の候補に Windows candidate window が本文として描画する文字列がある場合だけ、live passive suggestion として扱うようにしました。

対象にする文字列は以下です。

- `candidate.value()`
- `annotation.prefix()`
- `annotation.suffix()`

## Scope

変更範囲は Windows renderer の live passive suggestion 判定に限定しています。

変更しないもの:

- 変換ロジック
- 予測ロジック
- Zenz 補正
- 候補生成
- 通常の候補ウィンドウ
- 通常の suggestion window
- window 位置計算
- shadow / redraw ordering

## Verification

- `git diff --check`
- `//renderer/win32:candidate_window`
- `//renderer/win32:window_manager`
- `//renderer/win32:win32_renderer_main`
- `//:package`
- MSI extract で `mozc_renderer.exe` / `mozc_server.exe` の payload を確認
- clean uninstall → reboot → normal install
- 実機で live conversion 中の未完成ローマ字 prefix 入力を確認

## Notes

このPRでは、空 candidate payload の表示抑制だけを扱います。

サジェスト表示直前に枠だけが一瞬見える問題は、candidate window の表示タイミング / pre-rendering モデルに関わるため、このPRでは扱いません。
