### PR TITLE
Pre-render candidate window before showing live suggestions

### DIFF
--- a/src/renderer/win32/candidate_window.cc
+++ b/src/renderer/win32/candidate_window.cc
@@ -41,6 +41,7 @@
 #include <memory>
 #include <sstream>
 #include <string>
+#include <utility>
 
 #include "absl/log/check.h"
 #include "absl/log/log.h"
@@ -345,6 +346,8 @@ CandidateWindow::CandidateWindow()
       footer_logo_display_size_(0, 0),
       send_command_interface_(nullptr),
       table_layout_(std::make_unique<TableLayout>()),
+      cached_bitmap_size_(0, 0),
+      cached_bitmap_valid_(false),
       dpi_(::GetDpiForSystem()),
       text_renderer_(TextRenderer::Create(dpi_)),
       indicator_width_(0),
@@ -398,6 +401,7 @@ void CandidateWindow::UpdateDpi(uint32_t dpi) {
   if (dpi == dpi_) {
     return;
   }
+  ClearBitmapCache();
   dpi_ = dpi;
   UpdateDpiDependentResources();
   text_renderer_->OnDpiChanged(dpi_);
@@ -416,6 +420,7 @@ void CandidateWindow::EnableOrDisableWindowForWorkaround() {
 }
 
 void CandidateWindow::OnDestroy() {
+  ClearBitmapCache();
   shadow_window_.Destroy();
   // PostQuitMessage may stop the message loop even though other
   // windows are not closed. WindowManager should close these windows
@@ -502,6 +507,10 @@ void CandidateWindow::OnPaint(HDC dc) {
   }
   HDC target_dc = paint_dc.is_valid() ? paint_dc.get() : dc;
 
+  if (BitBltCachedBitmapTo(target_dc, client_rect)) {
+    return;
+  }
+
   // Render to offline bitmap first to avoid tearing.
   wil::unique_hdc memdc(::CreateCompatibleDC(target_dc));
   wil::unique_hbitmap bitmap(::CreateCompatibleBitmap(
@@ -514,6 +523,92 @@ void CandidateWindow::OnPaint(HDC dc) {
 }
 
 void CandidateWindow::OnPrintClient(HDC dc, UINT uFlags) { OnPaint(dc); }
+
+bool CandidateWindow::RenderToBitmapCache() {
+  ClearBitmapCache();
+
+  if (!table_layout_->IsLayoutFrozen()) {
+    return false;
+  }
+
+  const Size layout_size = table_layout_->GetTotalSize();
+  if (layout_size.width <= 0 || layout_size.height <= 0) {
+    return false;
+  }
+
+  HDC screen_dc = ::GetDC(nullptr);
+  if (screen_dc == nullptr) {
+    return false;
+  }
+
+  wil::unique_hdc memdc(::CreateCompatibleDC(screen_dc));
+  wil::unique_hbitmap bitmap(::CreateCompatibleBitmap(
+      screen_dc, layout_size.width, layout_size.height));
+  ::ReleaseDC(nullptr, screen_dc);
+
+  if (!memdc.is_valid() || !bitmap.is_valid()) {
+    return false;
+  }
+
+  wil::unique_select_object old_bitmap =
+      wil::SelectObject(memdc.get(), bitmap.get());
+  DoPaint(memdc.get());
+
+  cached_bitmap_ = std::move(bitmap);
+  cached_bitmap_size_ = layout_size;
+  cached_bitmap_valid_ = true;
+  return true;
+}
+
+bool CandidateWindow::BitBltCachedBitmapTo(HDC target_dc,
+                                           const RECT& target_rect) const {
+  if (target_dc == nullptr || !cached_bitmap_valid_ ||
+      !cached_bitmap_.is_valid()) {
+    return false;
+  }
+
+  const int width = target_rect.right - target_rect.left;
+  const int height = target_rect.bottom - target_rect.top;
+  if (width <= 0 || height <= 0 || cached_bitmap_size_.width != width ||
+      cached_bitmap_size_.height != height) {
+    return false;
+  }
+
+  wil::unique_hdc memdc(::CreateCompatibleDC(target_dc));
+  if (!memdc.is_valid()) {
+    return false;
+  }
+
+  wil::unique_select_object old_bitmap =
+      wil::SelectObject(memdc.get(), cached_bitmap_.get());
+  return ::BitBlt(target_dc, target_rect.left, target_rect.top, width, height,
+                  memdc.get(), 0, 0, SRCCOPY) != FALSE;
+}
+
+void CandidateWindow::ClearBitmapCache() {
+  cached_bitmap_.reset();
+  cached_bitmap_size_ = Size(0, 0);
+  cached_bitmap_valid_ = false;
+}
+
+void CandidateWindow::PresentCachedBitmapImmediately() {
+  if (m_hWnd == nullptr || !::IsWindow(m_hWnd)) {
+    return;
+  }
+
+  RECT client_rect = {};
+  if (!::GetClientRect(m_hWnd, &client_rect)) {
+    return;
+  }
+
+  HDC target_dc = ::GetDC(m_hWnd);
+  if (target_dc == nullptr) {
+    return;
+  }
+
+  BitBltCachedBitmapTo(target_dc, client_rect);
+  ::ReleaseDC(m_hWnd, target_dc);
+}
 
 void CandidateWindow::DoPaint(HDC dc) {
   switch (candidate_window_->category()) {
@@ -570,6 +665,7 @@ void CandidateWindow::OnSettingChange(UINT uFlags, LPCTSTR /*lpszSection*/) {
     case SPI_SETFONTSMOOTHINGTYPE:
     case SPI_SETNONCLIENTMETRICS:
       metrics_changed_ = true;
+      ClearBitmapCache();
       break;
     case SPI_SETACTIVEWINDOWTRACKING:
       EnableOrDisableWindowForWorkaround();
@@ -582,6 +678,7 @@ void CandidateWindow::OnSettingChange(UINT uFlags, LPCTSTR /*lpszSection*/) {
 
 void CandidateWindow::UpdateLayout(
     const commands::CandidateWindow& candidates) {
+  ClearBitmapCache();
   *candidate_window_ = candidates;
 
   const RendererStyleHandler::RendererStyleType style_type =
@@ -756,6 +853,8 @@ void CandidateWindow::UpdateLayout(
   table_layout_->EnsureCellSize(COLUMN_GAP2, gap2_size);
 
   table_layout_->FreezeLayout();
+
+  RenderToBitmapCache();
 
   if (m_hWnd != nullptr) {
     UpdateRoundedWindowRegion(m_hWnd, table_layout_->GetTotalSize(), dpi_,

--- a/src/renderer/win32/candidate_window.h
+++ b/src/renderer/win32/candidate_window.h
@@ -112,6 +112,12 @@ class CandidateWindow : public ATL::CWindowImpl<CandidateWindow, ATL::CWindow,
   void UpdateLayout(const commands::CandidateWindow& candidate_window);
   void UpdateEffectWindows();
   void RedrawImmediately();
+  // Paints the pre-rendered candidate window bitmap to the window DC
+  // immediately.  This is used just after SWP_SHOWWINDOW for live passive
+  // suggestion UI so that the first visible frame already contains the
+  // completed candidate contents.  If the cache is unavailable, this method
+  // is a no-op and the normal WM_PAINT path remains the fallback.
+  void PresentCachedBitmapImmediately();
   // Hides both the candidate window and its renderer-owned visual effects.
   // This avoids one-frame shadow remnants when WindowManager suppresses or
   // relocates candidate UI during live-conversion ruby updates.
@@ -127,6 +133,10 @@ class CandidateWindow : public ATL::CWindowImpl<CandidateWindow, ATL::CWindow,
 
  private:
   void DoPaint(HDC dc);
+
+  bool RenderToBitmapCache();
+  bool BitBltCachedBitmapTo(HDC target_dc, const RECT& target_rect) const;
+  void ClearBitmapCache();
 
   void DrawCells(HDC dc);
   void DrawVScrollBar(HDC dc);
@@ -214,6 +224,9 @@ class CandidateWindow : public ATL::CWindowImpl<CandidateWindow, ATL::CWindow,
   Size footer_logo_display_size_;
   client::SendCommandInterface* send_command_interface_;
   std::unique_ptr<TableLayout> table_layout_;
+  wil::unique_hbitmap cached_bitmap_;
+  Size cached_bitmap_size_;
+  bool cached_bitmap_valid_;
   uint32_t dpi_;
   std::unique_ptr<TextRenderer> text_renderer_;
   int indicator_width_;

--- a/src/renderer/win32/window_manager.cc
+++ b/src/renderer/win32/window_manager.cc
@@ -443,6 +443,7 @@ void WindowManager::UpdateLayout(const commands::RendererCommand& command) {
                              main_window_rect.Top(), main_window_rect.Width(),
                              main_window_rect.Height(), set_windows_pos_flags);
   if (is_live_conversion_passive_suggestion) {
+    main_window_->PresentCachedBitmapImmediately();
     main_window_->RedrawImmediately();
   }
   main_window_->UpdateEffectWindows();


### PR DESCRIPTION
## Summary

ライブ変換中の passive suggestion window について、表示直後に枠だけが先に見える first-frame を抑えるため、CandidateWindow の描画結果を事前に bitmap cache 化し、表示直後に即時 present できるようにしました。

## Details

これまで CandidateWindow は `WM_PAINT` 時に毎回 offscreen bitmap を作成し、`DoPaint()` で背景・候補文字・フレーム等を描画してから `BitBlt()` していました。

この変更では、`UpdateLayout()` 後に同じ `DoPaint()` 経路で事前に bitmap cache を作成します。

- `UpdateLayout()` で layout 確定後に `RenderToBitmapCache()` を実行
- `OnPaint()` では cache が有効なら cached bitmap を `BitBlt()`
- cache が無効な場合は従来どおり `DoPaint()` fallback
- live passive suggestion の `SWP_SHOWWINDOW` 直後に `PresentCachedBitmapImmediately()` を呼び、初回表示 frame に完成済み内容を反映

`UpdateRoundedWindowRegion()` は `SetWindowRgn(..., TRUE)` により redraw を発生させる可能性があるため、bitmap cache はその前に作成しています。

## Scope

変更範囲は Windows renderer の CandidateWindow 表示処理に限定しています。

変更しないもの:

- 変換ロジック
- 予測ロジック
- Zenz 補正
- 候補生成
- 候補順位
- `ApplyRendererWindowOpacity()`
- `WS_EX_LAYERED` / alpha 0 透明化
- `UpdateLayeredWindow` 全面移行
- shadow 実装

## Verification

- `git diff --check`
- renderer 単体ビルド
  - `//renderer/win32:candidate_window`
  - `//renderer/win32:window_manager`
  - `//renderer/win32:win32_renderer_main`
- `bazelisk ... build package`
- MSI extract で payload 確認
  - `mozc_renderer.exe`
  - `mozc_server.exe`
- clean uninstall → reboot → normal install
- install 後の `mozc_renderer.exe` / `mozc_server.exe` の配置確認
- TIP registry / WinUserLanguageList 確認
- 実機確認
  - live passive suggestion 表示
  - サジェスト表示前の枠だけ描画
  - 通常変換候補
  - Space / Down / Tab 操作
  - 候補文字欠け・古い候補残像・サイズ不一致がないこと