### PR TITLE
Normalize ruby window geometry with GUI caret

### DIFF
--- a/src/renderer/win32/ruby_window.cc
+++ b/src/renderer/win32/ruby_window.cc
@@ -5,6 +5,7 @@
 #include <cstdint>
 #include <string>
 
+#include "base/win32/win_util.h"
 #include "base/win32/wide_char.h"
 #include "config/config_handler.h"
 #include "protocol/commands.pb.h"
@@ -279,10 +280,26 @@ bool RubyWindow::GetBasePosition(const commands::RendererCommand& command,
     const commands::RendererCommand::Rectangle& rect =
         command.preedit_rectangle();
 
-    const int height = rect.bottom() - rect.top();
+    RECT physical_rect = {rect.left(), rect.top(), rect.right(), rect.bottom()};
+    if (command.has_application_info()) {
+      const commands::RendererCommand::ApplicationInfo& app_info =
+          command.application_info();
+      if (app_info.input_framework() ==
+              commands::RendererCommand::ApplicationInfo::TSF &&
+          app_info.has_target_window_handle() &&
+          app_info.target_window_handle() != 0) {
+        const HWND target_window =
+            WinUtil::DecodeWindowHandle(app_info.target_window_handle());
+        const RECT logical_rect = physical_rect;
+        layout_manager.GetRectInPhysicalCoords(target_window, logical_rect,
+                                               &physical_rect);
+      }
+    }
+
+    const int height = physical_rect.bottom - physical_rect.top;
     if (height > 0) {
-      point->x = rect.left();
-      point->y = rect.top();
+      point->x = physical_rect.left;
+      point->y = physical_rect.top;
       *line_height = height;
       if (from_preedit_rectangle != nullptr) {
         *from_preedit_rectangle = true;

--- a/src/win32/tip/tip_ui_handler_conventional.cc
+++ b/src/win32/tip/tip_ui_handler_conventional.cc
@@ -34,6 +34,7 @@
 #include <windows.h>
 
 #include <cstddef>
+#include <cstdint>
 #include <utility>
 
 #include "absl/log/check.h"
@@ -67,6 +68,99 @@ using Annotation = ::mozc::commands::Preedit_Segment::Annotation;
 using IndicatorInfo = ::mozc::commands::RendererCommand_IndicatorInfo;
 using RendererCommand = ::mozc::commands::RendererCommand;
 using ApplicationInfo = ::mozc::commands::RendererCommand::ApplicationInfo;
+
+bool FillRubyPreeditRectangleFromGuiCaret(HWND target_window,
+                                          const RECT& text_rect,
+                                          bool vertical_writing,
+                                          RendererCommand* command) {
+  if (target_window == nullptr || !::IsWindow(target_window) ||
+      vertical_writing || command == nullptr) {
+    return false;
+  }
+
+  const int text_height = text_rect.bottom - text_rect.top;
+  if (text_height <= 0) {
+    return false;
+  }
+
+  DWORD target_process_id = 0;
+  const DWORD target_thread_id =
+      ::GetWindowThreadProcessId(target_window, &target_process_id);
+  if (target_thread_id == 0 ||
+      target_process_id != ::GetCurrentProcessId()) {
+    return false;
+  }
+
+  GUITHREADINFO gui_info = {};
+  gui_info.cbSize = sizeof(gui_info);
+  if (!::GetGUIThreadInfo(target_thread_id, &gui_info) ||
+      gui_info.hwndCaret == nullptr || !::IsWindow(gui_info.hwndCaret)) {
+    return false;
+  }
+
+  DWORD caret_process_id = 0;
+  if (::GetWindowThreadProcessId(gui_info.hwndCaret, &caret_process_id) == 0 ||
+      caret_process_id != target_process_id) {
+    return false;
+  }
+
+  POINT caret_top_left = {gui_info.rcCaret.left, gui_info.rcCaret.top};
+  POINT caret_bottom_right = {gui_info.rcCaret.right,
+                              gui_info.rcCaret.bottom};
+  if (!::ClientToScreen(gui_info.hwndCaret, &caret_top_left) ||
+      !::ClientToScreen(gui_info.hwndCaret, &caret_bottom_right)) {
+    return false;
+  }
+
+  const RECT caret_rect = {caret_top_left.x, caret_top_left.y,
+                           caret_bottom_right.x, caret_bottom_right.y};
+  const int caret_height = caret_rect.bottom - caret_rect.top;
+
+  // Some frameworks expose only a one- or two-pixel caret stroke instead of
+  // the input line box. Such a rectangle must not drive ruby placement.
+  constexpr int kMinimumCaretHeight = 8;
+  if (caret_height < kMinimumCaretHeight) {
+    return false;
+  }
+
+  // Accept only a substantial but plausible reduction. This corrects cases
+  // such as Notepad's anomalous 49px first-line TSF rectangle with a 25px GUI
+  // caret, while preserving the existing geometry for Word, Excel, ordinary
+  // editor lines, and thin Qt carets.
+  constexpr int kMinimumCaretHeightPercent = 40;
+  constexpr int kMaximumCaretHeightPercentForCorrection = 75;
+  constexpr int kMinimumHeightReduction = 4;
+  if (static_cast<int64_t>(caret_height) * 100 <
+          static_cast<int64_t>(text_height) *
+              kMinimumCaretHeightPercent ||
+      static_cast<int64_t>(caret_height) * 100 >
+          static_cast<int64_t>(text_height) *
+              kMaximumCaretHeightPercentForCorrection ||
+      text_height - caret_height < kMinimumHeightReduction) {
+    return false;
+  }
+
+  // The target anomaly contains excess space above the actual line while
+  // sharing its lower edge. Reject unrelated or stale caret rectangles.
+  const int bottom_delta =
+      caret_rect.bottom >= text_rect.bottom
+          ? caret_rect.bottom - text_rect.bottom
+          : text_rect.bottom - caret_rect.bottom;
+  const int bottom_tolerance = text_height > 16 ? text_height / 4 : 4;
+  if (bottom_delta > bottom_tolerance ||
+      caret_rect.top < text_rect.top - bottom_tolerance ||
+      caret_rect.top >= text_rect.bottom) {
+    return false;
+  }
+
+  RendererCommand::Rectangle* preedit_rect =
+      command->mutable_preedit_rectangle();
+  preedit_rect->set_left(text_rect.left);
+  preedit_rect->set_top(caret_rect.top);
+  preedit_rect->set_right(text_rect.right);
+  preedit_rect->set_bottom(caret_rect.bottom);
+  return true;
+}
 
 size_t GetTargetPos(const commands::Output& output) {
   if (!output.has_candidate_window() ||
@@ -212,10 +306,11 @@ wil::com_ptr_nothrow<ITfRange> GetSelectionRange(ITfContext* context,
 // TODO(yukawa): Replace FillCharPosition with new one designed for TSF.
 bool FillCharPosition(TipPrivateContext* private_context, ITfContext* context,
                       TfEditCookie read_cookie, bool has_composition,
-                      ApplicationInfo* app_info, bool* no_layout) {
-  if (private_context == nullptr) {
+                      RendererCommand* command, bool* no_layout) {
+  if (private_context == nullptr || command == nullptr) {
     return false;
   }
+  ApplicationInfo* app_info = command->mutable_application_info();
   bool dummy_no_layout = false;
   if (no_layout == nullptr) {
     no_layout = &dummy_no_layout;
@@ -226,7 +321,8 @@ bool FillCharPosition(TipPrivateContext* private_context, ITfContext* context,
     return false;
   }
 
-  (void)WinUtil::DecodeWindowHandle(app_info->target_window_handle());
+  const HWND target_window =
+      WinUtil::DecodeWindowHandle(app_info->target_window_handle());
 
   wil::com_ptr_nothrow<ITfRange> range =
       has_composition ? GetCompositionRange(context, read_cookie)
@@ -327,6 +423,11 @@ bool FillCharPosition(TipPrivateContext* private_context, ITfContext* context,
   area->set_right(document_rect.right);
   area->set_bottom(document_rect.bottom);
 
+  if (output.live_conversion() && output.has_preedit()) {
+    FillRubyPreeditRectangleFromGuiCaret(target_window, text_rect,
+                                         vertical_writing, command);
+  }
+
   return true;
 }
 
@@ -355,7 +456,7 @@ void UpdateCommand(TipTextService* text_service, ITfContext* context,
   FillVisibility(ui_element_manager.get(), private_context, command);
   FillWindowHandle(context, app_info);
   FillCharPosition(private_context, context, read_cookie,
-                   command->output().has_preedit(), app_info, no_layout);
+                   command->output().has_preedit(), command, no_layout);
 
   if (private_context != nullptr) {
     const TipInputModeManager* input_mode_manager =


### PR DESCRIPTION
## 概要

* TSFのテキスト矩形に過剰な上側余白が含まれる場合、WindowsのGUIキャレットを利用してルビウィンドウの位置と行高を補正
* 補正した矩形はルビ専用の`preedit_rectangle`として設定
* 候補ウィンドウやサジェストウィンドウの配置には影響しないよう、既存の`composition_target`は維持
* GUIキャレットが取得できない場合や、矩形が不適切な場合は従来のTSF座標へフォールバック

## 確認内容

* Windows向けpackage buildが成功することを確認
* メモ帳1行目でルビウィンドウの過剰な上方向のずれが改善されることを確認
* メモ帳2行目、Word、Excel、サクラエディタ、LINEで既存の配置を維持することを確認
* 診断コードを除去したクリーンビルドで、追加のちらつきが発生しないことを確認
