### PR TITLE
Fix bounds check in CandidateList::MoveToPageIndex (#1544)

### DIFF
--- a/src/engine/candidate_list.cc
+++ b/src/engine/candidate_list.cc
@@ -304,7 +304,8 @@ bool CandidateList::MoveToId(const int base_id) {
 
 bool CandidateList::MoveToPageIndex(const size_t page_index) {
   const auto [begin, end] = GetPageRange(focused_index_);
-  if (begin + page_index > end) {
+  // Note: |end| is exclusive, i.e. the valid index range is [begin, end).
+  if (begin + page_index >= end) {
     return false;
   }
   focused_index_ = begin + page_index;

--- a/src/engine/candidate_list_test.cc
+++ b/src/engine/candidate_list_test.cc
@@ -227,6 +227,16 @@ TEST_F(CandidateListTest, MoveToPageIndex) {
   // main12
   EXPECT_TRUE(main_list_->MoveToId(10));
 
+  // main12 (id 10) is at page index 3 of the last page, whose valid page
+  // indexes are [0, 4) as the list has 13 elements in total.
+  EXPECT_TRUE(main_list_->MoveToPageIndex(3));
+  EXPECT_EQ(main_list_->focused_id(), 10);
+
+  // Regression test for https://github.com/google/mozc/issues/1543.
+  // Boundary check: page index 4 points to one past the last candidate.
+  EXPECT_FALSE(main_list_->MoveToPageIndex(4));
+  EXPECT_EQ(main_list_->focused_id(), 10);
+
   // invalid index
   EXPECT_FALSE(main_list_->MoveToPageIndex(7));
 }


### PR DESCRIPTION
## 概要

`CandidateList::MoveToPageIndex()` のページ内インデックス境界判定にある off-by-one を修正します。

`GetPageRange()` が返す終端位置は排他的ですが、従来は終端と同じ位置を有効として扱っていました。

## 変更内容

* ページ内インデックスの境界判定を `>` から `>=` に修正
* 最終候補の1つ後を指定した場合に `false` を返す回帰テストを追加
* 無効なインデックス指定時に、現在の選択候補が変化しないことを確認

## 影響

有効なページ内インデックスの動作は変わりません。

ページ終端の1つ後を指定した場合のみ、候補範囲外への移動を防止します。

## 確認

* `//engine:candidate_list_test`
* `//session:session_handler_stress_test`

  * 16 runsすべて成功

## Upstream

`google/mozc@7f1973ba0ee6c94483253ecfa70ff33dd084d5c3`
