### PR TITLE
Fix boundary pattern field matching

### DIFF
--- a/src/converter/gen_boundary_data.py
+++ b/src/converter/gen_boundary_data.py
@@ -63,7 +63,10 @@ import sys
 
 
 def PatternToRegexp(pattern):
-  return '^' + pattern.replace('*', '[^,]+')
+  regexp = '^' + pattern.replace('*', '[^,]+')
+  if not regexp.endswith(','):
+    regexp += '(?:,|$)'
+  return regexp
 
 
 def LoadPatterns(file):

--- a/src/data/rules/boundary.def
+++ b/src/data/rules/boundary.def
@@ -39,6 +39,18 @@
 #
 # label: (SUFFIX|PREFIX) suffix rule or prefix rule.
 # feature_regexp: POS/feature regexp patterns.
+# Note on matching behavior:
+# - Patterns are compiled into regex anchored at the beginning ('^').
+# - If a pattern does not end with a comma, '(?:,|$)' is appended so that the
+#   last specified field must end at either a field boundary or the end of the
+#   feature string.
+#   For example, '名詞,接尾' matches both '名詞,接尾' and
+#   '名詞,接尾,一般', but does not match '名詞,接尾可能'.
+# - A trailing comma preserves prefix matching from that field boundary.
+#   For example, '動詞,自立,' matches strings beginning with
+#   '動詞,自立,', but does not match '動詞,自立'.
+# - The '*' character is reserved as a wildcard for a single field (replaced
+#   by '[^,]+'). To use regex repetition, use '+' or '{0,}' instead.
 # penalty: penality cost.
 #
 # basically if a word exists at the beginning or end of user input,


### PR DESCRIPTION
## 概要

`boundary.def` の品詞パターンが、フィールド名の途中まで前方一致する問題を修正します。

従来はパターン末尾に品詞フィールド境界の条件がなかったため、「さ」を対象とするルールが「さらに」にも一致していました。

## 変更内容

* 末尾がカンマではないパターンに `(?:,|$)` を追加
* 最後に指定した品詞フィールドが、カンマまたは特徴文字列の終端で終了することを要求
* 末尾カンマによる明示的な前方一致は従来どおり維持
* `boundary.def` にパターンの一致規則を記載

## 影響

OSS品詞データ2672件を旧ロジックと比較した結果、ペナルティが変化するのは次の1件だけでした。

```text
副詞,助詞類接続,*,*,*,*,さらに
PREFIX penalty: 2000 → 12
```

「さ」専用の誤分割抑制ルールが「さらに」へ誤適用されなくなり、通常の副詞ルールが適用されます。

## 確認

* `PatternToRegexp()` の回帰ケース
* `//converter:gen_boundary_data` のビルド
* `//data_manager/oss:mozc_dataset_for_oss@boundary` の生成
* `//data_manager/oss:oss_data_manager_test`
* `//converter:converter_regression_test`
* 全2672品詞IDに対する旧・新ペナルティの意味差分監査

## Upstream

`google/mozc@425ce1b1a3ad01c1b79c0689110effd2903102eb` を基に、品詞フィールド境界修正を最小限バックポートしています。
