### PR TITLE
Normalize keys in SymbolRewriter dictionary

### DIFF
--- a/src/rewriter/BUILD.bazel
+++ b/src/rewriter/BUILD.bazel
@@ -563,6 +563,7 @@ mozc_cc_library(
         "//base:util",
         "//base:vlog",
         "//base/strings:assign",
+        "//base/strings:japanese",
         "//converter:attribute",
         "//converter:segments",
         "//data_manager:serialized_dictionary",

--- a/src/rewriter/gen_symbol_rewriter_dictionary_main.cc
+++ b/src/rewriter/gen_symbol_rewriter_dictionary_main.cc
@@ -1001,17 +1001,17 @@ void AddSymbolToDictionary(const absl::string_view pos,
     sorting_key = it->second;
   }
 
+  absl::flat_hash_set<std::string> normalized_keys;
   for (const std::string& key : keys) {
-    const rewriter::Token &token = dictionary.AddToken(
-        {sorting_key, key, std::string(value), std::string(pos),
-         std::string(description), std::string(additional_description)});
+    std::string normalized_key = japanese::FullWidthAsciiToHalfWidthAscii(key);
+    Util::LowerString(&normalized_key);
+    normalized_keys.insert(normalized_key);
+  }
 
-    std::string fw_key = japanese::HalfWidthAsciiToFullWidthAscii(token.key);
-    if (fw_key != key) {
-      rewriter::Token fw_token = token;
-      fw_token.key = std::move(fw_key);
-      dictionary.AddToken(std::move(fw_token));
-    }
+  for (const std::string& key : normalized_keys) {
+    dictionary.AddToken({sorting_key, key, std::string(value), std::string(pos),
+                         std::string(description),
+                         std::string(additional_description)});
   }
 }
 

--- a/src/rewriter/symbol_rewriter.cc
+++ b/src/rewriter/symbol_rewriter.cc
@@ -46,6 +46,7 @@
 #include "absl/strings/string_view.h"
 #include "base/japanese_util.h"
 #include "base/strings/assign.h"
+#include "base/strings/japanese.h"
 #include "base/util.h"
 #include "base/vlog.h"
 #include "converter/attribute.h"
@@ -66,11 +67,7 @@
 namespace mozc {
 
 namespace {
-// Try to start inserting symbols from this position
-constexpr size_t kDefaultOffset = 3;
 constexpr size_t kOffsetForSymbolKey = 1;
-// Number of symbols which are inserted to first part
-constexpr size_t kMaxInsertToMedium = 15;
 
 size_t GetOffset(const ConversionRequest& request, absl::string_view key) {
   const bool is_symbol_key =
@@ -313,6 +310,14 @@ void InsertCandidates(size_t default_offset, int32_t promotion_size,
   segment->insert_candidates(segment->candidates_size(), std::move(candidates));
 }
 
+SerializedDictionary::IterRange Lookup(const SerializedDictionary& dictionary,
+                                       const absl::string_view key) {
+  // Normalize the key to half-width and lowercase.
+  std::string normalized_key = japanese::FullWidthAsciiToHalfWidthAscii(key);
+  Util::LowerString(&normalized_key);
+  return dictionary.equal_range(normalized_key);
+}
+
 }  // namespace
 
 bool SymbolRewriter::RewriteEachCandidate(const ConversionRequest& request,
@@ -323,7 +328,7 @@ bool SymbolRewriter::RewriteEachCandidate(const ConversionRequest& request,
                                      .symbol_rewriter_promotion_size();
   for (Segment& segment : segments->conversion_segments()) {
     absl::string_view key = segment.key();
-    const SerializedDictionary::IterRange range = dictionary_->equal_range(key);
+    const SerializedDictionary::IterRange range = Lookup(*dictionary_, key);
     if (range.first == range.second) {
       continue;
     }
@@ -347,7 +352,7 @@ bool SymbolRewriter::RewriteEntireCandidate(const ConversionRequest& request,
   }
 
   absl::string_view key = segments->conversion_segment(0).key();
-  const SerializedDictionary::IterRange range = dictionary_->equal_range(key);
+  const SerializedDictionary::IterRange range = Lookup(*dictionary_, key);
   if (range.first == range.second) {
     return false;
   }
@@ -384,7 +389,7 @@ SymbolRewriter::CheckResizeSegmentsRequest(const ConversionRequest& request,
   }
   const uint8_t segment_size = static_cast<uint8_t>(key_len);
 
-  const SerializedDictionary::IterRange range = dictionary_->equal_range(key);
+  const SerializedDictionary::IterRange range = Lookup(*dictionary_, key);
   if (range.first == range.second) {
     return std::nullopt;
   }

--- a/src/rewriter/symbol_rewriter.h
+++ b/src/rewriter/symbol_rewriter.h
@@ -30,7 +30,6 @@
 #ifndef MOZC_REWRITER_SYMBOL_REWRITER_H_
 #define MOZC_REWRITER_SYMBOL_REWRITER_H_
 
-#include <cstddef>
 #include <memory>
 #include <optional>
 

--- a/src/rewriter/symbol_rewriter_test.cc
+++ b/src/rewriter/symbol_rewriter_test.cc
@@ -457,4 +457,36 @@ TEST_F(SymbolRewriterTest, ResizeSegmentFailureIsNotFatal) {
   EXPECT_EQ(resize_request->segment_sizes[0], 2);
 }
 
+TEST_F(SymbolRewriterTest, CaseNormalizationTest) {
+  auto symbol_rewriter = std::make_from_tuple<SymbolRewriter>(
+      data_manager_->GetSymbolRewriterData());
+  const ConversionRequest request;
+
+  // "tm" (half-width lower) is not defined in symbol.tsv, but it should be
+  // automatically generated and registered by
+  // gen_symbol_rewriter_dictionary_main.
+  {
+    Segments segments;
+    AddSegment("tm", "tm", &segments);
+    EXPECT_TRUE(symbol_rewriter.Rewrite(request, &segments));
+    EXPECT_TRUE(HasCandidate(segments, 0, "™"));
+  }
+
+  // "ＴＭ" (full-width upper) should also be automatically registered.
+  {
+    Segments segments;
+    AddSegment("ＴＭ", "ＴＭ", &segments);
+    EXPECT_TRUE(symbol_rewriter.Rewrite(request, &segments));
+    EXPECT_TRUE(HasCandidate(segments, 0, "™"));
+  }
+
+  // "ｔｍ" (full-width lower) should also be automatically registered.
+  {
+    Segments segments;
+    AddSegment("ｔｍ", "ｔｍ", &segments);
+    EXPECT_TRUE(symbol_rewriter.Rewrite(request, &segments));
+    EXPECT_TRUE(HasCandidate(segments, 0, "™"));
+  }
+}
+
 }  // namespace mozc


### PR DESCRIPTION
## 概要

記号辞書のキーを半角・小文字へ正規化し、入力時の文字幅や大文字・小文字にかかわらず記号候補を検索できるようにします。

## 変更内容

* 記号辞書生成時にキーを半角・小文字へ正規化
* 正規化後に重複するキーをまとめて登録
* 記号辞書検索時にも入力キーを半角・小文字へ正規化
* 全角・半角および大文字・小文字の回帰テストを追加

例えば、以下の入力から同じ `™` 候補を取得できるようになります。

```text
tm
ＴＭ
ｔｍ
```

## 影響

従来は全角キーを別途複製して辞書へ登録していましたが、正規化された単一のキーへ統合します。

既存の記号入力を維持しつつ、文字幅と大文字・小文字の違いによる検索漏れを防ぎます。

## 確認

* `//rewriter:symbol_rewriter_test`
* `//data_manager/oss:mozc_dataset_for_oss@symbol`
* `//data_manager/oss:oss_data_manager_test`
* `//converter:converter_regression_test`

異なる2つの `output_user_root` で記号辞書を生成し、生成結果が完全に一致することも確認しました。

```text
symbol_token.data
  Size: 140688 bytes
  SHA-256: 7C663D3796EE0765BC00D20F06C672561874384CE38E5AF27278AA4E31C5A94F

symbol_string.data
  Size: 86088 bytes
  SHA-256: E906464133C63FF819096BE28B7D492214FE096F11EB18815276A56E1DE790C2
```

## Upstream

`google/mozc@c9eb9b4cc7b97e3cb304474ac068eb885090eaf4`
