### PR TITLE
Improve Zenz scorer port allocation and recovery

### DIFF
--- a/src/zenz_scorer/BUILD.bazel
+++ b/src/zenz_scorer/BUILD.bazel
@@ -9,6 +9,7 @@ mozc_cc_binary(
         "Advapi32.lib",
         "Bcrypt.lib",
         "Winhttp.lib",
+        "Ws2_32.lib",
     ],
     tags = MOZC_TAGS.WIN_ONLY,
     target_compatible_with = ["@platforms//os:windows"],

--- a/src/zenz_scorer/main.cc
+++ b/src/zenz_scorer/main.cc
@@ -1,5 +1,7 @@
 #define WIN32_LEAN_AND_MEAN
 
+#include <winsock2.h>
+#include <ws2tcpip.h>
 #include <windows.h>
 #include <bcrypt.h>
 #include <sddl.h>
@@ -22,29 +24,33 @@
 #pragma comment(lib, "Advapi32.lib")
 #pragma comment(lib, "Bcrypt.lib")
 #pragma comment(lib, "Winhttp.lib")
+#pragma comment(lib, "Ws2_32.lib")
 
 namespace {
 
 std::atomic<bool> g_llama_launch_started{false};
-std::atomic<bool> g_llama_ready_probe_started{false};
 std::atomic<bool> g_llama_server_ready{false};
+std::atomic<int> g_llama_port{0};
 std::atomic<bool> g_shutdown_requested{false};
 
 std::mutex g_llama_process_mutex;
 HANDLE g_llama_process = nullptr;
 HANDLE g_llama_job = nullptr;
+DWORD g_llama_process_id = 0;
 
 constexpr wchar_t kDefaultPipeName[] = L"\\\\.\\pipe\\mozc_zenz_scorer";
 constexpr wchar_t kSingleInstanceMutexName[] =
     L"Local\\MozcZenzScorerSingleInstance";
 
 constexpr wchar_t kDefaultHost[] = L"127.0.0.1";
-constexpr int kRandomPortMin = 49152;
-constexpr int kRandomPortMax = 65535;
 constexpr int kApiKeyBytes = 32;
 constexpr int kDefaultCtx = 256;
 constexpr int kDefaultThreads = 4;
 constexpr int kDefaultNPredict = 64;
+constexpr int kMaxLlamaLaunchAttempts = 3;
+constexpr int kLlamaReadyProbeAttempts = 120;
+constexpr int kLlamaReadyProbeIntervalMsec = 500;
+constexpr int kLlamaReadyProbeHttpTimeoutMsec = 1500;
 
 constexpr uint32_t kZenzWireMagic = 0x315A4E5A;  // "ZNZ1"
 constexpr uint16_t kZenzWireVersion = 1;
@@ -97,9 +103,8 @@ struct ZenzWireResponseHeader {
 struct Options {
   std::wstring pipe_name = kDefaultPipeName;
   std::wstring host = kDefaultHost;
-  int port = 0;
   std::string api_key;
-  bool random_ok = false;
+  bool api_key_ok = false;
 
   int ctx = kDefaultCtx;
   int threads = kDefaultThreads;
@@ -239,16 +244,6 @@ std::string HexEncode(const uint8_t* data, size_t size) {
   return output;
 }
 
-int GenerateRandomPort() {
-  uint32_t value = 0;
-  if (!FillRandomBytes(&value, sizeof(value))) {
-    return 0;
-  }
-
-  constexpr int kRange = kRandomPortMax - kRandomPortMin + 1;
-  return kRandomPortMin + static_cast<int>(value % kRange);
-}
-
 std::string GenerateApiKey() {
   std::vector<uint8_t> bytes(kApiKeyBytes);
   if (!FillRandomBytes(bytes.data(), bytes.size())) {
@@ -314,11 +309,8 @@ Options LoadOptions() {
         JoinPath(JoinPath(exe_dir, L"models"), L"zenz-v3.2-small-Q5_K_M.gguf");
   }
 
-  options.port = GenerateRandomPort();
   options.api_key = GenerateApiKey();
-  options.random_ok = options.port >= kRandomPortMin &&
-                      options.port <= kRandomPortMax &&
-                      !options.api_key.empty();
+  options.api_key_ok = !options.api_key.empty();
 
   options.ctx = std::clamp(
       GetEnvInt(L"MOZC_ZENZ_CTX", kDefaultCtx),
@@ -717,22 +709,71 @@ bool BuildCurrentUserOnlyPipeSecurityDescriptor(
   return true;
 }
 
+struct LlamaProcessSnapshot {
+  bool has_process = false;
+  bool running = false;
+  DWORD process_id = 0;
+  DWORD exit_code = STILL_ACTIVE;
+  DWORD wait_error = ERROR_SUCCESS;
+};
+
 void ResetLlamaReadyState() {
   g_llama_launch_started = false;
-  g_llama_ready_probe_started = false;
   g_llama_server_ready = false;
+  g_llama_port = 0;
 }
 
-void StopLlamaServer() {
+LlamaProcessSnapshot GetLlamaProcessSnapshot() {
   std::lock_guard<std::mutex> lock(g_llama_process_mutex);
 
-  if (g_llama_job != nullptr) {
-    ::TerminateJobObject(g_llama_job, 0);
+  LlamaProcessSnapshot snapshot;
+  if (g_llama_process == nullptr) {
+    return snapshot;
+  }
+
+  snapshot.has_process = true;
+  snapshot.process_id = g_llama_process_id;
+
+  const DWORD wait_result = ::WaitForSingleObject(g_llama_process, 0);
+  if (wait_result == WAIT_TIMEOUT) {
+    snapshot.running = true;
+    return snapshot;
+  }
+
+  if (wait_result == WAIT_FAILED) {
+    snapshot.wait_error = ::GetLastError();
+    return snapshot;
+  }
+
+  DWORD exit_code = 0;
+  if (::GetExitCodeProcess(g_llama_process, &exit_code)) {
+    snapshot.exit_code = exit_code;
+  } else {
+    snapshot.wait_error = ::GetLastError();
+  }
+
+  return snapshot;
+}
+
+void CleanupLlamaProcess(bool terminate_running_process) {
+  std::lock_guard<std::mutex> lock(g_llama_process_mutex);
+
+  if (g_llama_process != nullptr && terminate_running_process) {
+    const DWORD wait_result = ::WaitForSingleObject(g_llama_process, 0);
+    if (wait_result == WAIT_TIMEOUT) {
+      if (g_llama_job != nullptr) {
+        ::TerminateJobObject(g_llama_job, 0);
+      }
+
+      if (::WaitForSingleObject(g_llama_process, 100) == WAIT_TIMEOUT) {
+        ::TerminateProcess(g_llama_process, 0);
+      }
+
+      ::WaitForSingleObject(g_llama_process, 3000);
+    }
   }
 
   if (g_llama_process != nullptr) {
-    ::TerminateProcess(g_llama_process, 0);
-    ::WaitForSingleObject(g_llama_process, 3000);
     ::CloseHandle(g_llama_process);
     g_llama_process = nullptr;
   }
@@ -742,6 +783,11 @@ void StopLlamaServer() {
     g_llama_job = nullptr;
   }
 
+  g_llama_process_id = 0;
+}
+
+void StopLlamaServer() {
+  CleanupLlamaProcess(/*terminate_running_process=*/true);
   ResetLlamaReadyState();
 }
 
@@ -758,6 +804,50 @@ BOOL WINAPI ConsoleCtrlHandler(DWORD control_type) {
     default:
       return FALSE;
   }
+}
+
+int FindAvailableLoopbackPort(int* socket_error) {
+  if (socket_error != nullptr) {
+    *socket_error = 0;
+  }
+
+  SOCKET socket_handle = ::socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+  if (socket_handle == INVALID_SOCKET) {
+    if (socket_error != nullptr) {
+      *socket_error = ::WSAGetLastError();
+    }
+    return 0;
+  }
+
+  sockaddr_in address = {};
+  address.sin_family = AF_INET;
+  address.sin_addr.s_addr = ::htonl(INADDR_LOOPBACK);
+  address.sin_port = ::htons(0);
+
+  if (::bind(socket_handle,
+             reinterpret_cast<const sockaddr*>(&address),
+             sizeof(address)) == SOCKET_ERROR) {
+    if (socket_error != nullptr) {
+      *socket_error = ::WSAGetLastError();
+    }
+    ::closesocket(socket_handle);
+    return 0;
+  }
+
+  int address_length = sizeof(address);
+  if (::getsockname(socket_handle,
+                    reinterpret_cast<sockaddr*>(&address),
+                    &address_length) == SOCKET_ERROR) {
+    if (socket_error != nullptr) {
+      *socket_error = ::WSAGetLastError();
+    }
+    ::closesocket(socket_handle);
+    return 0;
+  }
+
+  const int port = static_cast<int>(::ntohs(address.sin_port));
+  ::closesocket(socket_handle);
+  return port;
 }
 
 void RememberLlamaProcess(PROCESS_INFORMATION* process) {
@@ -800,12 +890,20 @@ void RememberLlamaProcess(PROCESS_INFORMATION* process) {
   }
 
   g_llama_process = process->hProcess;
+  g_llama_process_id = process->dwProcessId;
   process->hProcess = nullptr;
 
   g_llama_job = job;
 }
 
-bool LaunchLlamaServer(const Options& options, std::wstring* error) {
+bool LaunchLlamaServer(const Options& options,
+                       int port,
+                       DWORD* process_id,
+                       std::wstring* error) {
+  if (process_id != nullptr) {
+    *process_id = 0;
+  }
+
   if (!FileExists(options.llama_server_path)) {
     *error = L"llama_server_not_found";
     return false;
@@ -826,15 +924,15 @@ bool LaunchLlamaServer(const Options& options, std::wstring* error) {
   cmd += L" -t ";
   cmd += std::to_wstring(options.threads);
   cmd += L" --host 127.0.0.1 --port ";
-  cmd += std::to_wstring(options.port);
+  cmd += std::to_wstring(port);
   // The API key is defense-in-depth for accidental or stale localhost servers.
   // It is passed to llama-server via command line because llama-server exposes
   // --api-key.  Do not treat it as a strong same-user secret.
   cmd += L" --api-key ";
   cmd += Utf8ToWide(options.api_key);
 
-  Debug(L"launch llama-server port=random api_key_bytes=" +
-        std::to_wstring(options.api_key.size()));
+  Debug(L"launch llama-server port=" + std::to_wstring(port) +
+        L" api_key_bytes=" + std::to_wstring(options.api_key.size()));
 
   std::vector<wchar_t> cmd_buffer(cmd.begin(), cmd.end());
   cmd_buffer.push_back(L'\0');
@@ -864,6 +962,10 @@ bool LaunchLlamaServer(const Options& options, std::wstring* error) {
     return false;
   }
 
+  if (process_id != nullptr) {
+    *process_id = process.dwProcessId;
+  }
+
   ::CloseHandle(process.hThread);
   RememberLlamaProcess(&process);
 
@@ -876,6 +978,7 @@ bool LaunchLlamaServer(const Options& options, std::wstring* error) {
 
 bool HttpPostCompletion(
     const Options& options,
+    int port,
     const std::string& prompt,
     uint32_t timeout_msec,
     uint32_t max_output_chars,
@@ -902,7 +1005,7 @@ bool HttpPostCompletion(
   HINTERNET connect = WinHttpConnect(
       session,
       options.host.c_str(),
-      static_cast<INTERNET_PORT>(options.port),
+      static_cast<INTERNET_PORT>(port),
       0);
 
   if (!connect) {
@@ -1063,80 +1166,202 @@ bool HttpPostCompletion(
   return true;
 }
 
-void StartLlamaReadyProbeInBackground(const Options& options);
+void LogLlamaProcessExit(const wchar_t* prefix,
+                         int attempt,
+                         int port,
+                         const LlamaProcessSnapshot& snapshot,
+                         DWORD elapsed_msec) {
+  std::wstring message(prefix);
+  message += L" attempt=" + std::to_wstring(attempt);
+  message += L" port=" + std::to_wstring(port);
+  message += L" pid=" + std::to_wstring(snapshot.process_id);
+  message += L" elapsed_msec=" + std::to_wstring(elapsed_msec);
+
+  if (!snapshot.has_process) {
+    message += L" state=no_process";
+  } else if (snapshot.wait_error != ERROR_SUCCESS) {
+    message += L" wait_error=" + std::to_wstring(snapshot.wait_error);
+  } else {
+    message += L" exit_code=" + std::to_wstring(snapshot.exit_code);
+  }
+
+  Debug(message);
+}
 
 void StartLlamaServerInBackground(const Options& options) {
   bool expected = false;
   if (!g_llama_launch_started.compare_exchange_strong(expected, true)) {
-    StartLlamaReadyProbeInBackground(options);
     return;
   }
 
+  g_llama_server_ready = false;
+
   std::thread([options]() {
-    std::wstring launch_error;
-    if (!LaunchLlamaServer(options, &launch_error)) {
-      Debug(L"background launch failed: " + launch_error);
-      g_llama_launch_started = false;
-      g_llama_ready_probe_started = false;
+    int attempts_used = 0;
+
+    for (int attempt = 1;
+         attempt <= kMaxLlamaLaunchAttempts &&
+         !g_shutdown_requested.load();
+         ++attempt) {
+      attempts_used = attempt;
+      CleanupLlamaProcess(/*terminate_running_process=*/true);
       g_llama_server_ready = false;
-      return;
-    }
+      g_llama_port = 0;
 
-    Debug(L"background launch requested");
-    StartLlamaReadyProbeInBackground(options);
-  }).detach();
-}
-
-void StartLlamaReadyProbeInBackground(const Options& options) {
-  bool expected = false;
-  if (!g_llama_ready_probe_started.compare_exchange_strong(expected, true)) {
-    return;
-  }
-
-  std::thread([options]() {
-    Debug(L"ready probe started");
-
-    // Model loading + warmup may take several seconds on cold start.
-    // This probe is intentionally outside Mozc's request path.
-    for (int i = 0; i < 120; ++i) {
-      std::this_thread::sleep_for(std::chrono::milliseconds(500));
-
-      std::string value;
-      std::string local_debug;
-
-      if (HttpPostCompletion(
-              options,
-              "\xEE\xB8\x82\xEE\xB8\x80テスト\xEE\xB8\x81",
-              1500,
-              8,
-              &value,
-              &local_debug)) {
-        g_llama_server_ready = true;
-        g_llama_ready_probe_started = false;
-        Debug(L"ready probe succeeded");
-        return;
+      int socket_error = 0;
+      const int port = FindAvailableLoopbackPort(&socket_error);
+      if (port == 0) {
+        Debug(L"loopback port allocation failed attempt=" +
+              std::to_wstring(attempt) +
+              L" socket_error=" + std::to_wstring(socket_error));
+        continue;
       }
 
-      if (i % 10 == 0) {
-        Debug(L"ready probe waiting");
+      std::wstring launch_error;
+      DWORD process_id = 0;
+      if (!LaunchLlamaServer(
+              options, port, &process_id, &launch_error)) {
+        Debug(L"background launch failed attempt=" +
+              std::to_wstring(attempt) +
+              L" port=" + std::to_wstring(port) +
+              L" error=" + launch_error);
+        continue;
+      }
+
+      g_llama_port = port;
+
+      Debug(L"background launch requested attempt=" +
+            std::to_wstring(attempt) +
+            L" port=" + std::to_wstring(port) +
+            L" pid=" + std::to_wstring(process_id));
+      Debug(L"ready probe started attempt=" +
+            std::to_wstring(attempt) +
+            L" port=" + std::to_wstring(port) +
+            L" pid=" + std::to_wstring(process_id));
+
+      const DWORD launch_start = ::GetTickCount();
+      bool process_exited = false;
+
+      // Model loading + warmup may take several seconds on cold start.
+      // This supervisor is intentionally outside Mozc's request path.
+      for (int probe = 0;
+           probe < kLlamaReadyProbeAttempts &&
+           !g_shutdown_requested.load();
+           ++probe) {
+        std::this_thread::sleep_for(
+            std::chrono::milliseconds(kLlamaReadyProbeIntervalMsec));
+
+        const LlamaProcessSnapshot snapshot = GetLlamaProcessSnapshot();
+        if (!snapshot.has_process || !snapshot.running) {
+          LogLlamaProcessExit(
+              L"llama-server exited",
+              attempt,
+              port,
+              snapshot,
+              ::GetTickCount() - launch_start);
+          CleanupLlamaProcess(
+              /*terminate_running_process=*/
+              snapshot.wait_error != ERROR_SUCCESS);
+          g_llama_port = 0;
+          process_exited = true;
+          break;
+        }
+
+        std::string value;
+        std::string local_debug;
+
+        if (HttpPostCompletion(
+                options,
+                port,
+                "\xEE\xB8\x82\xEE\xB8\x80テスト\xEE\xB8\x81",
+                kLlamaReadyProbeHttpTimeoutMsec,
+                8,
+                &value,
+                &local_debug)) {
+          const LlamaProcessSnapshot ready_snapshot =
+              GetLlamaProcessSnapshot();
+          if (ready_snapshot.has_process &&
+              ready_snapshot.running &&
+              !g_shutdown_requested.load()) {
+            g_llama_server_ready = true;
+            Debug(L"ready probe succeeded attempt=" +
+                  std::to_wstring(attempt) +
+                  L" port=" + std::to_wstring(port) +
+                  L" pid=" + std::to_wstring(process_id) +
+                  L" waited_msec=" +
+                  std::to_wstring(::GetTickCount() - launch_start));
+            return;
+          }
+        }
+
+        if (probe % 10 == 0) {
+          Debug(L"ready probe waiting attempt=" +
+                std::to_wstring(attempt) +
+                L" port=" + std::to_wstring(port) +
+                L" pid=" + std::to_wstring(process_id) +
+                L" reason=" + Utf8ToWide(local_debug));
+        }
+      }
+
+      if (g_shutdown_requested.load()) {
+        CleanupLlamaProcess(/*terminate_running_process=*/true);
+        g_llama_port = 0;
+        break;
+      }
+
+      if (!process_exited) {
+        Debug(L"ready probe timeout attempt=" +
+              std::to_wstring(attempt) +
+              L" port=" + std::to_wstring(port) +
+              L" pid=" + std::to_wstring(process_id));
+        CleanupLlamaProcess(/*terminate_running_process=*/true);
+        g_llama_port = 0;
+        break;
       }
     }
 
-    Debug(L"ready probe timeout");
-    StopLlamaServer();
+    g_llama_server_ready = false;
+    g_llama_port = 0;
+    g_llama_launch_started = false;
+
+    if (!g_shutdown_requested.load()) {
+      Debug(L"llama-server unavailable attempts=" +
+            std::to_wstring(attempts_used));
+    }
   }).detach();
 }
 
 bool EnsureLlamaServerReadyWithinTimeout(const Options& options,
                                          uint32_t timeout_msec,
+                                         int* port,
                                          std::string* debug) {
+  *port = 0;
+
   if (g_llama_server_ready.load()) {
-    *debug = "server_ready";
-    return true;
+    const LlamaProcessSnapshot snapshot = GetLlamaProcessSnapshot();
+    const int active_port = g_llama_port.load();
+
+    if (snapshot.has_process &&
+        snapshot.running &&
+        active_port > 0) {
+      *port = active_port;
+      *debug = "server_ready";
+      return true;
+    }
+
+    LogLlamaProcessExit(
+        L"ready llama-server no longer running",
+        /*attempt=*/0,
+        active_port,
+        snapshot,
+        /*elapsed_msec=*/0);
+    CleanupLlamaProcess(
+        /*terminate_running_process=*/
+        snapshot.wait_error != ERROR_SUCCESS);
+    ResetLlamaReadyState();
   }
 
   StartLlamaServerInBackground(options);
-  StartLlamaReadyProbeInBackground(options);
 
   const uint32_t wait_budget_msec =
       std::max<uint32_t>(
@@ -1147,13 +1372,24 @@ bool EnsureLlamaServerReadyWithinTimeout(const Options& options,
 
   const DWORD start = GetTickCount();
 
-  while (GetTickCount() - start < wait_budget_msec) {
+  while (::GetTickCount() - start < wait_budget_msec) {
     if (g_llama_server_ready.load()) {
-      const DWORD waited = GetTickCount() - start;
-      *debug = "server_ready_after_wait";
-      Debug(L"server ready wait succeeded waited_msec=" +
-            std::to_wstring(waited));
-      return true;
+      const int active_port = g_llama_port.load();
+      if (active_port > 0) {
+        const DWORD waited = ::GetTickCount() - start;
+        *port = active_port;
+        *debug = "server_ready_after_wait";
+        Debug(L"server ready wait succeeded waited_msec=" +
+              std::to_wstring(waited) +
+              L" port=" + std::to_wstring(active_port));
+        return true;
+      }
+    }
+
+    if (!g_llama_launch_started.load()) {
+      *debug = "server_start_failed";
+      Debug(L"server ready wait stopped because launch failed");
+      return false;
     }
 
     std::this_thread::sleep_for(
@@ -1267,8 +1503,9 @@ void HandleClient(HANDLE pipe, const Options& options) {
         L" " + RedactedUtf8Bytes(L"prompt", prompt));
 
   std::string debug;
+  int port = 0;
   if (!EnsureLlamaServerReadyWithinTimeout(
-          options, timeout_msec, &debug)) {
+          options, timeout_msec, &port, &debug)) {
     const DWORD latency = GetTickCount() - start;
     SendResponse(pipe, request_header.generation, kStatusTimeout, latency, "",
                  debug);
@@ -1278,11 +1515,28 @@ void HandleClient(HANDLE pipe, const Options& options) {
   std::string value;
   if (!HttpPostCompletion(
           options,
+          port,
           prompt,
           timeout_msec,
           max_output_chars,
           &value,
           &debug)) {
+    const LlamaProcessSnapshot snapshot = GetLlamaProcessSnapshot();
+    if (!snapshot.has_process || !snapshot.running) {
+      LogLlamaProcessExit(
+          L"llama-server exited during completion",
+          /*attempt=*/0,
+          port,
+          snapshot,
+          ::GetTickCount() - start);
+      CleanupLlamaProcess(
+          /*terminate_running_process=*/
+          snapshot.wait_error != ERROR_SUCCESS);
+      ResetLlamaReadyState();
+      StartLlamaServerInBackground(options);
+      debug = "server_exited";
+    }
+
     const DWORD latency = GetTickCount() - start;
     SendResponse(pipe, request_header.generation, kStatusError, latency, "",
                  debug);
@@ -1307,12 +1561,12 @@ int RunServer(const Options& options) {
         L" " +
         RedactedWideChars(L"model_path", options.model_path));
 
-  if (!options.random_ok) {
+  if (!options.api_key_ok) {
     Debug(L"secure random initialization failed");
     return 1;
   }
 
-  Debug(L"http_port_mode=random");
+  Debug(L"http_port_mode=os_assigned_loopback");
   Debug(L"api_key_bytes=" + std::to_wstring(options.api_key.size()));
   Debug(L"n_predict=" + std::to_wstring(options.n_predict));
 
@@ -1378,6 +1632,15 @@ int RunServer(const Options& options) {
 int wmain() {
   ::SetConsoleCtrlHandler(ConsoleCtrlHandler, TRUE);
 
+  WSADATA winsock_data = {};
+  const int winsock_result =
+      ::WSAStartup(MAKEWORD(2, 2), &winsock_data);
+  if (winsock_result != 0) {
+    Debug(L"WSAStartup failed error=" +
+          std::to_wstring(winsock_result));
+    return 1;
+  }
+
   HANDLE single_instance_mutex =
       ::CreateMutexW(nullptr, TRUE, kSingleInstanceMutexName);
 
@@ -1385,6 +1648,7 @@ int wmain() {
       ::GetLastError() == ERROR_ALREADY_EXISTS) {
     Debug(L"another scorer instance already exists");
     ::CloseHandle(single_instance_mutex);
+    ::WSACleanup();
     return 0;
   }
 
@@ -1398,5 +1662,6 @@ int wmain() {
     ::CloseHandle(single_instance_mutex);
   }
 
+  ::WSACleanup();
   return result;
 }


### PR DESCRIPTION
## 概要

Zenz scorerが使用するHTTPポートの割り当てと、`llama-server`終了時の復旧処理を改善します。

## 変更内容

* アプリ側で動的ポート範囲から未検証のポートを乱数選択する方式を廃止
* `127.0.0.1:0`へbindし、Windowsが割り当てた利用可能な動的ポートを使用
* `llama-server`のPIDと終了状態を追跡
* 起動直後に終了した場合、別ポートで最大3回再試行
* ready後に終了した場合、次回要求時に新しいポートで自動再起動
* scorer終了時に子プロセスを確実に終了
* ポート、PID、試行回数を含む診断ログを追加
* APIキー自体はログへ出力しない

## 背景

従来は、Windowsの動的ポート範囲から暗号学的乱数でポート番号を選択していました。

ただし、選択したポートが実際にbind可能かを確認していなかったため、環境によっては`llama-server`が起動直後に終了することがありました。

さらに、scorerが子プロセスの終了を検出せず、同じポートを使用し続けることで、Zenz補正が利用できない状態が継続する場合がありました。

## セキュリティ

今回も固定ポートには変更していません。

Windowsが起動時に割り当てた動的ポートを使用し、以下の既存の保護を維持しています。

* `127.0.0.1`のみで待ち受け
* 暗号学的乱数で生成した32バイトのAPIキーを使用
* APIキーの値をログへ出力しない
* Mozcとscorer間のnamed pipeを現在のユーザーに制限

ポート番号自体を認証情報として扱うのではなく、loopback制限とAPIキーを維持したまま、ポート割り当ての信頼性を改善します。

## 確認内容

* Zenz scorer単体のrelease build
* package build
* MSI内scorerとビルド済みscorerのSHA256一致
* クリーンアンインストール、再起動、通常インストール
* インストール済みIMEからのZenz推論成功
* `llama-server`強制終了後、新しいPID・ポートで自動復旧
* 復旧後のZenz補正適用
* scorer終了時の子プロセス終了

実機確認では、`llama-server`を強制終了した後、次のように復旧しました。

```text
旧: PID 25088 / port 56146
新: PID 17868 / port 56158
```
