### PR TITLE
Fix/upstream sort and verify unique

### DIFF
--- a/src/base/container/flat_internal.h
+++ b/src/base/container/flat_internal.h
@@ -80,7 +80,7 @@ template <class T, class Compare = std::less<>>
 constexpr void SortAndVerifyUnique(absl::Span<T> span,
                                    const Compare &cmp = Compare()) {
   std::sort(span.begin(), span.end(), cmp);
-  for (int i = 0; i + i < span.size(); ++i) {
+  for (int i = 0; i + 1 < span.size(); ++i) {
     if (!cmp(span[i], span[i + 1]) && !cmp(span[i + 1], span[i])) {
       DuplicateEntryFound();
     }

--- a/src/base/container/flat_set_test.cc
+++ b/src/base/container/flat_set_test.cc
@@ -69,5 +69,25 @@ TEST(FlatSetTest, CustomCompare) {
   EXPECT_FALSE(kSet.contains("six"));
 }
 
+TEST(FlatSetTest, SingleElement) {
+  // The uniqueness verification used to read past the end of the array for a
+  // single-element set, which failed the constant evaluation.
+  constexpr auto kSet = CreateFlatSet<int>({42});
+
+  EXPECT_TRUE(kSet.contains(42));
+  EXPECT_FALSE(kSet.contains(0));
+}
+
+#if defined(EXPECT_DEATH)
+TEST(FlatSetDeathTest, DuplicateEntries) {
+  // Runtime construction with duplicate entries hits LOG(FATAL). Compile-time
+  // construction with duplicate entries fails the build instead.
+  EXPECT_DEATH(CreateFlatSet<int>({1, 1, 2, 3, 4}), "Duplicate entry found");
+  // The uniqueness verification used to stop at the middle of the sorted
+  // array, missing duplicates in the second half.
+  EXPECT_DEATH(CreateFlatSet<int>({1, 2, 3, 4, 4}), "Duplicate entry found");
+}
+#endif  // defined(EXPECT_DEATH)
+
 }  // namespace
 }  // namespace mozc

--- a/src/base/container/flat_set_test.cc
+++ b/src/base/container/flat_set_test.cc
@@ -80,12 +80,21 @@ TEST(FlatSetTest, SingleElement) {
 
 #if defined(EXPECT_DEATH)
 TEST(FlatSetDeathTest, DuplicateEntries) {
+#if defined(_WIN32)
+  // On Windows, GoogleTest observes the child-process death, but the
+  // Abseil fatal log text may not be captured in the death-test output.
+  constexpr char kDuplicateEntryDeathRegex[] = ".*";
+#else
+  constexpr char kDuplicateEntryDeathRegex[] = "Duplicate entry found";
+#endif
   // Runtime construction with duplicate entries hits LOG(FATAL). Compile-time
   // construction with duplicate entries fails the build instead.
-  EXPECT_DEATH(CreateFlatSet<int>({1, 1, 2, 3, 4}), "Duplicate entry found");
+  EXPECT_DEATH(CreateFlatSet<int>({1, 1, 2, 3, 4}),
+               kDuplicateEntryDeathRegex);
   // The uniqueness verification used to stop at the middle of the sorted
   // array, missing duplicates in the second half.
-  EXPECT_DEATH(CreateFlatSet<int>({1, 2, 3, 4, 4}), "Duplicate entry found");
+  EXPECT_DEATH(CreateFlatSet<int>({1, 2, 3, 4, 4}),
+               kDuplicateEntryDeathRegex);
 }
 #endif  // defined(EXPECT_DEATH)
 


### PR DESCRIPTION
## 概要

upstream Mozcの`SortAndVerifyUnique`修正をMozkeyへ取り込みます。

* Upstream PR: `google/mozc#1538`
* Upstream commit: `d73e864c1d5c3357e00b3d346611dae489241038`
* Title: `Fix the loop condition in SortAndVerifyUnique`

## 変更内容

`SortAndVerifyUnique()`の重複検査ループを修正します。

```cpp
// 修正前
i + i < span.size()

// 修正後
i + 1 < span.size()
```

修正前は検査が配列の途中で終了するため、後半にある重複要素を見逃す可能性がありました。

また、要素数が1の場合には`span[i + 1]`が範囲外となり、定数評価に失敗する問題がありました。

## 影響

この処理はコンパイル時に評価される固定コンテナの検証処理です。

既存の登録内容には、今回の修正によって新たに拒否される重複要素がないことがupstreamで確認されています。

通常の変換処理、辞書内容、候補順位、設定形式には影響しません。

## Windows向けテスト適応

upstreamで追加されたdeath testは、重複検出による異常終了に加えて、エラーメッセージ`Duplicate entry found`も照合します。

Windows環境では子プロセスの異常終了は検出できる一方、Abseilのfatal log文字列がGoogleTestのdeath test出力へ渡らないため、メッセージ照合だけが失敗しました。

そのためWindowsでは異常終了そのものを検証し、Windows以外ではupstreamどおりエラーメッセージも検証します。

## 確認内容

以下のWindows releaseテストを実行し、すべて成功しました。

```text
//base/container:flat_set_test        PASSED
//base/container:flat_map_test        PASSED
//base/container:flat_multimap_test   PASSED
```

`flat_set_test`では次の回帰ケースも確認しています。

* 1要素の`FlatSet`を定数評価で構築できること
* 配列前半の重複を検出すること
* 配列後半の重複を検出すること
