### PR TITLE
Add placeholders for compiler_(gcc|msvc)_like configurations.

### DIFF
--- a/src/.bazelrc
+++ b/src/.bazelrc
@@ -62,6 +62,10 @@ build:compiler_msvc_like --cxxopt "/utf-8" --host_cxxopt "/utf-8"
 # Disable all warnings for external code.
 build:compiler_gcc_like  --per_file_copt="external/.*@-w" --host_per_file_copt="external/.*@-w"
 build:compiler_msvc_like --per_file_copt="external/.*@/w" --host_per_file_copt="external/.*@/w"
+# Placeholder for non-build configurations (e.g. `bazel mod`).
+# `--announce_rc=false` practically works as no-op. Explicit command line flag can override it.
+common:compiler_gcc_like --announce_rc=false
+common:compiler_msvc_like --announce_rc=false
 
 ## Linux specific options
 build:linux_env --build_tag_filters=-nolinux --copt "-fPIC"


### PR DESCRIPTION
## 概要

upstream MozcのBazel設定修正をMozkeyへ取り込みます。

* Upstream commit: `09d84bea9789bf36eb57afa1fdc320fb047f5f23`
* Title: `Add placeholders for compiler_(gcc|msvc)_like configurations.`

## 変更内容

`src/.bazelrc`へ、次の設定を追加します。

```text
common:compiler_gcc_like --announce_rc=false
common:compiler_msvc_like --announce_rc=false
```

プラットフォーム固有設定から参照される`compiler_gcc_like`と`compiler_msvc_like`について、`common`コマンド用のplaceholderを定義します。

## 背景

修正前は、Windows環境で通常のbuildやtestは実行できる一方、`bazelisk query`などの非buildコマンドを実行すると、次のエラーが発生しました。

```text
ERROR: Config value 'compiler_msvc_like' is not defined in any .rc file
```

`build:compiler_msvc_like`は定義されていましたが、`query`から参照できる`common:compiler_msvc_like`が存在しないことが原因です。

今回のplaceholder追加により、プラットフォーム固有設定を維持したまま、非buildコマンドでも設定名を解決できるようになります。

## 影響

この変更はBazelの設定解決だけに影響します。

以下には変更を加えません。

* Mozkeyの実行バイナリ
* 変換ロジック
* 辞書
* 候補順位
* Windowsへのインストール内容
* Zenz処理

## 確認内容

修正前に次の失敗を再現しました。

```text
bazelisk query //base/container:flat_set_test

ERROR: Config value 'compiler_msvc_like' is not defined in any .rc file
```

修正後、同じコマンドが成功しました。

```text
//base/container:flat_set_test
```

さらにWindows release構成で回帰テストを実行し、成功しました。

```text
//base/container:flat_set_test PASSED
```
