### PR TITLE
Use native macOS selection for live conversion

### DIFF
--- a/src/mac/mozc_imk_input_controller.h
+++ b/src/mac/mozc_imk_input_controller.h
@@ -65,6 +65,9 @@
    * should be -1. */
   int cursorPosition_;
 
+  /** True when AppKit should choose the native marked-text selection. */
+  bool useUnspecifiedSelectionRange_;
+
   /** |mode_| stores the current input mode (Direct or conversion). */
   mozc::commands::CompositionMode mode_;
 
@@ -187,6 +190,10 @@
  * @param preedit The protobuf data representing the composed string.
  */
 - (void)updateComposedString:(const mozc::commands::Preedit *)preedit;
+
+/** Updates the composed string with the display semantics of live conversion. */
+- (void)updateComposedString:(const mozc::commands::Preedit *)preedit
+              liveConversion:(bool)liveConversion;
 
 /** Updates |candidates_| from the result of a key event.
  *

--- a/src/mac/mozc_imk_input_controller.mm
+++ b/src/mac/mozc_imk_input_controller.mm
@@ -36,6 +36,7 @@
 
 #include <unistd.h>
 
+#include <algorithm>
 #include <cstdint>
 #include <cstdlib>
 #include <functional>
@@ -231,6 +232,24 @@ int32_t GetRendererAnchorPosition(const Output &output) {
   }
   return 0;
 }
+
+NSUInteger CodePointOffsetToUtf16Offset(NSString *text, uint32_t code_point_offset) {
+  const NSUInteger length = [text length];
+  NSUInteger utf16_offset = 0;
+  uint32_t current_code_point = 0;
+  while (utf16_offset < length && current_code_point < code_point_offset) {
+    const unichar first = [text characterAtIndex:utf16_offset];
+    ++utf16_offset;
+    if (first >= 0xD800 && first <= 0xDBFF && utf16_offset < length) {
+      const unichar second = [text characterAtIndex:utf16_offset];
+      if (second >= 0xDC00 && second <= 0xDFFF) {
+        ++utf16_offset;
+      }
+    }
+    ++current_code_point;
+  }
+  return utf16_offset;
+}
 }  // namespace
 
 @implementation MozcImkInputController
@@ -278,6 +297,7 @@ int32_t GetRendererAnchorPosition(const Output &output) {
   originalString_ = [[NSMutableString alloc] init];
   composedString_ = [[NSMutableAttributedString alloc] init];
   cursorPosition_ = -1;
+  useUnspecifiedSelectionRange_ = false;
   mode_ = mozc::commands::DIRECT;
   suppressSuggestion_ = false;
   yenSignCharacter_ = mozc::config::Config::YEN_SIGN;
@@ -649,7 +669,8 @@ int32_t GetRendererAnchorPosition(const Output &output) {
     }
   }
 
-  [self updateComposedString:&(output->preedit())];
+  [self updateComposedString:&(output->preedit())
+                liveConversion:output->live_conversion()];
   [self updateCandidates:output];
 
   if (output->has_mode()) {
@@ -758,28 +779,52 @@ int32_t GetRendererAnchorPosition(const Output &output) {
 }
 
 - (void)updateComposedString:(const Preedit *)preedit {
+  [self updateComposedString:preedit liveConversion:false];
+}
+
+- (void)updateComposedString:(const Preedit *)preedit
+              liveConversion:(bool)live_conversion {
   // If the last and the current composed string length is 0,
   // we don't update the composition.
-  if (([composedString_ length] == 0) && ((preedit == nullptr || preedit->segment_size() == 0))) {
+  if (([composedString_ length] == 0) &&
+      ((preedit == nullptr || preedit->segment_size() == 0))) {
     return;
   }
 
   [composedString_ deleteCharactersInRange:NSMakeRange(0, [composedString_ length])];
   cursorPosition_ = -1;
+  useUnspecifiedSelectionRange_ = false;
   if (preedit != nullptr) {
-    cursorPosition_ = preedit->cursor();
+    NSDictionary *highlightAttributes =
+        [self markForStyle:kTSMHiliteSelectedConvertedText
+                   atRange:NSMakeRange(NSNotFound, 0)];
+    NSDictionary *underlineAttributes =
+        [self markForStyle:kTSMHiliteConvertedText
+                   atRange:NSMakeRange(NSNotFound, 0)];
+
     for (size_t i = 0; i < preedit->segment_size(); ++i) {
-      NSDictionary *highlightAttributes = [self markForStyle:kTSMHiliteSelectedConvertedText
-                                                     atRange:NSMakeRange(NSNotFound, 0)];
-      NSDictionary *underlineAttributes = [self markForStyle:kTSMHiliteConvertedText
-                                                     atRange:NSMakeRange(NSNotFound, 0)];
       const Preedit::Segment &seg = preedit->segment(static_cast<int32_t>(i));
-      NSDictionary *attr = (seg.annotation() == Preedit::Segment::HIGHLIGHT) ? highlightAttributes
-                                                                             : underlineAttributes;
+      NSDictionary *attributes = nil;
+      if (!live_conversion) {
+        attributes = (seg.annotation() == Preedit::Segment::HIGHLIGHT)
+                         ? highlightAttributes
+                         : underlineAttributes;
+      }
       NSString *seg_string = [NSString stringWithUTF8String:seg.value().c_str()];
       NSAttributedString *seg_attributed_string =
-          [[NSAttributedString alloc] initWithString:seg_string attributes:attr];
+          [[NSAttributedString alloc] initWithString:seg_string attributes:attributes];
       [composedString_ appendAttributedString:seg_attributed_string];
+    }
+
+    if (live_conversion && [composedString_ length] > 0) {
+      // Live conversion is a conversion preview, not a focused-clause
+      // selection.  Leaving the selection unspecified lets AppKit keep its
+      // native insertion caret instead of showing Mozc's focused-clause
+      // boundary as the caret.
+      useUnspecifiedSelectionRange_ = true;
+    } else {
+      cursorPosition_ = static_cast<int>(
+          CodePointOffsetToUtf16Offset([composedString_ string], preedit->cursor()));
     }
   }
   if ([composedString_ length] == 0) {
@@ -812,6 +857,7 @@ int32_t GetRendererAnchorPosition(const Output &output) {
   return composedString_;
 }
 
+
 - (void)clearCandidates {
   hasLiveConversionAnchorLeft_ = false;
   allowCandidateWindowForLiveConversion_ = false;
@@ -826,6 +872,9 @@ int32_t GetRendererAnchorPosition(const Output &output) {
 // |selecrionRange| method is defined at IMKInputController class and
 // means the position of cursor actually.
 - (NSRange)selectionRange {
+  if (useUnspecifiedSelectionRange_) {
+    return NSMakeRange(NSNotFound, 0);
+  }
   if (imkClientForTest_) {
     return NSMakeRange(cursorPosition_, 0);
   }

--- a/src/mac/mozc_imk_input_controller_test.mm
+++ b/src/mac/mozc_imk_input_controller_test.mm
@@ -88,6 +88,7 @@
   NSRange expectedRange;
   NSDictionary *expectedAttributes;
   int lastCharacterIndex_;
+  NSRange lastMarkedSelectionRange_;
   std::string selectedMode_;
   NSString *insertedText_;
   NSString *overriddenLayout_;
@@ -99,6 +100,7 @@
 @property(readwrite) NSDictionary *expectedAttributes;
 @property(readwrite, assign) NSRange expectedRange;
 @property(readonly) int lastCharacterIndex;
+@property(readonly) NSRange lastMarkedSelectionRange;
 @property(readonly) std::string selectedMode;
 @property(readonly) NSString *insertedText;
 @property(readonly) NSString *overriddenLayout;
@@ -110,6 +112,7 @@
 @synthesize expectedAttributes;
 @synthesize expectedRange;
 @synthesize lastCharacterIndex = lastCharacterIndex_;
+@synthesize lastMarkedSelectionRange = lastMarkedSelectionRange_;
 @synthesize selectedMode = selectedMode_;
 @synthesize insertedText = insertedText_;
 @synthesize overriddenLayout = overriddenLayout_;
@@ -119,6 +122,7 @@
   self.bundleIdentifier = @"com.google.exampleBundle";
   expectedRange = NSMakeRange(NSNotFound, NSNotFound);
   lastCharacterIndex_ = NSNotFound;
+  lastMarkedSelectionRange_ = NSMakeRange(NSNotFound, NSNotFound);
   return self;
 }
 
@@ -171,7 +175,8 @@
 - (void)setMarkedText:(id)string
        selectionRange:(NSRange)selectionRange
      replacementRange:(NSRange)replacementRange {
-  // Do nothing
+  counters_["setMarkedText:selectionRange:replacementRange:"]++;
+  lastMarkedSelectionRange_ = selectionRange;
 }
 
 - (void)insertText:(NSString *)result replacementRange:(NSRange)range {
@@ -330,7 +335,7 @@ bool ComparePreedit(NSAttributedString *expected, NSAttributedString *actual) {
     // Check attributes for underlines
     NSNumber *expectedUnderlineStyle =
         [expectedAttributes valueForKey:NSUnderlineStyleAttributeName];
-    NSNumber *actualUnderlineStyle = [expectedAttributes valueForKey:NSUnderlineStyleAttributeName];
+    NSNumber *actualUnderlineStyle = [actualAttributes valueForKey:NSUnderlineStyleAttributeName];
     if (![expectedUnderlineStyle isEqualToNumber:actualUnderlineStyle] ||
         actualUnderlineStyle == nil) {
       LOG(ERROR) << "underline style is different at range (" << expectedRange.location << ", "
@@ -424,6 +429,138 @@ TEST_F(MozcImkInputControllerTest, UpdateComposedString) {
   NSAttributedString *actual = [controller_ composedString:nil];
   EXPECT_TRUE(ComparePreedit(expected, actual))
       << [[NSString stringWithFormat:@"expected:%@ actual:%@", expected, actual] UTF8String];
+}
+
+TEST_F(MozcImkInputControllerTest, ExplicitConversionPreservesFocusedClauseCursor) {
+  commands::Preedit preedit;
+  preedit.set_cursor(4);
+
+  commands::Preedit::Segment *segment = preedit.add_segment();
+  segment->set_annotation(commands::Preedit::Segment::HIGHLIGHT);
+  segment->set_value("どういう");
+  segment->set_value_length(4);
+
+  segment = preedit.add_segment();
+  segment->set_annotation(commands::Preedit::Segment::UNDERLINE);
+  segment->set_value("こと");
+  segment->set_value_length(2);
+
+  [controller_ updateComposedString:&preedit];
+
+  EXPECT_TRUE(NSEqualRanges(mock_client_.lastMarkedSelectionRange, NSMakeRange(4, 0)));
+  NSDictionary *highlightAttributes =
+      [controller_ markForStyle:kTSMHiliteSelectedConvertedText
+                        atRange:NSMakeRange(NSNotFound, 0)];
+  NSDictionary *underlineAttributes =
+      [controller_ markForStyle:kTSMHiliteConvertedText
+                        atRange:NSMakeRange(NSNotFound, 0)];
+  NSMutableAttributedString *expected =
+      [[NSMutableAttributedString alloc] initWithString:@"どういうこと"];
+  [expected addAttributes:highlightAttributes range:NSMakeRange(0, 4)];
+  [expected addAttributes:underlineAttributes range:NSMakeRange(4, 2)];
+  NSAttributedString *actual = [controller_ composedString:nil];
+  EXPECT_TRUE(ComparePreedit(expected, actual))
+      << [[NSString stringWithFormat:@"expected:%@ actual:%@", expected, actual] UTF8String];
+}
+
+TEST_F(MozcImkInputControllerTest,
+       LiveConversionUsesUnfocusedTextAndUnspecifiedSelection) {
+  commands::Preedit preedit;
+  preedit.set_cursor(4);
+
+  commands::Preedit::Segment *segment = preedit.add_segment();
+  segment->set_annotation(commands::Preedit::Segment::HIGHLIGHT);
+  segment->set_value("どういう");
+  segment->set_value_length(4);
+
+  segment = preedit.add_segment();
+  segment->set_annotation(commands::Preedit::Segment::UNDERLINE);
+  segment->set_value("こと");
+  segment->set_value_length(2);
+
+  [controller_ updateComposedString:&preedit liveConversion:true];
+
+  EXPECT_TRUE(NSEqualRanges(mock_client_.lastMarkedSelectionRange,
+                            NSMakeRange(NSNotFound, 0)));
+  NSAttributedString *actual = [controller_ composedString:nil];
+  EXPECT_EQ([actual length], 6);
+  EXPECT_EQ([[actual attributesAtIndex:0 effectiveRange:nullptr] count], 0);
+  EXPECT_EQ([[actual attributesAtIndex:4 effectiveRange:nullptr] count], 0);
+  EXPECT_EQ([mock_client_ getCounter:"attributesForCharacterIndex:lineHeightRectangle:"], 0);
+}
+
+TEST_F(MozcImkInputControllerTest, ProcessOutputAppliesLiveConversionPresentation) {
+  commands::Output output;
+  output.set_consumed(true);
+  output.set_live_conversion(true);
+  commands::Preedit *preedit = output.mutable_preedit();
+  preedit->set_cursor(1);
+  commands::Preedit::Segment *segment = preedit->add_segment();
+  segment->set_annotation(commands::Preedit::Segment::HIGHLIGHT);
+  segment->set_value("愛");
+  segment->set_value_length(1);
+
+  [controller_ processOutput:&output client:mock_client_];
+
+  EXPECT_TRUE(NSEqualRanges(mock_client_.lastMarkedSelectionRange,
+                            NSMakeRange(NSNotFound, 0)));
+  NSAttributedString *actual = [controller_ composedString:nil];
+  EXPECT_EQ([[actual attributesAtIndex:0 effectiveRange:nullptr] count], 0);
+}
+
+TEST_F(MozcImkInputControllerTest, CompositionConvertsCodePointCursorToUtf16) {
+  commands::Preedit preedit;
+  preedit.set_cursor(1);
+
+  commands::Preedit::Segment *segment = preedit.add_segment();
+  segment->set_annotation(commands::Preedit::Segment::UNDERLINE);
+  segment->set_value("😀あ");
+  segment->set_value_length(2);
+
+  [controller_ updateComposedString:&preedit];
+
+  EXPECT_TRUE(NSEqualRanges(mock_client_.lastMarkedSelectionRange, NSMakeRange(2, 0)));
+}
+
+TEST_F(MozcImkInputControllerTest, LiveConversionUsesDisplayedValueWithoutClauseFocus) {
+  commands::Preedit preedit;
+  preedit.set_cursor(2);
+
+  commands::Preedit::Segment *segment = preedit.add_segment();
+  segment->set_annotation(commands::Preedit::Segment::HIGHLIGHT);
+  segment->set_key("あい");
+  segment->set_value("愛");
+  segment->set_value_length(1);
+
+  [controller_ updateComposedString:&preedit liveConversion:true];
+
+  EXPECT_TRUE(NSEqualRanges(mock_client_.lastMarkedSelectionRange,
+                            NSMakeRange(NSNotFound, 0)));
+  NSAttributedString *actual = [controller_ composedString:nil];
+  EXPECT_TRUE([[actual string] isEqualToString:@"愛"]);
+  EXPECT_EQ([[actual attributesAtIndex:0 effectiveRange:nullptr] count], 0);
+}
+
+TEST_F(MozcImkInputControllerTest, ExplicitCompositionRestoresSpecifiedSelectionAfterLiveConversion) {
+  commands::Preedit live_preedit;
+  live_preedit.set_cursor(1);
+  commands::Preedit::Segment *segment = live_preedit.add_segment();
+  segment->set_annotation(commands::Preedit::Segment::HIGHLIGHT);
+  segment->set_value("愛");
+  segment->set_value_length(1);
+  [controller_ updateComposedString:&live_preedit liveConversion:true];
+  ASSERT_TRUE(NSEqualRanges(mock_client_.lastMarkedSelectionRange,
+                            NSMakeRange(NSNotFound, 0)));
+
+  commands::Preedit composition;
+  composition.set_cursor(1);
+  segment = composition.add_segment();
+  segment->set_annotation(commands::Preedit::Segment::UNDERLINE);
+  segment->set_value("あ");
+  segment->set_value_length(1);
+  [controller_ updateComposedString:&composition];
+
+  EXPECT_TRUE(NSEqualRanges(mock_client_.lastMarkedSelectionRange, NSMakeRange(1, 0)));
 }
 
 TEST_F(MozcImkInputControllerTest, ClearCandidates) {


### PR DESCRIPTION
## 概要

macOSのライブ変換中に、変換文節の途中へカーソルが表示される問題を修正します。

ライブ変換中はフォーカス文節として扱わず、InputMethodKit側のネイティブな選択状態を使用することで、未確定文字列の末尾へカーソルを表示します。

## 変更内容

- `Output.live_conversion`をpreedit表示処理へ渡すように変更
- ライブ変換中は文節のハイライト・下線属性を付与しない
- ライブ変換中の`selectionRange`を未指定として扱う
- 通常入力時のカーソル位置をUnicodeコードポイント単位からUTF-16単位へ変換
- ライブ変換、通常変換、サロゲートペアを含む文字列のテストを追加

Spaceによる通常変換時の文節表示とカーソル位置は、従来のmacOS動作を維持します。

## 確認内容

- `//mac:mozc_imk_input_controller_test`が成功
- arm64向けmacOSパッケージのビルドが成功
- TextEditでライブ変換中のカーソルが未確定文字列末尾へ表示されることを確認
- 追加入力、Backspace、Enter確定が正常に動作することを確認
- 人工的なカーソルウィンドウを使用していないことを確認
