### PR TITLE
Fix Enter during pending live conversion

### DIFF
--- a/src/session/session.cc
+++ b/src/session/session.cc
@@ -3052,8 +3052,33 @@ std::unique_ptr<ImeContext> Session::CreateContext(
 }
 
 void Session::PushUndoContext() {
-  // Copy the current context and push it to the undo stack.
-  undo_contexts_.emplace_back(std::make_unique<ImeContext>(*context_));
+  UndoEntry entry;
+  entry.context = std::make_unique<ImeContext>(*context_);
+
+  // A pending live-conversion preedit is partly owned by Session rather than
+  // ImeContext: the converted stable prefix and the raw suffix are composed at
+  // output time. Preserve that display state so Undo can restore exactly what
+  // the user saw before submitting it. Generation numbers are intentionally not
+  // stored; PopUndoContext() issues a fresh generation to keep old callbacks
+  // stale.
+  if (live_conversion_pending_ &&
+      context_->state() == ImeContext::COMPOSITION) {
+    PendingLiveConversionUndoState state;
+    state.pending_key = pending_live_conversion_key_;
+    state.pending_input = pending_live_conversion_input_;
+    state.pending_suggestion_candidate_window =
+        pending_live_conversion_suggestion_candidate_window_;
+    state.live_suggestion_candidate_window =
+        live_conversion_suggestion_candidate_window_;
+    state.live_key = live_conversion_key_;
+    state.live_preedit = live_conversion_preedit_;
+    state.live_value = live_conversion_value_;
+    state.live_preedit_output = live_conversion_preedit_output_;
+    entry.pending_live_conversion = std::move(state);
+  }
+
+  undo_contexts_.push_back(std::move(entry));
+
   // If the stack size exceeds the limitation, purge the oldest entries.
   while (undo_contexts_.size() > kMultipleUndoMaxSize) {
     undo_contexts_.pop_front();
@@ -3061,12 +3086,56 @@ void Session::PushUndoContext() {
   DCHECK_LE(undo_contexts_.size(), kMultipleUndoMaxSize);
 }
 
+void Session::PushDirectCommitUndoContext() {
+  PushUndoContext();
+  DCHECK(!undo_contexts_.empty());
+  undo_contexts_.back().revert_converter_on_undo = false;
+}
+
 void Session::PopUndoContext() {
   if (!HasUndoContext()) {
     return;
   }
-  context_ = std::move(undo_contexts_.back());
+
+  UndoEntry entry = std::move(undo_contexts_.back());
   undo_contexts_.pop_back();
+  context_ = std::move(entry.context);
+
+  // Invalidate every callback issued before Undo. If the restored entry was
+  // pending, it receives a new generation and a new callback from Undo().
+  ClearLiveConversionState();
+
+  if (!entry.pending_live_conversion.has_value() ||
+      context_->state() != ImeContext::COMPOSITION) {
+    return;
+  }
+
+  PendingLiveConversionUndoState& state =
+      *entry.pending_live_conversion;
+  const std::string current_key =
+      context_->composer().GetQueryForConversion();
+  if (state.pending_key.empty() || state.pending_key != current_key) {
+    return;
+  }
+
+  live_conversion_pending_ = true;
+  pending_live_conversion_generation_ = live_conversion_generation_;
+  pending_live_conversion_key_ = std::move(state.pending_key);
+  pending_live_conversion_input_ = std::move(state.pending_input);
+  pending_live_conversion_suggestion_candidate_window_ =
+      std::move(state.pending_suggestion_candidate_window);
+  live_conversion_suggestion_candidate_window_ =
+      std::move(state.live_suggestion_candidate_window);
+  live_conversion_key_ = std::move(state.live_key);
+  live_conversion_preedit_ = std::move(state.live_preedit);
+  live_conversion_value_ = std::move(state.live_value);
+  live_conversion_preedit_output_ =
+      std::move(state.live_preedit_output);
+}
+
+bool Session::ShouldRevertConverterOnUndo() const {
+  return HasUndoContext() &&
+         undo_contexts_.back().revert_converter_on_undo;
 }
 
 void Session::ClearUndoContext() { undo_contexts_.clear(); }
@@ -4534,8 +4603,12 @@ bool Session::Undo(commands::Command* command) {
     return DoNothing(command);
   }
 
-  // Rollback the last user history.
-  context_->mutable_converter()->Revert();
+  // Roll back converter learning only for commit paths that actually used the
+  // converter. Pending-display Submit commits a visible string directly and
+  // therefore has no converter learning to revert.
+  if (ShouldRevertConverterOnUndo()) {
+    context_->mutable_converter()->Revert();
+  }
 
   size_t result_size = 0;
   int32_t cursor_offset = 0;
@@ -4556,6 +4629,20 @@ bool Session::Undo(commands::Command* command) {
         command->mutable_output()->mutable_deletion_range();
     range->set_offset(-(static_cast<int32_t>(result_size) + cursor_offset));
     range->set_length(result_size);
+  }
+
+  if (live_conversion_pending_ &&
+      context_->state() == ImeContext::COMPOSITION) {
+    if (OutputPendingLiveConversion(command)) {
+      AttachCachedLiveConversionSuggestionCandidateWindow(
+          command->mutable_output());
+      AttachDelayedLiveConversionCallback(command);
+      return true;
+    }
+
+    // A corrupted or incompatible snapshot must degrade to ordinary
+    // composition rather than leave an unserviceable pending state.
+    CancelPendingLiveConversion();
   }
 
   Output(command);
@@ -5138,30 +5225,6 @@ bool Session::ApplyDelayedLiveConversion(commands::Command* command) {
   }
 
   return MaybeStartLiveConversion(command);
-}
-
-bool Session::FlushPendingLiveConversion() {
-  if (!live_conversion_pending_) {
-    return false;
-  }
-
-  if (context_->state() != ImeContext::COMPOSITION) {
-    CancelPendingLiveConversion();
-    return false;
-  }
-
-  const std::string current_key = context_->composer().GetQueryForConversion();
-  if (current_key != pending_live_conversion_key_ ||
-      ShouldSkipLiveConversionForCompositionKey(
-          current_key,
-          GetLiveConversionCommittedLeftBoundary(*context_),
-          GetLiveConversionMinKeyLength(context_->GetConfig()))) {
-    CancelPendingLiveConversion();
-    return false;
-  }
-
-  commands::Command dummy_command;
-  return MaybeStartLiveConversion(&dummy_command);
 }
 
 std::string Session::ExtractZenzLeftContext(uint32_t max_chars) const {
@@ -7014,12 +7077,12 @@ bool Session::CommitLiveConversionResult(commands::Command* command) {
   return true;
 }
 
-bool Session::CommitPendingLiveConversionDisplayDirectly(
-    commands::Command* command) {
-  const std::string key = context_->composer().GetQueryForConversion();
-  const std::string raw_preedit = context_->composer().GetStringForPreedit();
-
-  std::string value;
+std::pair<std::string, std::string>
+Session::GetPendingLiveConversionDisplayCommitStrings() const {
+  const std::string key =
+      context_->composer().GetQueryForConversion();
+  const std::string raw_preedit =
+      context_->composer().GetStringForPreedit();
 
   const bool has_stable_live_conversion =
       !live_conversion_key_.empty() &&
@@ -7030,17 +7093,49 @@ bool Session::CommitPendingLiveConversionDisplayDirectly(
   if (has_stable_live_conversion &&
       StartsWithString(key, live_conversion_key_) &&
       StartsWithString(raw_preedit, live_conversion_preedit_)) {
-    const std::string suffix_value =
-        raw_preedit.substr(live_conversion_preedit_.size());
-
-    value = live_conversion_value_;
-    value.append(suffix_value);
-  } else {
-    value = context_->composer().GetStringForSubmission();
+    std::string value = live_conversion_value_;
+    value.append(raw_preedit.substr(live_conversion_preedit_.size()));
+    return {key, std::move(value)};
   }
+
+  return {key, context_->composer().GetStringForSubmission()};
+}
+
+bool Session::CommitPendingLiveConversionDisplayDirectly(
+    commands::Command* command) {
+  auto [key, value] =
+      GetPendingLiveConversionDisplayCommitStrings();
 
   ClearLiveConversionState();
   CommitStringDirectly(key, value, command);
+  return true;
+}
+
+bool Session::CommitPendingLiveConversionDisplayForSubmit(
+    commands::Command* command) {
+  if (!live_conversion_pending_ ||
+      context_->state() != ImeContext::COMPOSITION) {
+    return false;
+  }
+
+  auto [key, value] =
+      GetPendingLiveConversionDisplayCommitStrings();
+  if (key.empty() || value.empty()) {
+    CancelPendingLiveConversion();
+    return false;
+  }
+
+  // Enter accepts only the preedit already visible to the user. The pending
+  // converter result is speculative and must not be materialized, committed,
+  // or learned. Unlike direct-commit punctuation, Enter preserves Mozc Undo.
+  PushDirectCommitUndoContext();
+  ClearPendingRerankedPreeditCommitAfterConvertCancel();
+  ClearLiveConversionState();
+  CommitStringDirectly(key, value, command);
+
+  // Undo() reads the committed result from context_->output() to build the
+  // deletion range before restoring the pending preedit snapshot.
+  *context_->mutable_output() = command->output();
   return true;
 }
 
@@ -7743,7 +7838,10 @@ bool Session::Commit(commands::Command* command) {
     return true;
   }
 
-  FlushPendingLiveConversion();
+  if (CommitPendingLiveConversionDisplayForSubmit(command)) {
+    return true;
+  }
+
   return CommitInternal(command,
                         context_->GetRequest().zero_query_suggestion());
 }

--- a/src/session/session.h
+++ b/src/session/session.h
@@ -36,6 +36,7 @@
 #include <cstdint>
 #include <deque>
 #include <memory>
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
@@ -441,14 +442,33 @@ class Session {
   ZenzFeedbackStore zenz_feedback_store_;
   std::unique_ptr<ZenzLiveCorrector> zenz_live_corrector_;
 
+  struct PendingLiveConversionUndoState {
+    std::string pending_key;
+    commands::Input pending_input;
+    commands::CandidateWindow pending_suggestion_candidate_window;
+    commands::CandidateWindow live_suggestion_candidate_window;
+    std::string live_key;
+    std::string live_preedit;
+    std::string live_value;
+    commands::Preedit live_preedit_output;
+  };
+
+  struct UndoEntry {
+    std::unique_ptr<ImeContext> context;
+    std::optional<PendingLiveConversionUndoState> pending_live_conversion;
+    bool revert_converter_on_undo = true;
+  };
+
   // Undo stack. *begin is the oldest, and *back is the newest.
-  std::deque<std::unique_ptr<ImeContext>> undo_contexts_;
+  std::deque<UndoEntry> undo_contexts_;
 
   std::unique_ptr<ImeContext> CreateContext(
       const EngineInterface& engine) const;
 
   void PushUndoContext();
+  void PushDirectCommitUndoContext();
   void PopUndoContext();
+  bool ShouldRevertConverterOnUndo() const;
   // Clear the undo context.
   // This should be called when the composer's preedit or cursor position
   // is updated by non-undo related operations. This achieves intuitive
@@ -541,7 +561,6 @@ class Session {
   bool MaybeStartLiveConversion(mozc::commands::Command* command);
   bool MaybeScheduleLiveConversion(mozc::commands::Command* command);
   bool ApplyDelayedLiveConversion(mozc::commands::Command* command);
-  bool FlushPendingLiveConversion();
   bool IgnoreStaleDelayedLiveConversion(mozc::commands::Command* command);
   void CancelPendingLiveConversion();
   void ClearLiveConversionState();
@@ -561,7 +580,11 @@ class Session {
   bool AttachCachedLiveConversionSuggestionCandidateWindow(
       mozc::commands::Output* output);
   bool CommitLiveConversionResult(mozc::commands::Command* command);
+  std::pair<std::string, std::string>
+  GetPendingLiveConversionDisplayCommitStrings() const;
   bool CommitPendingLiveConversionDisplayDirectly(
+      mozc::commands::Command* command);
+  bool CommitPendingLiveConversionDisplayForSubmit(
       mozc::commands::Command* command);
   bool OutputPendingLiveConversion(mozc::commands::Command* command) const;
   void AttachDelayedLiveConversionCallback(

--- a/src/session/session_test.cc
+++ b/src/session/session_test.cc
@@ -108,6 +108,7 @@ class SessionTestPeer : testing::TestPeer<Session> {
   PEER_METHOD(HandlePendingDirectCommitLearningForSessionCommand);
   PEER_METHOD(Suggest);
   PEER_METHOD(MaybeStartLiveConversion);
+  PEER_METHOD(OutputPendingLiveConversion);
   PEER_METHOD(AttachLiveConversionSuggestionCandidateWindow);
   PEER_METHOD(AttachCachedLiveConversionSuggestionCandidateWindow);
 
@@ -3052,6 +3053,125 @@ TEST_F(SessionTest, LiveConversionHonorsRaisedMinKeyLength) {
   EXPECT_EQ(session.context().state(), ImeContext::CONVERSION);
   EXPECT_TRUE(command.output().live_conversion());
   EXPECT_TRUE(EnsurePreedit("愛雨", command));
+}
+
+TEST_F(SessionTest,
+       PendingLiveConversionEnterCommitsVisibleRawPreeditWithoutConversion) {
+  MockEngine engine;
+  std::shared_ptr<MockConverter> converter = CreateEngineConverterMock(&engine);
+
+  Session session(engine);
+  SessionTestPeer session_peer(session);
+  InitSessionToPrecomposition(&session);
+
+  config::Config config;
+  config::ConfigHandler::GetDefaultConfig(&config);
+  config.set_use_live_conversion(true);
+  config.set_live_conversion_delay_msec(1000);
+  config.set_live_conversion_min_key_length(1);
+  session.SetConfig(config);
+
+  commands::Command command;
+  InsertCharacterString("あめ", "ab", &session, &command);
+
+  ASSERT_EQ(session.context().state(), ImeContext::COMPOSITION);
+  ASSERT_TRUE(session_peer.live_conversion_pending_());
+  ASSERT_TRUE(command.output().live_conversion_pending());
+  EXPECT_PREEDIT("あめ", command);
+
+  EXPECT_CALL(*converter, StartConversion(_, _)).Times(0);
+
+  command.Clear();
+  ASSERT_TRUE(SendSpecialKey(commands::KeyEvent::ENTER, &session, &command));
+
+  EXPECT_RESULT("あめ", command);
+  EXPECT_FALSE(command.output().has_preedit());
+  EXPECT_EQ(session.context().state(), ImeContext::PRECOMPOSITION);
+  EXPECT_FALSE(session_peer.live_conversion_pending_());
+}
+
+TEST_F(SessionTest,
+       PendingLiveConversionEnterCommitsVisibleStablePrefixAndUndoRestoresIt) {
+  MockEngine engine;
+  std::shared_ptr<MockConverter> converter = CreateEngineConverterMock(&engine);
+
+  Session session(engine);
+  SessionTestPeer session_peer(session);
+  InitSessionToPrecomposition(&session);
+
+  config::Config config;
+  config::ConfigHandler::GetDefaultConfig(&config);
+  config.set_use_live_conversion(true);
+  config.set_live_conversion_delay_msec(1000);
+  config.set_live_conversion_min_key_length(1);
+  session.SetConfig(config);
+
+  commands::Capability capability;
+  capability.set_text_deletion(commands::Capability::DELETE_PRECEDING_TEXT);
+  session.set_client_capability(capability);
+
+  commands::Command command;
+  InsertCharacterString("きょうはあめ", "abcdef", &session, &command);
+
+  ASSERT_EQ(session.context().state(), ImeContext::COMPOSITION);
+  ASSERT_TRUE(session_peer.live_conversion_pending_());
+  ASSERT_TRUE(command.output().has_callback());
+  ASSERT_TRUE(command.output().callback().has_session_command());
+  const commands::SessionCommand old_delayed_command =
+      command.output().callback().session_command();
+
+  session_peer.live_conversion_key_() = "きょうは";
+  session_peer.live_conversion_preedit_() = "きょうは";
+  session_peer.live_conversion_value_() = "今日は";
+
+  commands::Preedit& live_preedit =
+      session_peer.live_conversion_preedit_output_();
+  live_preedit.Clear();
+  commands::Preedit::Segment* segment = live_preedit.add_segment();
+  segment->set_key("きょうは");
+  segment->set_value("今日は");
+  segment->set_value_length(Util::CharsLen("今日は"));
+
+  command.Clear();
+  ASSERT_TRUE(session_peer.OutputPendingLiveConversion(&command));
+  EXPECT_PREEDIT("今日はあめ", command);
+
+  EXPECT_CALL(*converter, StartConversion(_, _)).Times(0);
+
+  command.Clear();
+  ASSERT_TRUE(SendSpecialKey(commands::KeyEvent::ENTER, &session, &command));
+
+  EXPECT_RESULT("今日はあめ", command);
+  EXPECT_FALSE(command.output().has_preedit());
+  EXPECT_EQ(session.context().state(), ImeContext::PRECOMPOSITION);
+  EXPECT_FALSE(session_peer.live_conversion_pending_());
+
+  command.Clear();
+  ASSERT_TRUE(session.Undo(&command));
+
+  ASSERT_TRUE(command.output().has_deletion_range());
+  EXPECT_EQ(command.output().deletion_range().offset(), -5);
+  EXPECT_EQ(command.output().deletion_range().length(), 5);
+  EXPECT_PREEDIT("今日はあめ", command);
+  EXPECT_EQ(session.context().state(), ImeContext::COMPOSITION);
+  EXPECT_TRUE(session_peer.live_conversion_pending_());
+  ASSERT_TRUE(command.output().has_callback());
+  ASSERT_TRUE(command.output().callback().has_session_command());
+  const commands::SessionCommand new_delayed_command =
+      command.output().callback().session_command();
+  EXPECT_NE(new_delayed_command.live_conversion_generation(),
+            old_delayed_command.live_conversion_generation());
+
+  // The callback issued before Enter must remain stale even after Undo.
+  command.Clear();
+  command.mutable_input()->set_type(commands::Input::SEND_COMMAND);
+  *command.mutable_input()->mutable_command() = old_delayed_command;
+  ASSERT_TRUE(session.SendCommand(&command));
+
+  EXPECT_PREEDIT("今日はあめ", command);
+  EXPECT_TRUE(command.output().live_conversion_pending());
+  EXPECT_EQ(session.context().state(), ImeContext::COMPOSITION);
+  EXPECT_TRUE(session_peer.live_conversion_pending_());
 }
 
 TEST_F(SessionTest,


### PR DESCRIPTION
## 概要 #188 

ライブ変換の遅延処理待機中に Enter を押した際、画面にまだ表示されていない変換結果が確定される問題を修正しました。

## 変更内容

* Enter 押下時は、未実行の変換結果ではなく表示中の preedit をそのまま確定
* 変換済みの接頭部と未変換の接尾部を含む表示状態を Undo 用に保存
* 直接確定時は converter の学習を行わず、Undo 時の不要な `Revert()` を抑止
* Undo 後に古い遅延ライブ変換コールバックが適用されないよう generation を更新
* pending 全体および変換済み接頭部を含むケースのテストを追加

## 確認内容

* `SessionTest.PendingLiveConversionEnter*` 成功
* `//session:session_test` 全体成功
* `//server:mozc_server` ビルド成功
* Windows 実機で Enter、Undo、句読点の挙動を確認
