### PR TITLE
Fix macOS live conversion candidate navigation

### DIFF
--- a/src/mac/mozc_imk_input_controller.mm
+++ b/src/mac/mozc_imk_input_controller.mm
@@ -1113,10 +1113,12 @@ NSUInteger CodePointOffsetToUtf16Offset(NSString *text, uint32_t code_point_offs
   }
   keyEvent.set_mode(mode_);
 
-  if (useLiveConversion_) {
-    allowCandidateWindowForLiveConversion_ =
-        keyEvent.has_special_key() &&
-      keyEvent.special_key() == mozc::commands::KeyEvent::SPACE;
+  if (useLiveConversion_ && keyEvent.has_special_key() &&
+      keyEvent.special_key() == mozc::commands::KeyEvent::SPACE) {
+    // This flag represents the explicit conversion state, not a property
+    // of the current key.  Keep it enabled during candidate navigation.
+    // updateCandidates() or clearCandidates() resets it when that state ends.
+    allowCandidateWindowForLiveConversion_ = true;
   }
 
   if ([composedString_ length] == 0 && CanSelectedRange(clientBundle_) &&

--- a/src/mac/mozc_imk_input_controller_test.mm
+++ b/src/mac/mozc_imk_input_controller_test.mm
@@ -674,6 +674,49 @@ TEST_F(MozcImkInputControllerTest,
   EXPECT_TRUE(controller_.rendererCommand.visible());
 }
 
+TEST_F(MozcImkInputControllerTest,
+       DownKeepsExplicitCandidateWindowVisibleDuringLiveConversion) {
+  controller_.mode = commands::HIRAGANA;
+  controller_.useLiveConversionForTest = true;
+  controller_.allowCandidateWindowForLiveConversionForTest = true;
+
+  commands::Output output;
+  output.set_consumed(true);
+
+  commands::CandidateWindow *candidate_window =
+      output.mutable_candidate_window();
+  candidate_window->set_focused_index(1);
+  candidate_window->set_size(2);
+
+  commands::CandidateWindow::Candidate *candidate =
+      candidate_window->add_candidate();
+  candidate->set_index(0);
+  candidate->set_value("abc");
+
+  candidate = candidate_window->add_candidate();
+  candidate->set_index(1);
+  candidate->set_value("def");
+
+  mock_client_.expectedCursor = NSMakeRect(50, 50, 1, 10);
+  mock_client_.expectedAttributes =
+      @{@"IMKBaseline" : [NSValue valueWithPoint:NSMakePoint(50, 718)]};
+
+  EXPECT_CALL(*mock_mozc_client_,
+              SendKeyWithContext(
+                  HasSpecialKey(commands::KeyEvent::DOWN), _, NotNull()))
+      .WillOnce(DoAll(SetArgPointee<2>(output), Return(true)));
+
+  EXPECT_TRUE(SendKeyEvent(kVK_DownArrow, controller_, mock_client_));
+
+  [[NSRunLoop currentRunLoop]
+      runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.1]];
+
+  EXPECT_TRUE(controller_.allowCandidateWindowForLiveConversionForTest);
+  EXPECT_TRUE(controller_.rendererCommand.visible());
+  EXPECT_EQ(
+      controller_.rendererCommand.output().candidate_window().focused_index(),
+      1);
+}
 TEST_F(MozcImkInputControllerTest, UpdateCandidatesForLiveConversionWithoutCandidateWindow) {
   commands::Output output;
   output.set_live_conversion(true);


### PR DESCRIPTION
## 概要

macOSでライブ変換中にSpaceで候補ウィンドウを表示した後、上下キーで候補を移動すると候補ウィンドウが閉じる問題を修正します。

## 変更内容

* Spaceによる明示的な候補表示状態を保持
* 上下キーなどの候補移動中は候補ウィンドウを維持
* 通常入力や確定など、候補操作以外では状態をリセット
* 回帰テストを追加

## 確認内容

* macOS arm64でクリーンビルド
* 通常入力
* Zenzライブ補正
* Spaceによる候補表示
* 上下キーによる候補移動
* 候補移動中も候補ウィンドウが閉じないこと
