### PR TITLE
Show suggestions during macOS live conversion

### DIFF
--- a/src/mac/mozc_imk_input_controller.h
+++ b/src/mac/mozc_imk_input_controller.h
@@ -104,9 +104,6 @@
   /** True when the current config enables live conversion. */
   bool useLiveConversion_;
 
-  /** True after explicit conversion request so candidate UI may be shown. */
-  bool allowCandidateWindowForLiveConversion_;
-
   /** Latest delayed callback requested by Output::Callback. */
   std::unique_ptr<mozc::commands::SessionCommand> delayedSessionCommand_;
   __weak id delayedSessionCommandClient_;
@@ -132,7 +129,6 @@
 @property(readwrite, assign) NSRange replacementRange;
 @property(readwrite, retain) id imkClientForTest;
 @property(readwrite, assign) bool useLiveConversionForTest;
-@property(readwrite, assign) bool allowCandidateWindowForLiveConversionForTest;
 
 /** Sets the RendererReceiver used by all instances of the controller.
  * the RendererReceiver is a singleton object used as a proxy to receive messages from

--- a/src/mac/mozc_imk_input_controller.mm
+++ b/src/mac/mozc_imk_input_controller.mm
@@ -190,13 +190,22 @@ bool ShouldDisplayRendererForOutput(const Output &output) {
          (output.live_conversion() && output.has_preedit());
 }
 
-bool ShouldSuppressCandidateWindowForLiveConversion(const Output &output,
-                                                   bool use_live_conversion,
-                                                   bool allow_candidate_window) {
-  return use_live_conversion && !allow_candidate_window &&
-         output.has_candidate_window() &&
-         output.candidate_window().candidate_size() > 0 &&
-         !output.live_conversion();
+bool ShouldSuppressCandidateWindowForLiveConversion(
+    const Output &output, bool use_live_conversion) {
+  if (!use_live_conversion ||
+      !output.has_candidate_window() ||
+      output.candidate_window().candidate_size() == 0 ||
+      output.live_conversion()) {
+    return false;
+  }
+
+  const mozc::commands::CandidateWindow &candidate_window =
+      output.candidate_window();
+
+  // focused_index is the protocol-level distinction between an actual
+  // candidate-selection state and a passive suggestion state.  Do not infer
+  // this state from the physical key or require a particular category.
+  return !candidate_window.has_focused_index();
 }
 
 bool ShouldRecalculateRendererPosition(const RendererCommand &command) {
@@ -261,8 +270,6 @@ NSUInteger CodePointOffsetToUtf16Offset(NSString *text, uint32_t code_point_offs
 @synthesize replacementRange = replacementRange_;
 @synthesize imkClientForTest = imkClientForTest_;
 @synthesize useLiveConversionForTest = useLiveConversion_;
-@synthesize allowCandidateWindowForLiveConversionForTest =
-    allowCandidateWindowForLiveConversion_;
 - (mozc::client::ClientInterface *)mozcClient {
   return mozcClient_.get();
 }
@@ -304,7 +311,6 @@ NSUInteger CodePointOffsetToUtf16Offset(NSString *text, uint32_t code_point_offs
   liveConversionAnchorLeft_ = 0;
   hasLiveConversionAnchorLeft_ = false;
   useLiveConversion_ = false;
-  allowCandidateWindowForLiveConversion_ = false;
   mozcRenderer_ = mozc::renderer::RendererClient::Create();
   mozcClient_ = mozc::client::ClientFactory::NewClient();
   lastKeyDownTime_ = 0;
@@ -860,7 +866,6 @@ NSUInteger CodePointOffsetToUtf16Offset(NSString *text, uint32_t code_point_offs
 
 - (void)clearCandidates {
   hasLiveConversionAnchorLeft_ = false;
-  allowCandidateWindowForLiveConversion_ = false;
   rendererCommand_.set_type(RendererCommand::UPDATE);
   rendererCommand_.set_visible(false);
   rendererCommand_.clear_output();
@@ -964,14 +969,9 @@ NSUInteger CodePointOffsetToUtf16Offset(NSString *text, uint32_t code_point_offs
   }
 
   if (ShouldSuppressCandidateWindowForLiveConversion(
-          *output, useLiveConversion_, allowCandidateWindowForLiveConversion_)) {
+          *output, useLiveConversion_)) {
     [self clearCandidates];
     return;
-  }
-
-  if (output->live_conversion() || !output->has_candidate_window() ||
-      output->candidate_window().candidate_size() == 0) {
-    allowCandidateWindowForLiveConversion_ = false;
   }
 
   rendererCommand_.set_type(RendererCommand::UPDATE);
@@ -1112,14 +1112,6 @@ NSUInteger CodePointOffsetToUtf16Offset(NSString *text, uint32_t code_point_offs
     context.add_experimental_features("google_search_box");
   }
   keyEvent.set_mode(mode_);
-
-  if (useLiveConversion_ && keyEvent.has_special_key() &&
-      keyEvent.special_key() == mozc::commands::KeyEvent::SPACE) {
-    // This flag represents the explicit conversion state, not a property
-    // of the current key.  Keep it enabled during candidate navigation.
-    // updateCandidates() or clearCandidates() resets it when that state ends.
-    allowCandidateWindowForLiveConversion_ = true;
-  }
 
   if ([composedString_ length] == 0 && CanSelectedRange(clientBundle_) &&
       CanSurroundingText(clientBundle_)) {

--- a/src/mac/mozc_imk_input_controller_test.mm
+++ b/src/mac/mozc_imk_input_controller_test.mm
@@ -631,32 +631,36 @@ TEST_F(MozcImkInputControllerTest, UpdateCandidates) {
 }
 
 TEST_F(MozcImkInputControllerTest,
-       SuppressCandidateWindowWhileLiveConversionEnabledUntilSpace) {
+       SuppressUnfocusedSuggestionOutsideLiveConversionOutput) {
   controller_.useLiveConversionForTest = true;
-  controller_.allowCandidateWindowForLiveConversionForTest = false;
 
   commands::Output output;
-  commands::CandidateWindow *candidate_window = output.mutable_candidate_window();
-  candidate_window->set_focused_index(0);
+  commands::CandidateWindow *candidate_window =
+      output.mutable_candidate_window();
+  candidate_window->set_category(commands::SUGGESTION);
   candidate_window->set_size(1);
-  commands::CandidateWindow::Candidate *candidate = candidate_window->add_candidate();
+
+  commands::CandidateWindow::Candidate *candidate =
+      candidate_window->add_candidate();
   candidate->set_index(0);
   candidate->set_value("abc");
 
   [controller_ updateCandidates:&output];
-  [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.1]];
+
+  [[NSRunLoop currentRunLoop]
+      runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.1]];
 
   EXPECT_EQ(mock_renderer_->counter_ExecCommand(), 1);
   EXPECT_FALSE(controller_.rendererCommand.visible());
 }
 
 TEST_F(MozcImkInputControllerTest,
-       AllowCandidateWindowAfterExplicitSpaceDuringLiveConversion) {
+       ShowFocusedConversionCandidateWindowWhileLiveConversionEnabled) {
   controller_.useLiveConversionForTest = true;
-  controller_.allowCandidateWindowForLiveConversionForTest = true;
 
   commands::Output output;
   commands::CandidateWindow *candidate_window = output.mutable_candidate_window();
+  candidate_window->set_category(commands::CONVERSION);
   candidate_window->set_focused_index(0);
   candidate_window->set_size(1);
   commands::CandidateWindow::Candidate *candidate = candidate_window->add_candidate();
@@ -675,16 +679,61 @@ TEST_F(MozcImkInputControllerTest,
 }
 
 TEST_F(MozcImkInputControllerTest,
-       DownKeepsExplicitCandidateWindowVisibleDuringLiveConversion) {
+       TabShowsPredictionCandidateWindowDuringLiveConversion) {
   controller_.mode = commands::HIRAGANA;
   controller_.useLiveConversionForTest = true;
-  controller_.allowCandidateWindowForLiveConversionForTest = true;
 
   commands::Output output;
   output.set_consumed(true);
 
   commands::CandidateWindow *candidate_window =
       output.mutable_candidate_window();
+  candidate_window->set_category(commands::PREDICTION);
+  candidate_window->set_focused_index(0);
+  candidate_window->set_size(2);
+
+  commands::CandidateWindow::Candidate *candidate =
+      candidate_window->add_candidate();
+  candidate->set_index(0);
+  candidate->set_value("ありがとう");
+
+  candidate = candidate_window->add_candidate();
+  candidate->set_index(1);
+  candidate->set_value("ありがたい");
+
+  mock_client_.expectedCursor = NSMakeRect(50, 50, 1, 10);
+  mock_client_.expectedAttributes =
+      @{@"IMKBaseline" : [NSValue valueWithPoint:NSMakePoint(50, 718)]};
+
+  EXPECT_CALL(*mock_mozc_client_,
+              SendKeyWithContext(
+                  HasSpecialKey(commands::KeyEvent::TAB), _, NotNull()))
+      .WillOnce(DoAll(SetArgPointee<2>(output), Return(true)));
+
+  EXPECT_TRUE(SendKeyEvent(kVK_Tab, controller_, mock_client_));
+
+  [[NSRunLoop currentRunLoop]
+      runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.1]];
+
+  EXPECT_TRUE(controller_.rendererCommand.visible());
+  EXPECT_EQ(controller_.rendererCommand.output().candidate_window().category(),
+            commands::PREDICTION);
+  EXPECT_EQ(
+      controller_.rendererCommand.output().candidate_window().focused_index(),
+      0);
+}
+
+TEST_F(MozcImkInputControllerTest,
+       DownKeepsFocusedPredictionWindowVisibleDuringLiveConversion) {
+  controller_.mode = commands::HIRAGANA;
+  controller_.useLiveConversionForTest = true;
+
+  commands::Output output;
+  output.set_consumed(true);
+
+  commands::CandidateWindow *candidate_window =
+      output.mutable_candidate_window();
+  candidate_window->set_category(commands::PREDICTION);
   candidate_window->set_focused_index(1);
   candidate_window->set_size(2);
 
@@ -711,7 +760,6 @@ TEST_F(MozcImkInputControllerTest,
   [[NSRunLoop currentRunLoop]
       runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.1]];
 
-  EXPECT_TRUE(controller_.allowCandidateWindowForLiveConversionForTest);
   EXPECT_TRUE(controller_.rendererCommand.visible());
   EXPECT_EQ(
       controller_.rendererCommand.output().candidate_window().focused_index(),

--- a/src/renderer/mac/CandidateController.mm
+++ b/src/renderer/mac/CandidateController.mm
@@ -156,15 +156,32 @@ bool CandidateController::ExecCommand(const RendererCommand &command) {
   }
 
   if (command_.has_output() && command_.output().live_conversion()) {
-    candidate_window_->Hide();
+    const bool has_passive_suggestion =
+        command_.output().has_candidate_window() &&
+        command_.output().candidate_window().has_category() &&
+        command_.output().candidate_window().category() ==
+            commands::SUGGESTION &&
+        command_.output().candidate_window().candidate_size() > 0 &&
+        !command_.output().candidate_window().has_focused_index();
+
     cascading_window_->Hide();
     infolist_window_->Hide();
-    if (!ruby_window_->Update(command_)) {
-      ruby_window_->Hide();
-      return true;
+
+    if (has_passive_suggestion) {
+      candidate_window_->SetCandidateWindow(
+          command_.output().candidate_window());
+      AlignWindows();
+      candidate_window_->Show();
+    } else {
+      candidate_window_->Hide();
     }
-    AlignRubyWindow();
-    ruby_window_->Show();
+
+    if (ruby_window_->Update(command_)) {
+      AlignRubyWindow();
+      ruby_window_->Show();
+    } else {
+      ruby_window_->Hide();
+    }
     return true;
   }
 


### PR DESCRIPTION
## 概要

macOSでライブ変換中のサジェストウィンドウが表示されない問題と、候補選択へ移行した際に候補ウィンドウが消える問題を修正します。

## 変更内容

- ライブ変換中の非選択サジェストをmacOSレンダラーで表示
- 候補選択状態を物理キーではなく `focused_index` の有無で判定
- キー設定に応じて開始された通常候補・予測候補の表示を維持
- 不要になった候補表示許可フラグを削除
- サジェスト、通常候補、Tab、Downの回帰テストを追加

## 確認内容

- `//mac:mozc_imk_input_controller_test`
- `//renderer:mozc_renderer_macos`
- Zenzランタイム同梱のmacOS arm64パッケージをクリーンビルド
- macOS実機で以下を確認
  - ライブ変換中のサジェスト表示
  - Tabによる予測候補選択
  - キー設定で予測変換を割り当てたDownによる候補選択
  - Spaceによる通常変換
  - Up／Downによる候補移動
  - Enter／Esc
  - Zenz補正後のサジェスト表示