### PR TITLE
Improve macOS renderer appearance and ruby placement

### DIFF
--- a/src/gui/config_dialog/config_dialog.cc
+++ b/src/gui/config_dialog/config_dialog.cc
@@ -427,15 +427,18 @@ ConfigDialog::ConfigDialog()
   // Mode indicator is available only on Windows.
   useModeIndicator->hide();
 
-  // Candidate/ruby appearance options are available only on Windows.
+  // Preedit display color customization is available only on Windows TSF.
+  preeditDisplayColorGroupBox->hide();
+#endif  // !_WIN32
+
+#if !defined(_WIN32) && !defined(__APPLE__)
+  // Detailed renderer appearance controls are supported by the Windows and
+  // macOS desktop renderers.
   useDarkModeCandidateWindow->hide();
   candidateRubyFontLabel->hide();
   candidateRubyFontComboBox->hide();
   showLiveConversionRubyWindow->hide();
-
-  // Preedit display color customization is available only on Windows TSF.
-  preeditDisplayColorGroupBox->hide();
-#endif  // !_WIN32
+#endif  // !defined(_WIN32) && !defined(__APPLE__)
 
   // Reset texts explicitly for translations.
   configDialogButtonBox->button(QDialogButtonBox::Ok)->setText(tr("  Ok  "));
@@ -2392,9 +2395,9 @@ void ConfigDialog::InitializeWindowsImeIconStyleControls() {
 // Actually ConvertFromProto and ConvertToProto are almost the same.
 // The difference only SET_ and GET_. We would like to unify the twos.
 void ConfigDialog::InitializeRendererAppearanceControls() {
-#ifndef _WIN32
+#if !defined(_WIN32) && !defined(__APPLE__)
   return;
-#endif  // !_WIN32
+#endif  // !defined(_WIN32) && !defined(__APPLE__)
 
   useDarkModeCandidateWindow->hide();
   candidateRubyFontLabel->hide();
@@ -2403,7 +2406,9 @@ void ConfigDialog::InitializeRendererAppearanceControls() {
   constexpr int kRendererAppearanceGroupX = 30;
   constexpr int kRendererAppearanceGroupY = 1146;
   constexpr int kRendererAppearanceGroupWidth = 441;
+#ifdef _WIN32
   constexpr int kRendererAppearanceToPreeditMargin = 18;
+#endif  // _WIN32
   constexpr int kInputSupportBottomMargin = 30;
 
   QWidget* group = new QWidget(inputSupportScrollAreaWidgetContents);
@@ -2494,7 +2499,7 @@ void ConfigDialog::InitializeRendererAppearanceControls() {
   grid->setVerticalSpacing(2);
   root_layout->addWidget(color_grid_widget);
 
-  auto add_color_theme_combo = [this](QComboBox* combo, bool allow_follow) {
+  auto add_color_theme_combo = [](QComboBox* combo, bool allow_follow) {
     if (allow_follow) {
       combo->addItem(
           tr("Follow candidate window"),
@@ -2855,6 +2860,7 @@ void ConfigDialog::InitializeRendererAppearanceControls() {
   const int appearance_height = root_layout->sizeHint().height();
   group->setGeometry(kRendererAppearanceGroupX, kRendererAppearanceGroupY,
                      kRendererAppearanceGroupWidth, appearance_height);
+#ifdef _WIN32
   preeditDisplayColorGroupBox->move(
       kRendererAppearanceGroupX,
       group->y() + group->height() + kRendererAppearanceToPreeditMargin);
@@ -2862,7 +2868,13 @@ void ConfigDialog::InitializeRendererAppearanceControls() {
       485, preeditDisplayColorGroupBox->y() +
                preeditDisplayColorGroupBox->height() +
                kInputSupportBottomMargin);
-
+#else
+  // The preedit color section is Windows TSF-specific.  On macOS, terminate
+  // the scrollable content immediately after the renderer appearance section
+  // so that hiding the preedit section does not leave a large blank area.
+  inputSupportScrollAreaWidgetContents->resize(
+      485, group->y() + group->height() + kInputSupportBottomMargin);
+#endif  // _WIN32
 }
 
 void ConfigDialog::ConvertFromProto(const config::Config &config) {
@@ -3339,13 +3351,13 @@ void ConfigDialog::ConvertToProto(config::Config *config) const {
 
 void ConfigDialog::ConvertRendererAppearanceFromProto(
     const config::Config &config) {
-#ifndef _WIN32
+#if !defined(_WIN32) && !defined(__APPLE__)
   if (useDarkModeCandidateWindow != nullptr) {
     useDarkModeCandidateWindow->setChecked(
         config.use_dark_mode_candidate_window());
   }
   return;
-#endif  // !_WIN32
+#endif  // !defined(_WIN32) && !defined(__APPLE__)
 
   const int candidate_color_theme =
       config.has_candidate_window_color_theme()
@@ -3474,14 +3486,15 @@ void ConfigDialog::ConvertRendererAppearanceFromProto(
   UpdateRendererAppearanceControls();
 }
 
-void ConfigDialog::ConvertRendererAppearanceToProto(config::Config *config) const {
-#ifndef _WIN32
+void ConfigDialog::ConvertRendererAppearanceToProto(
+    config::Config *config) const {
+#if !defined(_WIN32) && !defined(__APPLE__)
   if (useDarkModeCandidateWindow != nullptr) {
     config->set_use_dark_mode_candidate_window(
         useDarkModeCandidateWindow->isChecked());
   }
   return;
-#endif  // !_WIN32
+#endif  // !defined(_WIN32) && !defined(__APPLE__)
 
   const int candidate_color_theme = GetComboCurrentData(
       FindComboBox(this, "candidateWindowColorThemeComboBox"),

--- a/src/mac/installer/preflight_template.sh
+++ b/src/mac/installer/preflight_template.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
 
 rm -Rf "/Applications/Mozc"
+rm -Rf "/Library/Input Methods/Mozc.app"
 /usr/bin/true

--- a/src/mac/mozc_imk_input_controller.mm
+++ b/src/mac/mozc_imk_input_controller.mm
@@ -213,33 +213,30 @@ bool ShouldRecalculateRendererPosition(const RendererCommand &command) {
          (command.has_output() && command.output().live_conversion());
 }
 
-uint32_t GetPreeditCharLength(const Preedit &preedit) {
-  uint32_t length = 0;
-  for (int i = 0; i < preedit.segment_size(); ++i) {
-    const Preedit::Segment &segment = preedit.segment(i);
-    if (segment.has_value_length()) {
-      length += segment.value_length();
-    } else {
-      length += mozc::Util::CharsLen(segment.value());
-    }
-  }
-  return length;
-}
-
 int32_t GetRendererAnchorPosition(const Output &output) {
-  if (output.live_conversion() && output.has_preedit()) {
-    const Preedit &preedit = output.preedit();
-    const uint32_t length = GetPreeditCharLength(preedit);
-    if (length == 0) {
-      return 0;
-    }
-    const uint32_t cursor = std::min(preedit.cursor(), length);
-    return (cursor == 0) ? 0 : static_cast<int32_t>(cursor - 1);
-  }
+  // CandidateWindow::position is the protocol-defined position within the
+  // composition.  Live conversion must not replace it with cursor - 1,
+  // because doing so moves a suggestion toward the end of a multi-character
+  // preedit.
   if (output.has_candidate_window()) {
     return output.candidate_window().position();
   }
+
+  // A live-conversion ruby window can be displayed without a candidate
+  // window.  Such a window is anchored to the start of the composition.
   return 0;
+}
+
+void SetRendererRectangle(
+    const NSRect &line_rect, const NSPoint &baseline,
+    RendererCommand::Rectangle *rectangle) {
+  const int right_offset = line_rect.size.width;
+  const int top_offset = -line_rect.size.height;
+
+  rectangle->set_left(baseline.x);
+  rectangle->set_right(baseline.x + right_offset);
+  rectangle->set_top(baseline.y + top_offset);
+  rectangle->set_bottom(baseline.y);
 }
 
 NSUInteger CodePointOffsetToUtf16Offset(NSString *text, uint32_t code_point_offset) {
@@ -923,36 +920,55 @@ NSUInteger CodePointOffsetToUtf16Offset(NSString *text, uint32_t code_point_offs
   rendererCommand_.set_visible(true);
 
   NSRect preeditRect = NSZeroRect;
-  const int32_t position = GetRendererAnchorPosition(rendererCommand_.output());
-  // Some applications throws error when we call attributesForCharacterIndex.
+  const Output &output = rendererCommand_.output();
+  const int32_t position = GetRendererAnchorPosition(output);
+
+  // Some applications throw an exception from
+  // attributesForCharacterIndex:lineHeightRectangle:.
   DLOG(INFO) << "attributesForCharacterIndex: " << position;
   @try {
-    NSDictionary *clientData = [[self client] attributesForCharacterIndex:position
-                                                      lineHeightRectangle:&preeditRect];
+    NSDictionary *clientData =
+        [[self client] attributesForCharacterIndex:position
+                              lineHeightRectangle:&preeditRect];
 
-    // IMKBaseline: Left-bottom of the composition.
-    NSPoint baseline = [clientData[@"IMKBaseline"] pointValue];
-    // IMKTextOrientation: 0: vertical writing, 1: horizontal writing.
-    // IMKLineHeight: Height of the composition (in horizontal writing).
-    // NSFont: Font information of the composition.
-    // IMKLineAscent: Not sure. A float number. (e.g. 9.240234)
+    // IMKBaseline is the left-bottom coordinate of the requested character.
+    const NSPoint baseline = [clientData[@"IMKBaseline"] pointValue];
 
-    const int right_offset = preeditRect.size.width;
-    const int top_offset = -preeditRect.size.height;
-    int left = baseline.x;
-    if (rendererCommand_.output().live_conversion()) {
+    int candidate_left = baseline.x;
+    if (output.live_conversion()) {
       if (!hasLiveConversionAnchorLeft_) {
         liveConversionAnchorLeft_ = baseline.x;
         hasLiveConversionAnchorLeft_ = true;
       }
-      left = liveConversionAnchorLeft_;
+      candidate_left = liveConversionAnchorLeft_;
     }
 
-    RendererCommand::Rectangle *rect = rendererCommand_.mutable_preedit_rectangle();
-    rect->set_left(left);
-    rect->set_right(left + right_offset);
-    rect->set_top(baseline.y + top_offset);
-    rect->set_bottom(baseline.y);
+    SetRendererRectangle(
+        preeditRect, NSMakePoint(candidate_left, baseline.y),
+        rendererCommand_.mutable_preedit_rectangle());
+
+    rendererCommand_.clear_ruby_preedit_rectangle();
+
+    if (output.live_conversion()) {
+      if (position == 0) {
+        rendererCommand_.mutable_ruby_preedit_rectangle()->CopyFrom(
+            rendererCommand_.preedit_rectangle());
+      } else {
+        // A passive suggestion may be anchored partway through the
+        // composition. Ruby represents the reading of the entire preedit and
+        // therefore needs the geometry of character index zero.
+        NSRect rubyPreeditRect = NSZeroRect;
+        NSDictionary *rubyClientData =
+            [[self client] attributesForCharacterIndex:0
+                                  lineHeightRectangle:&rubyPreeditRect];
+        const NSPoint rubyBaseline =
+            [rubyClientData[@"IMKBaseline"] pointValue];
+
+        SetRendererRectangle(
+            rubyPreeditRect, rubyBaseline,
+            rendererCommand_.mutable_ruby_preedit_rectangle());
+      }
+    }
 
   } @catch (NSException *exception) {
     LOG(ERROR) << "Exception from [" << clientBundle_ << "] " << [[exception name] UTF8String]

--- a/src/mac/mozc_imk_input_controller_test.mm
+++ b/src/mac/mozc_imk_input_controller_test.mm
@@ -139,6 +139,8 @@
 
 - (NSDictionary *)attributesForCharacterIndex:(int)index lineHeightRectangle:(NSRect *)rect {
   counters_["attributesForCharacterIndex:lineHeightRectangle:"]++;
+  counters_[std::string("attributesForCharacterIndex:") +
+            std::to_string(index)]++;
   lastCharacterIndex_ = index;
   *rect = expectedCursor;
   return expectedAttributes;
@@ -797,6 +799,75 @@ TEST_F(MozcImkInputControllerTest, UpdateCandidatesForLiveConversionWithoutCandi
   EXPECT_EQ(preedit_rectangle.top(), 708);
   EXPECT_EQ(preedit_rectangle.right(), 51);
   EXPECT_EQ(preedit_rectangle.bottom(), 718);
+}
+
+TEST_F(
+    MozcImkInputControllerTest,
+    LiveConversionSuggestionUsesCandidateWindowPosition) {
+  commands::Output output;
+  output.set_live_conversion(true);
+
+  commands::Preedit *preedit = output.mutable_preedit();
+  preedit->set_cursor(4);
+
+  commands::Preedit::Segment *segment = preedit->add_segment();
+  segment->set_annotation(commands::Preedit::Segment::HIGHLIGHT);
+  segment->set_key("こうほひょうじ");
+  segment->set_value("候補表示");
+  segment->set_value_length(4);
+
+  commands::CandidateWindow *candidate_window =
+      output.mutable_candidate_window();
+  candidate_window->set_category(commands::SUGGESTION);
+  candidate_window->set_position(1);
+  candidate_window->set_size(1);
+
+  commands::CandidateWindow::Candidate *candidate =
+      candidate_window->add_candidate();
+  candidate->set_index(0);
+  candidate->set_value("候補表示");
+
+  mock_client_.expectedCursor = NSMakeRect(50, 50, 1, 10);
+  mock_client_.expectedAttributes =
+      @{@"IMKBaseline" :
+            [NSValue valueWithPoint:NSMakePoint(50, 718)]};
+
+  [controller_ updateCandidates:&output];
+
+  [[NSRunLoop currentRunLoop]
+      runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.1]];
+
+  EXPECT_EQ(
+      [mock_client_
+          getCounter:"attributesForCharacterIndex:lineHeightRectangle:"],
+      2);
+  EXPECT_EQ(
+      [mock_client_ getCounter:"attributesForCharacterIndex:1"], 1);
+  EXPECT_EQ(
+      [mock_client_ getCounter:"attributesForCharacterIndex:0"], 1);
+
+  // Candidate geometry is queried at index 1. Ruby geometry is queried
+  // independently at composition index 0.
+  EXPECT_EQ(mock_client_.lastCharacterIndex, 0);
+  EXPECT_EQ(mock_renderer_->counter_ExecCommand(), 1);
+  EXPECT_TRUE(controller_.rendererCommand.visible());
+
+  ASSERT_TRUE(controller_.rendererCommand.has_preedit_rectangle());
+  ASSERT_TRUE(controller_.rendererCommand.has_ruby_preedit_rectangle());
+
+  EXPECT_EQ(controller_.rendererCommand.preedit_rectangle().left(), 50);
+  EXPECT_EQ(controller_.rendererCommand.preedit_rectangle().top(), 708);
+  EXPECT_EQ(controller_.rendererCommand.preedit_rectangle().right(), 51);
+  EXPECT_EQ(controller_.rendererCommand.preedit_rectangle().bottom(), 718);
+
+  EXPECT_EQ(
+      controller_.rendererCommand.ruby_preedit_rectangle().left(), 50);
+  EXPECT_EQ(
+      controller_.rendererCommand.ruby_preedit_rectangle().top(), 708);
+  EXPECT_EQ(
+      controller_.rendererCommand.ruby_preedit_rectangle().right(), 51);
+  EXPECT_EQ(
+      controller_.rendererCommand.ruby_preedit_rectangle().bottom(), 718);
 }
 
 TEST_F(MozcImkInputControllerTest, LiveConversionRecalculatesRendererPosition) {

--- a/src/protocol/renderer_command.proto
+++ b/src/protocol/renderer_command.proto
@@ -66,8 +66,13 @@ message RendererCommand {
 
   optional Output output = 3;
 
-  // Preedit rectangle
+  // Preedit rectangle used to position candidate and suggestion windows.
   optional Rectangle preedit_rectangle = 4;
+
+  // Mozkey macOS extension: composition-start rectangle used by the
+  // live-conversion ruby window. Keeping this separate prevents a suggestion's
+  // CandidateWindow::position from shifting the full-reading ruby overlay.
+  optional Rectangle ruby_preedit_rectangle = 1001;
 
   // An equivalent to IMECHARPOSITION in IMM32. (For Windows only)
   // TODO(yukawa): make a common candidate form format for all platforms.

--- a/src/renderer/mac/CandidateController.h
+++ b/src/renderer/mac/CandidateController.h
@@ -30,6 +30,7 @@
 #ifndef MOZC_RENDERER_MAC_CANDIDATE_CONTROLLER_H_
 #define MOZC_RENDERER_MAC_CANDIDATE_CONTROLLER_H_
 
+#include "base/coordinates.h"
 #include "protocol/renderer_command.pb.h"
 #include "renderer/renderer_interface.h"
 
@@ -62,7 +63,7 @@ class CandidateController : public RendererInterface {
  private:
   // Relocate windows to prevent overlaps.
   void AlignWindows();
-  void AlignRubyWindow();
+  bool AlignRubyWindow(const mozc::Rect *avoid_rect);
 
   // We don't use std::unique_ptr<> for those two pointers because we don't
   // want to include CandidateWindow.h when the user of this class
@@ -73,6 +74,8 @@ class CandidateController : public RendererInterface {
   CandidateWindow *cascading_window_;
   InfolistWindow *infolist_window_;
   RubyWindow *ruby_window_;
+  mozc::Rect candidate_rect_;
+  bool has_candidate_rect_ = false;
   mozc::commands::RendererCommand command_;
 };
 

--- a/src/renderer/mac/CandidateController.mm
+++ b/src/renderer/mac/CandidateController.mm
@@ -51,7 +51,6 @@ namespace mac {
 namespace {
 const int kHideWindowDelay = 500;  // msec
 const int kWindowMargin = 10;      // pixel
-const int kRubyWindowGap = 8;      // pixel
 
 // In Cocoa's coordinate system the origin point is left-bottom and the Y-axis
 // points up. But in Mozc's coordinate system the Y-axis points down. So we use
@@ -152,6 +151,7 @@ bool CandidateController::ExecCommand(const RendererCommand &command) {
     cascading_window_->Hide();
     infolist_window_->Hide();
     ruby_window_->Hide();
+    has_candidate_rect_ = false;
     return true;
   }
 
@@ -174,10 +174,16 @@ bool CandidateController::ExecCommand(const RendererCommand &command) {
       candidate_window_->Show();
     } else {
       candidate_window_->Hide();
+      has_candidate_rect_ = false;
     }
 
-    if (ruby_window_->Update(command_)) {
-      AlignRubyWindow();
+    const mozc::Rect *ruby_avoid_rect =
+        has_passive_suggestion && has_candidate_rect_
+            ? &candidate_rect_
+            : nullptr;
+
+    if (ruby_window_->Update(command_) &&
+        AlignRubyWindow(ruby_avoid_rect)) {
       ruby_window_->Show();
     } else {
       ruby_window_->Hide();
@@ -235,6 +241,8 @@ bool CandidateController::ExecCommand(const RendererCommand &command) {
 }
 
 void CandidateController::AlignWindows() {
+  has_candidate_rect_ = false;
+
   // If candidate window is not visible, we do nothing for aligning.
   if (!command_.has_preedit_rectangle()) {
     return;
@@ -279,6 +287,8 @@ void CandidateController::AlignWindows() {
   const mozc::Rect candidate_rect = WindowUtil::GetWindowRectForMainWindowFromTargetPointAndPreedit(
       target_point, preedit_rect, candidate_window_->GetWindowSize(), candidate_zero_point,
       display_rect, is_vertical);
+  candidate_rect_ = candidate_rect;
+  has_candidate_rect_ = true;
   candidate_window_->MoveWindow(OriginPointInCocoaCoord(candidate_rect));
 
   // Align infolist window
@@ -310,39 +320,45 @@ void CandidateController::AlignWindows() {
   cascading_window_->MoveWindow(OriginPointInCocoaCoord(cascading_rect));
 }
 
-void CandidateController::AlignRubyWindow() {
+bool CandidateController::AlignRubyWindow(
+    const mozc::Rect *avoid_rect) {
   if (!command_.has_preedit_rectangle()) {
-    return;
+    return false;
   }
 
   const mozc::Size ruby_size = ruby_window_->GetWindowSize();
   if (ruby_size.width <= 0 || ruby_size.height <= 0) {
-    return;
+    return false;
   }
+
+  const RendererCommand::Rectangle &anchor =
+      command_.has_ruby_preedit_rectangle()
+          ? command_.ruby_preedit_rectangle()
+          : command_.preedit_rectangle();
 
   const mozc::Size preedit_size(
-      command_.preedit_rectangle().right() - command_.preedit_rectangle().left(),
-      command_.preedit_rectangle().bottom() - command_.preedit_rectangle().top());
-  mozc::Rect preedit_rect(
-      mozc::Point(command_.preedit_rectangle().left(),
-                  command_.preedit_rectangle().top() - GetBaseScreenHeight()),
+      anchor.right() - anchor.left(),
+      anchor.bottom() - anchor.top());
+
+  const mozc::Rect preedit_rect(
+      mozc::Point(anchor.left(),
+                  anchor.top() - GetBaseScreenHeight()),
       preedit_size);
-  const mozc::Rect display_rect = GetNearestDisplayRect(preedit_rect);
 
-  const int max_left = std::max(display_rect.Left(),
-                                display_rect.Right() - ruby_size.width);
-  const int left = std::clamp(preedit_rect.Left(), display_rect.Left(), max_left);
+  const mozc::Rect display_rect =
+      GetNearestDisplayRect(preedit_rect);
 
-  int top = preedit_rect.Top() - ruby_size.height - kRubyWindowGap;
-  if (top < display_rect.Top()) {
-    top = preedit_rect.Bottom() + kRubyWindowGap;
+  mozc::Rect ruby_rect;
+  if (!WindowUtil::GetRubyWindowRect(
+          preedit_rect, ruby_size,
+          ruby_window_->GetCompositionGap(),
+          display_rect, avoid_rect, &ruby_rect)) {
+    return false;
   }
-  const int max_top = std::max(display_rect.Top(),
-                               display_rect.Bottom() - ruby_size.height);
-  top = std::clamp(top, display_rect.Top(), max_top);
 
   ruby_window_->MoveWindow(
-      OriginPointInCocoaCoord(mozc::Rect(left, top, ruby_size.width, ruby_size.height)));
+      OriginPointInCocoaCoord(ruby_rect));
+  return true;
 }
 
 }  // namespace mozc::renderer::mac

--- a/src/renderer/mac/CandidateView.mm
+++ b/src/renderer/mac/CandidateView.mm
@@ -64,6 +64,8 @@ using mozc::renderer::mac::MacViewUtil;
 // Private method declarations.
 @interface CandidateView ()
 - (void)initializeDefaultStyle;
+- (void)reloadStyleForCandidateWindow;
+- (void)updateStyleDependentResources;
 
 // Draw the |row|-th row.
 - (void)drawRow:(int)row;
@@ -105,35 +107,65 @@ using mozc::renderer::mac::MacViewUtil;
 }
 
 - (void)initializeDefaultStyle {
-  RendererStyleHandler::GetRendererStyle(&style_);
-
-  const std::string &logo_file_name = style_.logo_file_name();
-  logoImage_ = [NSImage imageNamed:[NSString stringWithUTF8String:logo_file_name.c_str()]];
-  if (logoImage_) {
-    // Fix the image size.  Sometimes the size can be smaller than the
-    // actual size because of blank margin.
-    const NSArray *logoReps = [logoImage_ representations];
-    if (logoReps && [logoReps count] > 0) {
-      const NSImageRep *representation = [logoReps objectAtIndex:0];
-      [logoImage_ setSize:NSMakeSize([representation pixelsWide], [representation pixelsHigh])];
-    }
+  if (!RendererStyleHandler::GetRendererStyleForWindowType(
+          RendererStyleHandler::RendererStyleType::kCandidate, &style_)) {
+    RendererStyleHandler::GetDefaultRendererStyle(&style_);
   }
+  [self updateStyleDependentResources];
 
-  NSString *nsstr = [NSString stringWithUTF8String:style_.column_minimum_width_string().c_str()];
-  NSDictionary *attr = [NSDictionary dictionaryWithObject:[NSFont messageFontOfSize:14]
-                                                   forKey:NSFontAttributeName];
-  const NSAttributedString *defaultMessage = [[NSAttributedString alloc] initWithString:nsstr
-                                                                             attributes:attr];
-  columnMinimumWidth_ = [defaultMessage size].width;
-
-  // default line width is specified as 1.0 *pt*, but we want to draw
-  // it as 1.0 px.
+  // Default line width is specified as 1.0 pt, but the renderer expects
+  // a one-pixel logical border.
   [NSBezierPath setDefaultLineWidth:1.0];
   [NSBezierPath setDefaultLineJoinStyle:NSLineJoinStyleMiter];
 }
 
+- (void)reloadStyleForCandidateWindow {
+  // Prediction is the focused continuation of suggestion UI, so both
+  // categories share the suggestion appearance bucket.
+  const bool use_suggestion_style =
+      candidate_window_.category() == mozc::commands::SUGGESTION ||
+      candidate_window_.category() == mozc::commands::PREDICTION;
+
+  const RendererStyleHandler::RendererStyleType style_type =
+      use_suggestion_style
+          ? RendererStyleHandler::RendererStyleType::kSuggestion
+          : RendererStyleHandler::RendererStyleType::kCandidate;
+
+  if (!RendererStyleHandler::GetRendererStyleForWindowType(style_type,
+                                                            &style_)) {
+    RendererStyleHandler::GetDefaultRendererStyle(&style_);
+  }
+
+  [self updateStyleDependentResources];
+}
+
+- (void)updateStyleDependentResources {
+  const std::string &logo_file_name = style_.logo_file_name();
+  logoImage_ =
+      [NSImage imageNamed:[NSString stringWithUTF8String:logo_file_name.c_str()]];
+
+  if (logoImage_) {
+    // Fix the image size. Sometimes the logical size can be smaller than the
+    // underlying representation because of transparent margins.
+    const NSArray *logoReps = [logoImage_ representations];
+    if (logoReps && [logoReps count] > 0) {
+      const NSImageRep *representation = [logoReps objectAtIndex:0];
+      [logoImage_
+          setSize:NSMakeSize([representation pixelsWide],
+                             [representation pixelsHigh])];
+    }
+  }
+
+  const NSAttributedString *minimumWidthText =
+      MacViewUtil::ToNSAttributedString(
+          style_.column_minimum_width_string(), style_.candidate_style());
+  columnMinimumWidth_ =
+      std::max(1, static_cast<int>([minimumWidthText size].width));
+}
+
 - (void)setCandidateWindow:(const CandidateWindow *)candidate_window {
   candidate_window_ = *candidate_window;
+  [self reloadStyleForCandidateWindow];
 }
 
 - (void)setSendCommandInterface:(SendCommandInterface *)command_sender {
@@ -276,6 +308,17 @@ using mozc::renderer::mac::MacViewUtil;
     LOG(WARNING) << "Unknown candidates category: " << candidate_window_.category();
     return;
   }
+
+  // Paint the complete view before drawing individual cells. Otherwise,
+  // column gaps and unused layout regions expose the NSPanel's default
+  // white background when a dark renderer style is active.
+  if (style_.candidate_style().has_background_color()) {
+    [MacViewUtil::ToNSColor(
+        style_.candidate_style().background_color()) set];
+  } else {
+    [NSColor.windowBackgroundColor set];
+  }
+  [NSBezierPath fillRect:self.bounds];
 
   for (int i = 0; i < candidate_window_.candidate_size(); ++i) {
     [self drawRow:i];

--- a/src/renderer/mac/RubyWindow.h
+++ b/src/renderer/mac/RubyWindow.h
@@ -30,6 +30,7 @@
 #ifndef MOZC_RENDERER_MAC_RUBY_WINDOW_H_
 #define MOZC_RENDERER_MAC_RUBY_WINDOW_H_
 
+#include <cstdint>
 #include <string>
 
 #include "renderer/mac/RendererBaseWindow.h"
@@ -51,12 +52,17 @@ class RubyWindow : public RendererBaseWindow {
 
   bool Update(const commands::RendererCommand &command);
 
+  // Returns the scaled distance between the composition text and ruby window.
+  int32_t GetCompositionGap() const;
+
  private:
   void InitWindow() override;
   void ResetView() override;
 
   bool BuildReadingText(const commands::RendererCommand &command,
                         std::string *reading) const;
+
+  int32_t composition_gap_ = 4;
 };
 
 }  // namespace mac

--- a/src/renderer/mac/RubyWindow.mm
+++ b/src/renderer/mac/RubyWindow.mm
@@ -31,77 +31,153 @@
 
 #import <Cocoa/Cocoa.h>
 
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
 #include <string>
 
 #include "protocol/commands.pb.h"
 #include "protocol/renderer_command.pb.h"
+#include "protocol/renderer_style.pb.h"
+#include "renderer/mac/mac_view_util.h"
+#include "renderer/renderer_style_handler.h"
 
 namespace {
 
-constexpr CGFloat kPaddingX = 14.0;
-constexpr CGFloat kPaddingY = 6.0;
-constexpr CGFloat kCornerRadius = 5.0;
-constexpr CGFloat kFontSize = 13.0;
+constexpr CGFloat kBaseFontSize = 13.0;
 
-NSString *ToNSString(const std::string &text) {
-  return [[NSString alloc] initWithUTF8String:text.c_str()];
+CGFloat ScaleMetric(uint32_t value, uint32_t size_percent) {
+  return std::round(
+      static_cast<CGFloat>(value) *
+      static_cast<CGFloat>(size_percent) / 100.0);
+}
+
+// Ruby spacing values are defined as physical pixels at the Windows
+// 144-DPI design baseline. Cocoa geometry is expressed in 72-DPI points.
+// Preserve the shared Windows value and convert only at the macOS boundary.
+CGFloat ScaleWindowsRubySpacingToCocoaPoints(
+    uint32_t value, uint32_t size_percent) {
+  const CGFloat windows_design_pixels =
+      std::round(
+          static_cast<CGFloat>(value) *
+          static_cast<CGFloat>(size_percent) / 100.0);
+  return windows_design_pixels * 72.0 / 144.0;
+}
+
+CGFloat ScaleFontSize(uint32_t size_percent) {
+  return std::max<CGFloat>(
+      1.0,
+      kBaseFontSize * static_cast<CGFloat>(size_percent) / 100.0);
+}
+
+NSColor *ToNSColor(uint32_t rgb) {
+  return [NSColor
+      colorWithCalibratedRed:static_cast<CGFloat>((rgb >> 16) & 0xff) / 255.0
+                       green:static_cast<CGFloat>((rgb >> 8) & 0xff) / 255.0
+                        blue:static_cast<CGFloat>(rgb & 0xff) / 255.0
+                       alpha:1.0];
+}
+
+void SetRgbColor(uint32_t rgb,
+                 mozc::renderer::RendererStyle::RGBAColor *color) {
+  color->set_r(static_cast<double>((rgb >> 16) & 0xff));
+  color->set_g(static_cast<double>((rgb >> 8) & 0xff));
+  color->set_b(static_cast<double>(rgb & 0xff));
+  color->set_a(1.0);
 }
 
 }  // namespace
 
 @interface RubyView : NSView
-- (void)setRubyText:(NSString *)text;
+- (void)setRubyText:(NSAttributedString *)text;
+- (void)setBackgroundColor:(NSColor *)backgroundColor
+               borderColor:(NSColor *)borderColor
+              cornerRadius:(CGFloat)cornerRadius
+         horizontalPadding:(CGFloat)horizontalPadding
+           verticalPadding:(CGFloat)verticalPadding;
 - (NSSize)preferredSize;
 @end
 
 @implementation RubyView {
-  NSString *text_;
-  NSDictionary<NSAttributedStringKey, id> *attributes_;
+  NSAttributedString *text_;
+  NSColor *backgroundColor_;
+  NSColor *borderColor_;
+  CGFloat cornerRadius_;
+  CGFloat horizontalPadding_;
+  CGFloat verticalPadding_;
 }
 
 - (instancetype)initWithFrame:(NSRect)frame {
   self = [super initWithFrame:frame];
   if (self) {
-    text_ = @"";
-    NSFont *font = [NSFont fontWithName:@"Hiragino Sans" size:kFontSize];
-    if (font == nil) {
-      font = [NSFont systemFontOfSize:kFontSize weight:NSFontWeightSemibold];
-    }
-    attributes_ = @{
-      NSFontAttributeName : font,
-      NSForegroundColorAttributeName : NSColor.whiteColor,
-    };
+    text_ = [[NSAttributedString alloc] initWithString:@""];
+    backgroundColor_ = [NSColor colorWithCalibratedWhite:0.10 alpha:1.0];
+    borderColor_ = NSColor.clearColor;
+    cornerRadius_ = 5.0;
+    horizontalPadding_ = 7.0;
+    verticalPadding_ = 6.0;
     [self setWantsLayer:YES];
   }
   return self;
 }
 
-- (void)setRubyText:(NSString *)text {
+- (void)setRubyText:(NSAttributedString *)text {
   text_ = [text copy];
   [self setNeedsDisplay:YES];
 }
 
+- (void)setBackgroundColor:(NSColor *)backgroundColor
+               borderColor:(NSColor *)borderColor
+              cornerRadius:(CGFloat)cornerRadius
+         horizontalPadding:(CGFloat)horizontalPadding
+           verticalPadding:(CGFloat)verticalPadding {
+  backgroundColor_ = backgroundColor;
+  borderColor_ = borderColor;
+  cornerRadius_ = std::max<CGFloat>(0.0, cornerRadius);
+  horizontalPadding_ = std::max<CGFloat>(0.0, horizontalPadding);
+  verticalPadding_ = std::max<CGFloat>(0.0, verticalPadding);
+  [self setNeedsDisplay:YES];
+}
+
 - (NSSize)preferredSize {
-  NSSize textSize = [text_ sizeWithAttributes:attributes_];
-  return NSMakeSize(ceil(textSize.width + kPaddingX * 2.0),
-                    ceil(textSize.height + kPaddingY * 2.0));
+  const NSSize textSize = [text_ size];
+  return NSMakeSize(
+      ceil(textSize.width + horizontalPadding_ * 2.0),
+      ceil(textSize.height + verticalPadding_ * 2.0));
 }
 
 - (void)drawRect:(NSRect)dirtyRect {
   [super drawRect:dirtyRect];
 
-  [[NSColor colorWithCalibratedWhite:0.10 alpha:0.90] setFill];
+  const NSRect pathBounds = NSInsetRect(self.bounds, 0.5, 0.5);
+  const CGFloat maximumRadius =
+      std::max<CGFloat>(
+          0.0,
+          std::min(NSWidth(pathBounds), NSHeight(pathBounds)) / 2.0);
+  const CGFloat effectiveRadius =
+      std::min(cornerRadius_, maximumRadius);
+
   NSBezierPath *background =
-      [NSBezierPath bezierPathWithRoundedRect:self.bounds
-                                     xRadius:kCornerRadius
-                                     yRadius:kCornerRadius];
+      [NSBezierPath bezierPathWithRoundedRect:pathBounds
+                                     xRadius:effectiveRadius
+                                     yRadius:effectiveRadius];
+
+  [backgroundColor_ setFill];
   [background fill];
 
-  NSSize textSize = [text_ sizeWithAttributes:attributes_];
-  NSRect textRect = NSMakeRect((NSWidth(self.bounds) - textSize.width) / 2.0,
-                               (NSHeight(self.bounds) - textSize.height) / 2.0,
-                               textSize.width, textSize.height);
-  [text_ drawInRect:textRect withAttributes:attributes_];
+  if (borderColor_ != nil) {
+    [borderColor_ setStroke];
+    [background setLineWidth:1.0];
+    [background stroke];
+  }
+
+  const NSSize textSize = [text_ size];
+  const NSRect textRect =
+      NSMakeRect((NSWidth(self.bounds) - textSize.width) / 2.0,
+                 (NSHeight(self.bounds) - textSize.height) / 2.0,
+                 textSize.width,
+                 textSize.height);
+  [text_ drawInRect:textRect];
 }
 @end
 
@@ -113,8 +189,9 @@ RubyWindow::RubyWindow() = default;
 
 RubyWindow::~RubyWindow() = default;
 
-bool RubyWindow::BuildReadingText(const commands::RendererCommand &command,
-                                  std::string *reading) const {
+bool RubyWindow::BuildReadingText(
+    const commands::RendererCommand &command,
+    std::string *reading) const {
   reading->clear();
 
   if (!command.has_output()) {
@@ -149,11 +226,67 @@ bool RubyWindow::Update(const commands::RendererCommand &command) {
     InitWindow();
   }
 
+  const RendererStyleHandler::RubyWindowStyle appearance =
+      RendererStyleHandler::GetRubyWindowStyle();
+
+  RendererStyle renderer_style;
+  if (!RendererStyleHandler::GetRendererStyleForWindowType(
+          RendererStyleHandler::RendererStyleType::kCandidate,
+          &renderer_style)) {
+    RendererStyleHandler::GetDefaultRendererStyle(&renderer_style);
+  }
+
+  RendererStyle::TextStyle text_style;
+  text_style.set_font_size(ScaleFontSize(appearance.size_percent));
+  text_style.set_font_weight(
+      static_cast<int32_t>(appearance.font_weight));
+  SetRgbColor(
+      appearance.text_color,
+      text_style.mutable_foreground_color());
+
+  if (renderer_style.has_candidate_style() &&
+      renderer_style.candidate_style().has_font_name() &&
+      !renderer_style.candidate_style().font_name().empty()) {
+    text_style.set_font_name(
+        renderer_style.candidate_style().font_name());
+  }
+
   RubyView *ruby_view = (RubyView *)view_;
-  [ruby_view setRubyText:ToNSString(reading)];
+  [ruby_view
+      setBackgroundColor:ToNSColor(appearance.background_color)
+             borderColor:ToNSColor(appearance.border_color)
+            cornerRadius:ScaleMetric(
+                             appearance.corner_radius,
+                             appearance.size_percent)
+       horizontalPadding:ScaleWindowsRubySpacingToCocoaPoints(
+                             appearance.horizontal_padding,
+                             appearance.size_percent)
+         verticalPadding:ScaleMetric(
+                             appearance.vertical_padding,
+                             appearance.size_percent)];
+
+  [ruby_view setRubyText:
+      MacViewUtil::ToNSAttributedString(reading, text_style)];
+
+  composition_gap_ = static_cast<int32_t>(
+      ScaleMetric(
+          appearance.composition_gap,
+          appearance.size_percent));
+
+  [window_ setAlphaValue:std::clamp<CGFloat>(
+      static_cast<CGFloat>(appearance.opacity_percent) / 100.0,
+      0.0,
+      1.0)];
+
   const NSSize size = [ruby_view preferredSize];
-  ResizeWindow(size.width, size.height);
+  ResizeWindow(
+      static_cast<int32_t>(ceil(size.width)),
+      static_cast<int32_t>(ceil(size.height)));
   return true;
+}
+
+int32_t RubyWindow::GetCompositionGap() const {
+  return composition_gap_;
 }
 
 void RubyWindow::InitWindow() {

--- a/src/renderer/mac/mac_view_util.mm
+++ b/src/renderer/mac/mac_view_util.mm
@@ -28,8 +28,84 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "renderer/mac/mac_view_util.h"
+
+#include <algorithm>
+
 #include "base/coordinates.h"
 #include "protocol/renderer_style.pb.h"
+
+namespace {
+
+NSFontWeight ToNSFontWeight(int renderer_weight) {
+  const int weight = std::clamp(renderer_weight, 100, 900);
+
+  if (weight < 150) {
+    return NSFontWeightUltraLight;
+  }
+  if (weight < 250) {
+    return NSFontWeightThin;
+  }
+  if (weight < 350) {
+    return NSFontWeightLight;
+  }
+  if (weight < 450) {
+    return NSFontWeightRegular;
+  }
+  if (weight < 550) {
+    return NSFontWeightMedium;
+  }
+  if (weight < 650) {
+    return NSFontWeightSemibold;
+  }
+  if (weight < 750) {
+    return NSFontWeightBold;
+  }
+  if (weight < 850) {
+    return NSFontWeightHeavy;
+  }
+  return NSFontWeightBlack;
+}
+
+NSFont *CreateFont(
+    const mozc::renderer::RendererStyle::TextStyle &style) {
+  const CGFloat font_size =
+      std::max<CGFloat>(1.0, static_cast<CGFloat>(style.font_size()));
+  const NSFontWeight font_weight = ToNSFontWeight(style.font_weight());
+
+  if (style.has_font_name() && !style.font_name().empty()) {
+    NSString *family =
+        [NSString stringWithUTF8String:style.font_name().c_str()];
+
+    NSDictionary *traits = [NSDictionary
+        dictionaryWithObject:[NSNumber numberWithDouble:font_weight]
+                      forKey:NSFontWeightTrait];
+    NSDictionary *attributes = [NSDictionary
+        dictionaryWithObjectsAndKeys:
+            family, NSFontFamilyAttribute,
+            traits, NSFontTraitsAttribute,
+            nil];
+
+    NSFontDescriptor *descriptor =
+        [NSFontDescriptor fontDescriptorWithFontAttributes:attributes];
+    NSFont *font =
+        [NSFont fontWithDescriptor:descriptor size:font_size];
+
+    if (font != nil) {
+      return font;
+    }
+
+    // Preserve the selected family even when the family does not publish
+    // the requested weight through its font descriptor.
+    font = [NSFont fontWithName:family size:font_size];
+    if (font != nil) {
+      return font;
+    }
+  }
+
+  return [NSFont systemFontOfSize:font_size weight:font_weight];
+}
+
+}  // namespace
 
 namespace mozc {
 namespace renderer {
@@ -67,25 +143,23 @@ NSColor *MacViewUtil::MacViewUtil::ToNSColor(
                                    alpha:color.a()];
 }
 
-NSAttributedString *MacViewUtil::ToNSAttributedString(const std::string &str,
-                                                      const RendererStyle::TextStyle &style) {
+NSAttributedString *MacViewUtil::ToNSAttributedString(
+    const std::string &str,
+    const RendererStyle::TextStyle &style) {
   NSString *nsstr = [NSString stringWithUTF8String:str.c_str()];
-  NSFont *font;
-  if (style.has_font_name()) {
-    font = [NSFont fontWithName:[NSString stringWithUTF8String:style.font_name().c_str()]
-                           size:style.font_size()];
-  } else {
-    font = [NSFont messageFontOfSize:style.font_size()];
-  }
-  NSDictionary *attr;
+  NSFont *font = CreateFont(style);
+
+  NSMutableDictionary *attributes =
+      [NSMutableDictionary dictionaryWithObject:font
+                                         forKey:NSFontAttributeName];
+
   if (style.has_foreground_color()) {
-    attr = [NSDictionary dictionaryWithObjectsAndKeys:font, NSFontAttributeName,
-                                                      ToNSColor(style.foreground_color()),
-                                                      NSForegroundColorAttributeName, nil];
-  } else {
-    attr = [NSDictionary dictionaryWithObjectsAndKeys:font, NSFontAttributeName, nil];
+    [attributes setObject:ToNSColor(style.foreground_color())
+                   forKey:NSForegroundColorAttributeName];
   }
-  return [[NSAttributedString alloc] initWithString:nsstr attributes:attr];
+
+  return [[NSAttributedString alloc] initWithString:nsstr
+                                         attributes:attributes];
 }
 }  // namespace mozc::renderer::mac
 }  // namespace mozc::renderer

--- a/src/renderer/renderer_style_handler.cc
+++ b/src/renderer/renderer_style_handler.cc
@@ -133,6 +133,9 @@ void ApplyLightCandidateWindowTheme(RendererStyle* style) {
   SetColor(style->mutable_shortcut_style()->mutable_background_color(),
            0xf3, 0xf4, 0xff);
 
+  SetColor(style->mutable_gap1_style()->mutable_background_color(),
+           0xff, 0xff, 0xff);
+
   SetColor(style->mutable_candidate_style()->mutable_foreground_color(),
            0x00, 0x00, 0x00);
   SetColor(style->mutable_candidate_style()->mutable_background_color(),
@@ -185,6 +188,9 @@ void ApplyDarkCandidateWindowTheme(RendererStyle* style) {
   SetColor(style->mutable_shortcut_style()->mutable_foreground_color(),
            0x96, 0xa0, 0xaa);
   SetColor(style->mutable_shortcut_style()->mutable_background_color(),
+           0x18, 0x1b, 0x20);
+
+  SetColor(style->mutable_gap1_style()->mutable_background_color(),
            0x18, 0x1b, 0x20);
 
   SetColor(style->mutable_candidate_style()->mutable_foreground_color(),
@@ -453,6 +459,8 @@ void RendererStyleHandler::ApplyCandidateWindowCustomColors(
               shortcut_text_color);
   SetRgbColor(style->mutable_shortcut_style()->mutable_background_color(),
               shortcut_background_color);
+  SetRgbColor(style->mutable_gap1_style()->mutable_background_color(),
+              background_color);
   SetRgbColor(style->mutable_candidate_style()->mutable_foreground_color(),
               text_color);
   SetRgbColor(style->mutable_candidate_style()->mutable_background_color(),

--- a/src/renderer/renderer_style_handler_test.cc
+++ b/src/renderer/renderer_style_handler_test.cc
@@ -100,6 +100,7 @@ TEST(RendererStyleHandlerTest, ApplyCandidateWindowCustomColors) {
   EXPECT_EQ(0x0d0e0f, Rgb(style.border_color()));
   EXPECT_EQ(0x101112, Rgb(style.shortcut_style().foreground_color()));
   EXPECT_EQ(0x131415, Rgb(style.shortcut_style().background_color()));
+  EXPECT_EQ(0x010203, Rgb(style.gap1_style().background_color()));
   EXPECT_EQ(0x161718, Rgb(style.description_style().foreground_color()));
   EXPECT_EQ(0x191a1b, Rgb(style.footer_style().foreground_color()));
   EXPECT_EQ(0x1c1d1e, Rgb(style.footer_top_color()));
@@ -108,6 +109,22 @@ TEST(RendererStyleHandlerTest, ApplyCandidateWindowCustomColors) {
   EXPECT_EQ(0x252627, Rgb(style.scrollbar_indicator_color()));
 }
 
+
+TEST(RendererStyleHandlerTest,
+     ApplyCandidateWindowThemeSetsGapBackground) {
+  RendererStyle style;
+  RendererStyleHandler::GetDefaultRendererStyle(&style);
+
+  RendererStyleHandler::ApplyCandidateWindowTheme(false, &style);
+  EXPECT_TRUE(style.gap1_style().has_background_color());
+  EXPECT_EQ(Rgb(style.candidate_style().background_color()),
+            Rgb(style.gap1_style().background_color()));
+
+  RendererStyleHandler::ApplyCandidateWindowTheme(true, &style);
+  EXPECT_TRUE(style.gap1_style().has_background_color());
+  EXPECT_EQ(Rgb(style.candidate_style().background_color()),
+            Rgb(style.gap1_style().background_color()));
+}
 
 TEST(RendererStyleHandlerTest, ApplyCandidateWindowSize) {
   RendererStyle style;

--- a/src/renderer/window_util.cc
+++ b/src/renderer/window_util.cc
@@ -29,6 +29,8 @@
 
 #include "renderer/window_util.h"
 
+#include <algorithm>
+
 #include "base/coordinates.h"
 
 namespace mozc {
@@ -210,6 +212,68 @@ Rect WindowUtil::GetWindowRectForCascadingWindow(const Rect& selected_row,
   }
 
   return window_rect;
+}
+
+bool WindowUtil::GetRubyWindowRect(
+    const Rect& preedit_rect, const Size& window_size, int gap,
+    const Rect& working_area, const Rect* avoid_rect, Rect* window_rect) {
+  if (window_rect == nullptr || window_size.width <= 0 ||
+      window_size.height <= 0 || working_area.Width() <= 0 ||
+      working_area.Height() <= 0) {
+    return false;
+  }
+
+  const int normalized_gap = std::max(0, gap);
+
+  int left = preedit_rect.Left();
+  if (preedit_rect.Width() > window_size.width) {
+    left += (preedit_rect.Width() - window_size.width) / 2;
+  }
+
+  const int max_left = std::max(
+      working_area.Left(), working_area.Right() - window_size.width);
+  left = std::clamp(left, working_area.Left(), max_left);
+
+  const auto intersects = [](const Rect& lhs, const Rect& rhs) {
+    return lhs.Left() < rhs.Right() && rhs.Left() < lhs.Right() &&
+           lhs.Top() < rhs.Bottom() && rhs.Top() < lhs.Bottom();
+  };
+
+  const auto is_usable = [&](const Rect& rect) {
+    if (rect.Left() < working_area.Left() ||
+        rect.Right() > working_area.Right() ||
+        rect.Top() < working_area.Top() ||
+        rect.Bottom() > working_area.Bottom()) {
+      return false;
+    }
+
+    if (avoid_rect != nullptr && intersects(rect, *avoid_rect)) {
+      return false;
+    }
+
+    return true;
+  };
+
+  const int above_top =
+      preedit_rect.Top() - window_size.height - normalized_gap;
+  const Rect above_rect(
+      left, above_top, window_size.width, window_size.height);
+
+  if (is_usable(above_rect)) {
+    *window_rect = above_rect;
+    return true;
+  }
+
+  const int below_top = preedit_rect.Bottom() + normalized_gap;
+  const Rect below_rect(
+      left, below_top, window_size.width, window_size.height);
+
+  if (is_usable(below_rect)) {
+    *window_rect = below_rect;
+    return true;
+  }
+
+  return false;
 }
 
 Rect WindowUtil::GetWindowRectForInfolistWindow(const Size& window_size,

--- a/src/renderer/window_util.h
+++ b/src/renderer/window_util.h
@@ -82,6 +82,15 @@ class WindowUtil {
                                               const Point& zero_point_offset,
                                               const Rect& working_area);
 
+  // Returns a ruby-window rectangle that stays inside |working_area| and
+  // does not intersect |avoid_rect|. Placement above the preedit is preferred;
+  // below is used as the fallback. Returns false if neither side is usable.
+  static bool GetRubyWindowRect(const Rect& preedit_rect,
+                                const Size& window_size, int gap,
+                                const Rect& working_area,
+                                const Rect* avoid_rect,
+                                Rect* window_rect);
+
   // Returns the appropriate infolist window position in the screen
   // coordinate.  |window_size| is the size of the infolist window.
   // |candidate_rect| is the rect of the candidate window.

--- a/src/renderer/window_util_test.cc
+++ b/src/renderer/window_util_test.cc
@@ -236,5 +236,47 @@ TEST_F(WindowUtilTest, MonitorErrors) {
   EXPECT_EQ(result.Top(), 32);
 }
 
+TEST_F(WindowUtilTest, RubyWindowPrefersAbovePreedit) {
+  const Rect preedit_rect(100, 200, 20, 20);
+  const Size ruby_size(100, 30);
+  const Rect working_area(0, 0, 1000, 800);
+
+  Rect result;
+  ASSERT_TRUE(WindowUtil::GetRubyWindowRect(
+      preedit_rect, ruby_size, 4, working_area, nullptr, &result));
+
+  EXPECT_EQ(result.Left(), 100);
+  EXPECT_EQ(result.Top(), 166);
+  EXPECT_EQ(result.Width(), 100);
+  EXPECT_EQ(result.Height(), 30);
+}
+
+TEST_F(WindowUtilTest, RubyWindowMovesBelowAvoidRectangle) {
+  const Rect preedit_rect(100, 200, 20, 20);
+  const Size ruby_size(100, 30);
+  const Rect working_area(0, 0, 1000, 800);
+  const Rect avoid_rect(90, 150, 160, 60);
+
+  Rect result;
+  ASSERT_TRUE(WindowUtil::GetRubyWindowRect(
+      preedit_rect, ruby_size, 4, working_area, &avoid_rect, &result));
+
+  EXPECT_EQ(result.Left(), 100);
+  EXPECT_EQ(result.Top(), 224);
+  EXPECT_EQ(result.Width(), 100);
+  EXPECT_EQ(result.Height(), 30);
+}
+
+TEST_F(WindowUtilTest, RubyWindowReturnsFalseWhenBothSidesAreBlocked) {
+  const Rect preedit_rect(100, 200, 20, 20);
+  const Size ruby_size(100, 30);
+  const Rect working_area(0, 0, 1000, 800);
+  const Rect avoid_rect(80, 140, 200, 140);
+
+  Rect result;
+  EXPECT_FALSE(WindowUtil::GetRubyWindowRect(
+      preedit_rect, ruby_size, 4, working_area, &avoid_rect, &result));
+}
+
 }  // namespace renderer
 }  // namespace mozc


### PR DESCRIPTION
## 概要

macOS向けレンダラーの外観設定と、候補・ルビウィンドウの表示位置を改善します。

## 主な変更

- macOSの候補・ルビウィンドウへ外観設定を反映
- ライブ変換時のルビ位置を候補ウィンドウと重ならないよう調整
- 画面上端付近ではルビを下側へフォールバック
- macOSのルビ左右余白をWindows側の設計値に合わせて調整
- 候補ウィンドウの表示位置・ダークモード時の表示を調整
- PKGアップグレード時に旧 `Mozc.app` の残存ファイルが混在しないようpreinstallを修正
- 関連テストを追加・更新

## 確認

- macOS Releaseビルド成功
- 対象4テストすべて成功
- PKGアップグレード後のpayload一致を確認
- `Mozc.app` のcodesign検証成功
- 標準LaunchAgentのログイン時自動ロードを確認
- ログアウト・再ログイン後の動作を確認
- Releaseビルドで候補のデバッグ表示（`R1` / `U`等）が出ないことを確認