### PR TITLE
Honor ruby window visibility setting on macOS

### DIFF
--- a/src/renderer/mac/CandidateController.mm
+++ b/src/renderer/mac/CandidateController.mm
@@ -38,6 +38,7 @@
 #include "renderer/mac/InfolistWindow.h"
 #include "renderer/mac/RubyWindow.h"
 #include "renderer/mac/mac_view_util.h"
+#include "renderer/renderer_style_handler.h"
 #include "renderer/table_layout.h"
 #include "renderer/window_util.h"
 
@@ -182,7 +183,9 @@ bool CandidateController::ExecCommand(const RendererCommand &command) {
             ? &candidate_rect_
             : nullptr;
 
-    if (ruby_window_->Update(command_) &&
+    const RendererStyleHandler::RubyWindowStyle ruby_style =
+        RendererStyleHandler::GetRubyWindowStyle();
+    if (ruby_style.enabled && ruby_window_->Update(command_) &&
         AlignRubyWindow(ruby_avoid_rect)) {
       ruby_window_->Show();
     } else {

--- a/src/renderer/renderer_server.cc
+++ b/src/renderer/renderer_server.cc
@@ -304,6 +304,8 @@ void UpdateRendererStyleFromConfig() {
       ruby_color_theme, shared_config->ruby_window_custom_color_palette(),
       candidate_style, ruby_corner_radius,
       shared_config->ruby_window_size_percent());
+  ruby_style.enabled =
+      shared_config->show_live_conversion_ruby_window();
   ruby_style.corner_radius = ruby_corner_radius;
   ruby_style.size_percent =
       ClampWindowSizePercent(shared_config->ruby_window_size_percent());

--- a/src/renderer/renderer_server_test.cc
+++ b/src/renderer/renderer_server_test.cc
@@ -134,6 +134,25 @@ TEST_F(RendererServerTest, UsesRubySpacingDefaultsWhenFieldsAreAbsent) {
   EXPECT_EQ(4u, style.composition_gap);
 }
 
+TEST_F(RendererServerTest,
+       UsesLiveConversionRubyVisibilityDefaultWhenFieldIsAbsent) {
+  config::Config input = config::ConfigHandler::DefaultConfig();
+  input.clear_show_live_conversion_ruby_window();
+  config::ConfigHandler::SetConfig(input);
+
+  TestRendererServer server;
+  EXPECT_TRUE(RendererStyleHandler::GetRubyWindowStyle().enabled);
+}
+
+TEST_F(RendererServerTest, AppliesLiveConversionRubyVisibilityConfig) {
+  config::Config input = config::ConfigHandler::DefaultConfig();
+  input.set_show_live_conversion_ruby_window(false);
+  config::ConfigHandler::SetConfig(input);
+
+  TestRendererServer server;
+  EXPECT_FALSE(RendererStyleHandler::GetRubyWindowStyle().enabled);
+}
+
 TEST_F(RendererServerTest, UsesFontWeightDefaultsWhenFieldsAreAbsent) {
   config::Config input = config::ConfigHandler::DefaultConfig();
   input.clear_candidate_window_font_weight();

--- a/src/renderer/renderer_style_handler.h
+++ b/src/renderer/renderer_style_handler.h
@@ -61,6 +61,7 @@ class RendererStyleHandler {
   };
 
   struct RubyWindowStyle {
+    bool enabled = true;
     uint32_t background_color = 0xffffff;
     uint32_t text_color = 0x000000;
     uint32_t border_color = 0x969696;


### PR DESCRIPTION
## 概要

macOSで「ライブ変換中にルビウィンドウを表示」を無効にしても、ルビウィンドウが表示され続ける問題を修正します。

## 変更内容

- `show_live_conversion_ruby_window` をmacOS Rendererへ反映
- 無効時はルビウィンドウを表示しないように修正
- デフォルト値および明示的な無効設定のテストを追加

## 確認

- `renderer_server_test` / `renderer_style_handler_test` PASS
- macOS RendererのRelease build成功
- Release PKGを実機インストールし、設定OFF時にルビウィンドウが表示されないことを確認
