### PR TITLE
Fix antialiased renderer corners and shadow z-order on Windows

### DIFF
--- a/src/renderer/win32/BUILD.bazel
+++ b/src/renderer/win32/BUILD.bazel
@@ -242,6 +242,7 @@ mozc_cc_library(
         "//protocol:config_cc_proto",
         "//protocol:renderer_cc_proto",
         "//renderer:renderer_style_handler",
+        "@com_microsoft_wil//:wil",
     ],
 )
 

--- a/src/renderer/win32/candidate_window.cc
+++ b/src/renderer/win32/candidate_window.cc
@@ -171,37 +171,6 @@ COLORREF GetFooterBorderColor(const RendererStyle& style) {
   return GetFrameColor(style);
 }
 
-int GetWindowCornerRadius(uint32_t dpi,
-                          RendererStyleHandler::RendererStyleType style_type) {
-  const uint32_t logical_radius =
-      RendererStyleHandler::GetCandidateWindowCornerRadius(style_type);
-  if (logical_radius == 0) {
-    return 0;
-  }
-  return static_cast<int>(std::lround(logical_radius *
-                                      GetDPIScalingFactor(dpi)));
-}
-
-void UpdateRoundedWindowRegion(
-    HWND hwnd, const Size& size, uint32_t dpi,
-    RendererStyleHandler::RendererStyleType style_type) {
-  if (hwnd == nullptr || size.width <= 0 || size.height <= 0) {
-    return;
-  }
-
-  const int radius = GetWindowCornerRadius(dpi, style_type);
-  if (radius <= 0) {
-    ::SetWindowRgn(hwnd, nullptr, TRUE);
-    return;
-  }
-  HRGN region =
-      ::CreateRoundRectRgn(0, 0, size.width + 1, size.height + 1,
-                           radius * 2, radius * 2);
-  if (region != nullptr) {
-    ::SetWindowRgn(hwnd, region, TRUE);
-  }
-}
-
 // Returns the smallest index of the given candidate list which satisfies
 // candidates.candidate(i) == |candidate_index|.
 // This function returns the size of the given candidate list when there
@@ -498,31 +467,25 @@ void CandidateWindow::OnMouseMove(UINT nFlags, CPoint point) {
 }
 
 void CandidateWindow::OnPaint(HDC dc) {
-  CRect client_rect;
-  this->GetClientRect(&client_rect);
-
-  wil::unique_hdc_paint paint_dc;
-  if (dc == nullptr) {
-    paint_dc = wil::BeginPaint(this->m_hWnd);
-  }
-  HDC target_dc = paint_dc.is_valid() ? paint_dc.get() : dc;
-
-  if (BitBltCachedBitmapTo(target_dc, client_rect)) {
+  if (dc != nullptr) {
+    DoPaint(dc, true);
     return;
   }
 
-  // Render to offline bitmap first to avoid tearing.
-  wil::unique_hdc memdc(::CreateCompatibleDC(target_dc));
-  wil::unique_hbitmap bitmap(::CreateCompatibleBitmap(
-      target_dc, client_rect.Width(), client_rect.Height()));
-  wil::unique_select_object old_bitmap =
-      wil::SelectObject(memdc.get(), bitmap.get());
-  DoPaint(memdc.get());
-  ::BitBlt(target_dc, client_rect.left, client_rect.top, client_rect.Width(),
-           client_rect.Height(), memdc.get(), 0, 0, SRCCOPY);
+  // UpdateLayeredWindow owns the on-screen candidate surface. WM_PAINT only
+  // validates the invalid region and re-presents the cache when necessary.
+  wil::unique_hdc_paint paint_dc = wil::BeginPaint(this->m_hWnd);
+  if (!cached_bitmap_valid_ && !RenderToBitmapCache()) {
+    return;
+  }
+  PresentCachedBitmapImmediately();
 }
 
-void CandidateWindow::OnPrintClient(HDC dc, UINT uFlags) { OnPaint(dc); }
+void CandidateWindow::OnPrintClient(HDC dc, UINT /*uFlags*/) {
+  if (dc != nullptr) {
+    DoPaint(dc, true);
+  }
+}
 
 bool CandidateWindow::RenderToBitmapCache() {
   ClearBitmapCache();
@@ -542,47 +505,42 @@ bool CandidateWindow::RenderToBitmapCache() {
   }
 
   wil::unique_hdc memdc(::CreateCompatibleDC(screen_dc));
-  wil::unique_hbitmap bitmap(::CreateCompatibleBitmap(
-      screen_dc, layout_size.width, layout_size.height));
+
+  uint32_t* pixels = nullptr;
+  wil::unique_hbitmap bitmap(CreateRendererLayeredWindowBitmap(
+      screen_dc, layout_size.width, layout_size.height, &pixels));
   ::ReleaseDC(nullptr, screen_dc);
 
-  if (!memdc.is_valid() || !bitmap.is_valid()) {
+  if (!memdc.is_valid() || !bitmap.is_valid() || pixels == nullptr) {
     return false;
   }
 
+  std::fill_n(pixels, static_cast<size_t>(layout_size.width) *
+                          static_cast<size_t>(layout_size.height),
+              0u);
+
   wil::unique_select_object old_bitmap =
       wil::SelectObject(memdc.get(), bitmap.get());
-  DoPaint(memdc.get());
+  DoPaint(memdc.get(), false);
+
+  // GDI may batch writes to a DIB section. Flush before touching the backing
+  // memory directly so the alpha/border pass observes the completed frame.
+  ::GdiFlush();
+
+  const RendererStyleHandler::RendererStyleType style_type =
+      GetRendererStyleType(*candidate_window_);
+  const RendererStyle style = GetCurrentRendererStyle(style_type);
+  const int corner_radius = GetRendererWindowCornerRadiusInPixels(
+      RendererStyleHandler::GetCandidateWindowCornerRadius(style_type), dpi_,
+      layout_size.width, layout_size.height);
+  ApplyRoundedRectAlphaAndBorder(pixels, layout_size.width, layout_size.height,
+                                 corner_radius, kWindowBorder,
+                                 GetFrameColor(style));
 
   cached_bitmap_ = std::move(bitmap);
   cached_bitmap_size_ = layout_size;
   cached_bitmap_valid_ = true;
   return true;
-}
-
-bool CandidateWindow::BitBltCachedBitmapTo(HDC target_dc,
-                                           const RECT& target_rect) const {
-  if (target_dc == nullptr || !cached_bitmap_valid_ ||
-      !cached_bitmap_.is_valid()) {
-    return false;
-  }
-
-  const int width = target_rect.right - target_rect.left;
-  const int height = target_rect.bottom - target_rect.top;
-  if (width <= 0 || height <= 0 || cached_bitmap_size_.width != width ||
-      cached_bitmap_size_.height != height) {
-    return false;
-  }
-
-  wil::unique_hdc memdc(::CreateCompatibleDC(target_dc));
-  if (!memdc.is_valid()) {
-    return false;
-  }
-
-  wil::unique_select_object old_bitmap =
-      wil::SelectObject(memdc.get(), cached_bitmap_.get());
-  return ::BitBlt(target_dc, target_rect.left, target_rect.top, width, height,
-                  memdc.get(), 0, 0, SRCCOPY) != FALSE;
 }
 
 void CandidateWindow::ClearBitmapCache() {
@@ -592,25 +550,23 @@ void CandidateWindow::ClearBitmapCache() {
 }
 
 void CandidateWindow::PresentCachedBitmapImmediately() {
-  if (m_hWnd == nullptr || !::IsWindow(m_hWnd)) {
+  if (m_hWnd == nullptr || !::IsWindow(m_hWnd) || !cached_bitmap_valid_ ||
+      !cached_bitmap_.is_valid() || cached_bitmap_size_.width <= 0 ||
+      cached_bitmap_size_.height <= 0) {
     return;
   }
 
-  RECT client_rect = {};
-  if (!::GetClientRect(m_hWnd, &client_rect)) {
-    return;
-  }
-
-  HDC target_dc = ::GetDC(m_hWnd);
-  if (target_dc == nullptr) {
-    return;
-  }
-
-  BitBltCachedBitmapTo(target_dc, client_rect);
-  ::ReleaseDC(m_hWnd, target_dc);
+  const RendererStyleHandler::RendererStyleType style_type =
+      GetRendererStyleType(*candidate_window_);
+  const RendererStyleHandler::CandidateWindowEffectStyle effect_style =
+      RendererStyleHandler::GetCandidateWindowEffectStyle(style_type);
+  PresentRendererLayeredWindowBitmap(
+      m_hWnd, cached_bitmap_.get(), cached_bitmap_size_.width,
+      cached_bitmap_size_.height,
+      RendererWindowOpacityToAlpha(effect_style.opacity_percent));
 }
 
-void CandidateWindow::DoPaint(HDC dc) {
+void CandidateWindow::DoPaint(HDC dc, bool draw_frame) {
   switch (candidate_window_->category()) {
     case commands::CONVERSION:
     case commands::PREDICTION:
@@ -638,7 +594,9 @@ void CandidateWindow::DoPaint(HDC dc) {
   DrawInformationIcon(dc);
   DrawVScrollBar(dc);
   DrawFooter(dc);
-  DrawFrame(dc);
+  if (draw_frame) {
+    DrawFrame(dc);
+  }
 }
 
 void CandidateWindow::OnShowWindow(BOOL shown, UINT /*status*/) {
@@ -855,18 +813,6 @@ void CandidateWindow::UpdateLayout(
   table_layout_->FreezeLayout();
 
   RenderToBitmapCache();
-
-  if (m_hWnd != nullptr) {
-    UpdateRoundedWindowRegion(m_hWnd, table_layout_->GetTotalSize(), dpi_,
-                              GetRendererStyleType(*candidate_window_));
-  }
-}
-
-void CandidateWindow::RedrawImmediately() {
-  if (m_hWnd != nullptr && ::IsWindow(m_hWnd)) {
-    ::RedrawWindow(m_hWnd, nullptr, nullptr,
-                   RDW_INVALIDATE | RDW_UPDATENOW | RDW_NOERASE);
-  }
 }
 
 void CandidateWindow::UpdateEffectWindows() {
@@ -877,7 +823,6 @@ void CandidateWindow::UpdateEffectWindows() {
       GetRendererStyleType(*candidate_window_);
   const RendererStyleHandler::CandidateWindowEffectStyle effect_style =
       RendererStyleHandler::GetCandidateWindowEffectStyle(style_type);
-  ApplyRendererWindowOpacity(m_hWnd, effect_style.opacity_percent);
   RECT window_rect = {};
   if (!::GetWindowRect(m_hWnd, &window_rect)) {
     shadow_window_.Hide();
@@ -888,10 +833,11 @@ void CandidateWindow::UpdateEffectWindows() {
   shadow_style.opacity_percent = effect_style.shadow.opacity_percent;
   shadow_style.angle_degrees = effect_style.shadow.angle_degrees;
   shadow_style.distance = effect_style.shadow.distance;
-  shadow_window_.Update(m_hWnd, window_rect, dpi_,
-                        RendererStyleHandler::GetCandidateWindowCornerRadius(
-                            style_type),
-                        shadow_style);
+  const int corner_radius = GetRendererWindowCornerRadiusInPixels(
+      RendererStyleHandler::GetCandidateWindowCornerRadius(style_type), dpi_,
+      window_rect.right - window_rect.left, window_rect.bottom - window_rect.top);
+  shadow_window_.Update(m_hWnd, window_rect, dpi_, corner_radius, shadow_style,
+                        shadow_z_order_anchor_);
 }
 
 void CandidateWindow::SetSendCommandInterface(
@@ -1116,8 +1062,10 @@ void CandidateWindow::DrawSelectedRect(HDC dc) {
 
     selected_rect.DeflateRect(4, 1);
 
-    const int radius = GetWindowCornerRadius(
-        dpi_, GetRendererStyleType(*candidate_window_));
+    const int radius = GetRendererWindowCornerRadiusInPixels(
+        RendererStyleHandler::GetCandidateWindowCornerRadius(
+            GetRendererStyleType(*candidate_window_)),
+        dpi_, selected_rect.Width(), selected_rect.Height());
 
     wil::unique_select_object prev_pen =
         wil::SelectObject(dc, static_cast<HPEN>(::GetStockObject(DC_PEN)));
@@ -1170,8 +1118,10 @@ void CandidateWindow::DrawFrame(HDC dc) {
   const Rect client_rect(Point(0, 0), table_layout_->GetTotalSize());
   const CRect client_crect = ToCRect(client_rect);
 
-  const int radius = GetWindowCornerRadius(
-        dpi_, GetRendererStyleType(*candidate_window_));
+  const int radius = GetRendererWindowCornerRadiusInPixels(
+      RendererStyleHandler::GetCandidateWindowCornerRadius(
+          GetRendererStyleType(*candidate_window_)),
+      dpi_, client_crect.Width(), client_crect.Height());
 
   wil::unique_select_object prev_pen =
       wil::SelectObject(dc, static_cast<HPEN>(::GetStockObject(DC_PEN)));

--- a/src/renderer/win32/candidate_window.h
+++ b/src/renderer/win32/candidate_window.h
@@ -58,8 +58,9 @@ namespace win32 {
 // SPI_GETACTIVEWINDOWTRACKING is enabled.
 // TODO(yukawa): Support mouse operations before we add a GUI feature which
 //   requires UI interaction by mouse and/or touch. (b/2954874)
-typedef ATL::CWinTraits<WS_POPUP | WS_DISABLED,
-                        WS_EX_TOOLWINDOW | WS_EX_TOPMOST | WS_EX_NOACTIVATE>
+typedef ATL::CWinTraits<
+    WS_POPUP | WS_DISABLED,
+    WS_EX_TOOLWINDOW | WS_EX_TOPMOST | WS_EX_NOACTIVATE | WS_EX_LAYERED>
     CandidateWindowTraits;
 
 // a class which implements an IME candidate window for Windows. This class
@@ -111,12 +112,12 @@ class CandidateWindow : public ATL::CWindowImpl<CandidateWindow, ATL::CWindow,
 
   void UpdateLayout(const commands::CandidateWindow& candidate_window);
   void UpdateEffectWindows();
-  void RedrawImmediately();
-  // Paints the pre-rendered candidate window bitmap to the window DC
-  // immediately.  This is used just after SWP_SHOWWINDOW for live passive
-  // suggestion UI so that the first visible frame already contains the
-  // completed candidate contents.  If the cache is unavailable, this method
-  // is a no-op and the normal WM_PAINT path remains the fallback.
+  void SetShadowZOrderAnchor(HWND hwnd) { shadow_z_order_anchor_ = hwnd; }
+  HWND GetWindowHandle() const { return m_hWnd; }
+  // Presents the pre-rendered PBGRA candidate surface with per-pixel alpha.
+  // The rounded silhouette and the configured whole-window opacity are both
+  // composed by UpdateLayeredWindow, so this must be used instead of BitBlt or
+  // SetLayeredWindowAttributes for candidate-like windows.
   void PresentCachedBitmapImmediately();
   // Hides both the candidate window and its renderer-owned visual effects.
   // This avoids one-frame shadow remnants when WindowManager suppresses or
@@ -132,10 +133,9 @@ class CandidateWindow : public ATL::CWindowImpl<CandidateWindow, ATL::CWindow,
   Rect GetFirstRowInClientCord() const;
 
  private:
-  void DoPaint(HDC dc);
+  void DoPaint(HDC dc, bool draw_frame);
 
   bool RenderToBitmapCache();
-  bool BitBltCachedBitmapTo(HDC target_dc, const RECT& target_rect) const;
   void ClearBitmapCache();
 
   void DrawCells(HDC dc);
@@ -232,6 +232,7 @@ class CandidateWindow : public ATL::CWindowImpl<CandidateWindow, ATL::CWindow,
   int indicator_width_;
   bool metrics_changed_;
   bool mouse_moving_;
+  HWND shadow_z_order_anchor_ = nullptr;
   RendererShadowWindow shadow_window_;
 };
 

--- a/src/renderer/win32/infolist_window.cc
+++ b/src/renderer/win32/infolist_window.cc
@@ -35,6 +35,8 @@
 #include <wil/resource.h>
 #include <windows.h>
 
+#include <algorithm>
+#include <cstddef>
 #include <cstdint>
 #include <string>
 
@@ -101,9 +103,11 @@ void InfolistWindow::UpdateDpi(uint32_t dpi) {
   GetScaledRendererStyleForWindowType(
       RendererStyleHandler::RendererStyleType::kCandidate, style_.get(), dpi_);
   text_renderer_->OnDpiChanged(dpi_);
+  ClearBitmapCache();
 }
 
 void InfolistWindow::OnDestroy() {
+  ClearBitmapCache();
   shadow_window_.Destroy();
   // PostQuitMessage may stop the message loop even though other
   // windows are not closed. WindowManager should close these windows
@@ -126,29 +130,27 @@ void InfolistWindow::OnGetMinMaxInfo(MINMAXINFO* min_max_info) {
 }
 
 void InfolistWindow::OnPaint(HDC dc) {
-  CRect client_rect;
-  this->GetClientRect(&client_rect);
-
-  wil::unique_hdc_paint paint_dc;
-  if (dc == nullptr) {
-    paint_dc = wil::BeginPaint(this->m_hWnd);
+  if (dc != nullptr) {
+    DoPaint(dc, true);
+    return;
   }
-  HDC target_dc = paint_dc.is_valid() ? paint_dc.get() : dc;
 
-  // Render to off-screen bitmap first to avoid tearing.
-  wil::unique_hdc memdc(::CreateCompatibleDC(target_dc));
-  wil::unique_hbitmap bitmap(::CreateCompatibleBitmap(
-      target_dc, client_rect.Width(), client_rect.Height()));
-  wil::unique_select_object old_bitmap =
-      wil::SelectObject(memdc.get(), bitmap.get());
-  DoPaint(memdc.get());
-  ::BitBlt(target_dc, client_rect.left, client_rect.top, client_rect.Width(),
-           client_rect.Height(), memdc.get(), 0, 0, SRCCOPY);
+  // The on-screen surface belongs to UpdateLayeredWindow. WM_PAINT only
+  // validates the region and restores the cached layered surface if needed.
+  wil::unique_hdc_paint paint_dc = wil::BeginPaint(this->m_hWnd);
+  if (!cached_bitmap_valid_ && !RenderToBitmapCache()) {
+    return;
+  }
+  PresentCachedBitmapImmediately();
 }
 
-void InfolistWindow::OnPrintClient(HDC dc, UINT uFlags) { OnPaint(dc); }
+void InfolistWindow::OnPrintClient(HDC dc, UINT /*uFlags*/) {
+  if (dc != nullptr) {
+    DoPaint(dc, true);
+  }
+}
 
-Size InfolistWindow::DoPaint(HDC dc) {
+Size InfolistWindow::DoPaint(HDC dc, bool draw_frame) {
   if (dc != nullptr) {
     ::SetBkMode(dc, TRANSPARENT);
   }
@@ -193,12 +195,26 @@ Size InfolistWindow::DoPaint(HDC dc) {
   }
   ypos += infostyle.window_border();
 
-  if (dc != nullptr) {
+  if (dc != nullptr && draw_frame) {
     const CRect rect(0, 0, infostyle.window_width(), ypos);
-    ::SetDCBrushColor(
-        dc, RGB(infostyle.border_color().r(), infostyle.border_color().g(),
-                infostyle.border_color().b()));
-    ::FrameRect(dc, &rect, static_cast<HBRUSH>(::GetStockObject(DC_BRUSH)));
+    const COLORREF border_color =
+        RGB(infostyle.border_color().r(), infostyle.border_color().g(),
+            infostyle.border_color().b());
+    const int corner_radius = GetRendererWindowCornerRadiusInPixels(
+        RendererStyleHandler::GetCandidateWindowCornerRadius(
+            RendererStyleHandler::RendererStyleType::kCandidate),
+        dpi_, rect.Width(), rect.Height());
+    wil::unique_select_object old_brush = wil::SelectObject(
+        dc, static_cast<HBRUSH>(::GetStockObject(HOLLOW_BRUSH)));
+    wil::unique_select_object old_pen =
+        wil::SelectObject(dc, static_cast<HPEN>(::GetStockObject(DC_PEN)));
+    ::SetDCPenColor(dc, border_color);
+    if (corner_radius <= 0) {
+      ::Rectangle(dc, rect.left, rect.top, rect.right, rect.bottom);
+    } else {
+      ::RoundRect(dc, rect.left, rect.top, rect.right, rect.bottom,
+                  corner_radius * 2, corner_radius * 2);
+    }
   }
 
   return Size(style_->infolist_style().window_width(), ypos);
@@ -313,6 +329,7 @@ void InfolistWindow::OnSettingChange(UINT uFlags, LPCTSTR /*lpszSection*/) {
     case SPI_SETFONTSMOOTHINGTYPE:
     case SPI_SETNONCLIENTMETRICS:
       metrics_changed_ = true;
+      ClearBitmapCache();
       break;
     default:
       // We ignore other changes.
@@ -335,6 +352,9 @@ void InfolistWindow::DelayShow(UINT mseconds) {
   visible_ = true;
   KillTimer(kIdDelayShowHideTimer);
   if (mseconds <= 0) {
+    // Prepare the layered pixels before exposing the window so delayed usage
+    // UI cannot flash an empty or rectangular first frame.
+    PresentCachedBitmapImmediately();
     SetWindowPos(HWND_TOPMOST, 0, 0, 0, 0,
                  SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE | SWP_SHOWWINDOW);
     SendMessageW(WM_NCACTIVATE, FALSE);
@@ -357,6 +377,7 @@ void InfolistWindow::DelayHide(UINT mseconds) {
 
 void InfolistWindow::UpdateLayout(
     const commands::CandidateWindow& candidate_window) {
+  ClearBitmapCache();
   *candidate_window_ = candidate_window;
 
   // InfolistWindow caches both RendererStyle and TextRenderer.  Mozkey's
@@ -366,7 +387,95 @@ void InfolistWindow::UpdateLayout(
       RendererStyleHandler::RendererStyleType::kCandidate, style_.get(), dpi_);
   text_renderer_->OnThemeChanged();
   metrics_changed_ = false;
-  UpdateEffectWindows();
+  RenderToBitmapCache();
+}
+
+bool InfolistWindow::RenderToBitmapCache() {
+  ClearBitmapCache();
+  if (metrics_changed_) {
+    GetScaledRendererStyleForWindowType(
+        RendererStyleHandler::RendererStyleType::kCandidate, style_.get(),
+        dpi_);
+    text_renderer_->OnThemeChanged();
+    metrics_changed_ = false;
+  }
+  const Size layout_size = DoPaint(nullptr, false);
+  if (layout_size.width <= 0 || layout_size.height <= 0) {
+    return false;
+  }
+
+  HDC screen_dc = ::GetDC(nullptr);
+  if (screen_dc == nullptr) {
+    return false;
+  }
+  wil::unique_hdc memory_dc(::CreateCompatibleDC(screen_dc));
+  uint32_t* pixels = nullptr;
+  wil::unique_hbitmap bitmap(CreateRendererLayeredWindowBitmap(
+      screen_dc, layout_size.width, layout_size.height, &pixels));
+  ::ReleaseDC(nullptr, screen_dc);
+  if (!memory_dc.is_valid() || !bitmap.is_valid() || pixels == nullptr) {
+    return false;
+  }
+
+  std::fill_n(pixels, static_cast<size_t>(layout_size.width) *
+                          static_cast<size_t>(layout_size.height),
+              0u);
+  wil::unique_select_object old_bitmap =
+      wil::SelectObject(memory_dc.get(), bitmap.get());
+
+  const RendererStyle::InfolistStyle& infostyle = style_->infolist_style();
+  COLORREF background_color = kDefaultBackgroundColor;
+  if (infostyle.title_style().has_background_color()) {
+    const RendererStyle::RGBAColor& background =
+        infostyle.title_style().background_color();
+    background_color = RGB(background.r(), background.g(), background.b());
+  }
+  const RECT background_rect = {0, 0, layout_size.width, layout_size.height};
+  FillSolidRect(memory_dc.get(), &background_rect, background_color);
+  DoPaint(memory_dc.get(), false);
+  ::GdiFlush();
+
+  const int corner_radius = GetRendererWindowCornerRadiusInPixels(
+      RendererStyleHandler::GetCandidateWindowCornerRadius(
+          RendererStyleHandler::RendererStyleType::kCandidate),
+      dpi_, layout_size.width, layout_size.height);
+  const COLORREF border_color =
+      RGB(infostyle.border_color().r(), infostyle.border_color().g(),
+          infostyle.border_color().b());
+  ApplyRoundedRectAlphaAndBorder(pixels, layout_size.width, layout_size.height,
+                                 corner_radius, /*border_width=*/1,
+                                 border_color);
+
+  cached_bitmap_ = std::move(bitmap);
+  cached_bitmap_size_ = layout_size;
+  cached_bitmap_valid_ = true;
+  return true;
+}
+
+void InfolistWindow::ClearBitmapCache() {
+  cached_bitmap_.reset();
+  cached_bitmap_size_ = Size(0, 0);
+  cached_bitmap_valid_ = false;
+}
+
+void InfolistWindow::PresentCachedBitmapImmediately() {
+  if (m_hWnd == nullptr || !::IsWindow(m_hWnd)) {
+    return;
+  }
+  if (!cached_bitmap_valid_ && !RenderToBitmapCache()) {
+    return;
+  }
+  if (!cached_bitmap_.is_valid() || cached_bitmap_size_.width <= 0 ||
+      cached_bitmap_size_.height <= 0) {
+    return;
+  }
+  const RendererStyleHandler::CandidateWindowEffectStyle effect_style =
+      RendererStyleHandler::GetCandidateWindowEffectStyle(
+          RendererStyleHandler::RendererStyleType::kCandidate);
+  PresentRendererLayeredWindowBitmap(
+      m_hWnd, cached_bitmap_.get(), cached_bitmap_size_.width,
+      cached_bitmap_size_.height,
+      RendererWindowOpacityToAlpha(effect_style.opacity_percent));
 }
 
 void InfolistWindow::UpdateEffectWindows() {
@@ -376,7 +485,7 @@ void InfolistWindow::UpdateEffectWindows() {
   const RendererStyleHandler::CandidateWindowEffectStyle effect_style =
       RendererStyleHandler::GetCandidateWindowEffectStyle(
           RendererStyleHandler::RendererStyleType::kCandidate);
-  ApplyRendererWindowOpacity(m_hWnd, effect_style.opacity_percent);
+  PresentCachedBitmapImmediately();
   RECT window_rect = {};
   if (!::GetWindowRect(m_hWnd, &window_rect)) {
     shadow_window_.Hide();
@@ -387,11 +496,13 @@ void InfolistWindow::UpdateEffectWindows() {
   shadow_style.opacity_percent = effect_style.shadow.opacity_percent;
   shadow_style.angle_degrees = effect_style.shadow.angle_degrees;
   shadow_style.distance = effect_style.shadow.distance;
-  shadow_window_.Update(
-      m_hWnd, window_rect, dpi_,
+  const int corner_radius = GetRendererWindowCornerRadiusInPixels(
       RendererStyleHandler::GetCandidateWindowCornerRadius(
           RendererStyleHandler::RendererStyleType::kCandidate),
-      shadow_style);
+      dpi_, window_rect.right - window_rect.left,
+      window_rect.bottom - window_rect.top);
+  shadow_window_.Update(m_hWnd, window_rect, dpi_, corner_radius, shadow_style,
+                        shadow_z_order_anchor_);
 }
 
 void InfolistWindow::SetSendCommandInterface(
@@ -399,7 +510,12 @@ void InfolistWindow::SetSendCommandInterface(
   send_command_interface_ = send_command_interface;
 }
 
-Size InfolistWindow::GetLayoutSize() { return DoPaint(nullptr); }
+Size InfolistWindow::GetLayoutSize() {
+  if (cached_bitmap_valid_) {
+    return cached_bitmap_size_;
+  }
+  return DoPaint(nullptr, false);
+}
 }  // namespace win32
 }  // namespace renderer
 }  // namespace mozc

--- a/src/renderer/win32/infolist_window.h
+++ b/src/renderer/win32/infolist_window.h
@@ -33,6 +33,7 @@
 #include <atlbase.h>
 #include <atltypes.h>
 #include <atlwin.h>
+#include <wil/resource.h>
 #include <windows.h>
 
 #include <cstdint>
@@ -52,7 +53,8 @@ namespace renderer {
 namespace win32 {
 
 typedef ATL::CWinTraits<WS_POPUP | WS_DISABLED,
-                        WS_EX_TOOLWINDOW | WS_EX_TOPMOST | WS_EX_NOACTIVATE>
+                        WS_EX_LAYERED | WS_EX_TOOLWINDOW | WS_EX_TOPMOST |
+                            WS_EX_NOACTIVATE>
     InfolistWindowTraits;
 
 // a class which implements an IME infolist window for Windows. This class
@@ -95,7 +97,9 @@ class InfolistWindow : public ATL::CWindowImpl<InfolistWindow, ATL::CWindow,
   void UpdateDpi(uint32_t dpi);
 
   void UpdateLayout(const commands::CandidateWindow& candidates);
+  void PresentCachedBitmapImmediately();
   void UpdateEffectWindows();
+  void SetShadowZOrderAnchor(HWND hwnd) { shadow_z_order_anchor_ = hwnd; }
   void SetSendCommandInterface(
       client::SendCommandInterface* send_command_interface);
 
@@ -106,8 +110,10 @@ class InfolistWindow : public ATL::CWindowImpl<InfolistWindow, ATL::CWindow,
   void DelayHide(UINT mseconds);
 
  private:
-  Size DoPaint(HDC dc);
+  Size DoPaint(HDC dc, bool draw_frame);
   Size DoPaintRow(HDC dc, int row, int ypos);
+  bool RenderToBitmapCache();
+  void ClearBitmapCache();
 
   inline LRESULT OnDestroy(UINT msg_id, WPARAM wparam, LPARAM lparam,
                            BOOL& handled) {
@@ -157,6 +163,10 @@ class InfolistWindow : public ATL::CWindowImpl<InfolistWindow, ATL::CWindow,
   std::unique_ptr<renderer::RendererStyle> style_;
   bool metrics_changed_;
   bool visible_;
+  wil::unique_hbitmap cached_bitmap_;
+  Size cached_bitmap_size_;
+  bool cached_bitmap_valid_ = false;
+  HWND shadow_z_order_anchor_ = nullptr;
   RendererShadowWindow shadow_window_;
 };
 

--- a/src/renderer/win32/ruby_window.cc
+++ b/src/renderer/win32/ruby_window.cc
@@ -2,8 +2,11 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstddef>
 #include <cstdint>
 #include <string>
+
+#include <wil/resource.h>
 
 #include "base/win32/win_util.h"
 #include "base/win32/wide_char.h"
@@ -46,14 +49,6 @@ COLORREF ToColorRef(uint32_t rgb) {
 
 RendererStyleHandler::RubyWindowStyle GetRubyWindowTheme() {
   return RendererStyleHandler::GetRubyWindowStyle();
-}
-
-int ScaleCornerRadius(uint32_t logical_radius, uint32_t dpi) {
-  if (logical_radius == 0) {
-    return 0;
-  }
-  return static_cast<int>(
-      std::lround(logical_radius * GetDPIScalingFactor(dpi)));
 }
 
 int ScaleByPercent(int value, uint32_t percent) {
@@ -207,9 +202,6 @@ void RubyWindow::Initialize() {
     Create(nullptr);
   }
 
-  ApplyRendererWindowOpacity(
-      m_hWnd, RendererStyleHandler::GetRubyWindowStyle().opacity_percent);
-
   ShowWindow(SW_HIDE);
 }
 
@@ -238,6 +230,14 @@ void RubyWindow::ClearPlacementTracking() {
 void RubyWindow::Hide() {
   ClearPlacementTracking();
   HideWindowOnly();
+}
+
+void RubyWindow::RaiseToTopmostWithoutActivation() {
+  if (m_hWnd == nullptr || !::IsWindow(m_hWnd) || !::IsWindowVisible(m_hWnd)) {
+    return;
+  }
+  SetWindowPos(HWND_TOPMOST, 0, 0, 0, 0,
+               SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE);
 }
 
 bool RubyWindow::BuildReadingText(
@@ -682,28 +682,29 @@ void RubyWindow::OnUpdate(const commands::RendererCommand& command,
   }
   transient_geometry_reject_count_ = 0;
 
-  const int radius = ScaleCornerRadius(
-      RendererStyleHandler::GetRubyWindowStyle().corner_radius, dpi_);
-  if (radius <= 0) {
-    ::SetWindowRgn(m_hWnd, nullptr, TRUE);
-  } else {
-    HRGN region = ::CreateRoundRectRgn(0, 0, window_size_.cx + 1,
-                                       window_size_.cy + 1, radius * 2,
-                                       radius * 2);
-    ::SetWindowRgn(m_hWnd, region, TRUE);
-    // Ownership of |region| is transferred to the window.
+  // Resize and position while still hidden. The layered surface is fully
+  // prepared before ShowWindow so the first visible ruby frame is already
+  // antialiased and complete.
+  SetWindowPos(HWND_TOPMOST, left, top, window_size_.cx, window_size_.cy,
+               SWP_NOACTIVATE);
+  if (!RenderAndPresent()) {
+    restore_previous_content();
+    HideWindowOnly();
+    return;
   }
 
-  SetWindowPos(HWND_TOPMOST, left, top, window_size_.cx, window_size_.cy,
-               SWP_NOACTIVATE | SWP_SHOWWINDOW);
-  ApplyRendererWindowOpacity(m_hWnd, GetRubyWindowTheme().opacity_percent);
+  ShowWindow(SW_SHOWNOACTIVATE);
+
+  const RendererStyleHandler::RubyWindowStyle current_theme =
+      GetRubyWindowTheme();
   RendererWindowShadowStyle shadow_style;
-  shadow_style.size = GetRubyWindowTheme().shadow.size;
-  shadow_style.opacity_percent = GetRubyWindowTheme().shadow.opacity_percent;
-  shadow_style.angle_degrees = GetRubyWindowTheme().shadow.angle_degrees;
-  shadow_style.distance = GetRubyWindowTheme().shadow.distance;
-  shadow_window_.Update(m_hWnd, window_rect, dpi_,
-                        GetRubyWindowTheme().corner_radius, shadow_style);
+  shadow_style.size = current_theme.shadow.size;
+  shadow_style.opacity_percent = current_theme.shadow.opacity_percent;
+  shadow_style.angle_degrees = current_theme.shadow.angle_degrees;
+  shadow_style.distance = current_theme.shadow.distance;
+  const int corner_radius = GetRendererWindowCornerRadiusInPixels(
+      current_theme.corner_radius, dpi_, window_size_.cx, window_size_.cy);
+  shadow_window_.Update(m_hWnd, window_rect, dpi_, corner_radius, shadow_style);
 
   last_valid_window_rect_ = window_rect;
 
@@ -713,13 +714,11 @@ void RubyWindow::OnUpdate(const commands::RendererCommand& command,
     has_last_target_identity_ = true;
   }
 
-  ShowWindow(SW_SHOWNOACTIVATE);
-  Invalidate(FALSE);
 }
 
-LRESULT RubyWindow::OnEraseBkgnd(UINT msg_id,
-                                 WPARAM wparam,
-                                 LPARAM lparam,
+LRESULT RubyWindow::OnEraseBkgnd(UINT /*msg_id*/,
+                                 WPARAM /*wparam*/,
+                                 LPARAM /*lparam*/,
                                  BOOL& handled) {
   handled = TRUE;
   return TRUE;
@@ -733,15 +732,59 @@ LRESULT RubyWindow::OnShowWindow(UINT /*msg_id*/, WPARAM wparam,
   return 0;
 }
 
-LRESULT RubyWindow::OnPaint(UINT msg_id,
-                            WPARAM wparam,
-                            LPARAM lparam,
-                            BOOL& handled) {
+LRESULT RubyWindow::OnPaint(UINT /*msg_id*/,
+                            WPARAM /*wparam*/,
+                            LPARAM /*lparam*/,
+                            BOOL& /*handled*/) {
   PAINTSTRUCT ps = {};
-  HDC dc = BeginPaint(&ps);
-  DoPaint(dc);
+  BeginPaint(&ps);
   EndPaint(&ps);
   return 0;
+}
+
+bool RubyWindow::RenderAndPresent() {
+  if (m_hWnd == nullptr || !::IsWindow(m_hWnd) || window_size_.cx <= 0 ||
+      window_size_.cy <= 0) {
+    return false;
+  }
+
+  HDC screen_dc = ::GetDC(nullptr);
+  if (screen_dc == nullptr) {
+    return false;
+  }
+  wil::unique_hdc memory_dc(::CreateCompatibleDC(screen_dc));
+  uint32_t* pixels = nullptr;
+  wil::unique_hbitmap bitmap(CreateRendererLayeredWindowBitmap(
+      screen_dc, window_size_.cx, window_size_.cy, &pixels));
+  ::ReleaseDC(nullptr, screen_dc);
+  if (!memory_dc.is_valid() || !bitmap.is_valid() || pixels == nullptr) {
+    return false;
+  }
+
+  std::fill_n(pixels, static_cast<size_t>(window_size_.cx) *
+                          static_cast<size_t>(window_size_.cy),
+              0u);
+  // A GDI bitmap can be selected into only one memory DC at a time. Keep the
+  // drawing selection scoped so the bitmap is restored to the original DC
+  // before PresentRendererLayeredWindowBitmap selects it into its own source
+  // DC for UpdateLayeredWindow.
+  {
+    wil::unique_select_object old_bitmap =
+        wil::SelectObject(memory_dc.get(), bitmap.get());
+    DoPaint(memory_dc.get());
+    ::GdiFlush();
+  }
+
+  const RendererStyleHandler::RubyWindowStyle theme = GetRubyWindowTheme();
+  const int corner_radius = GetRendererWindowCornerRadiusInPixels(
+      theme.corner_radius, dpi_, window_size_.cx, window_size_.cy);
+  ApplyRoundedRectAlphaAndBorder(pixels, window_size_.cx, window_size_.cy,
+                                 corner_radius, /*border_width=*/1,
+                                 ToColorRef(theme.border_color));
+
+  return PresentRendererLayeredWindowBitmap(
+      m_hWnd, bitmap.get(), window_size_.cx, window_size_.cy,
+      RendererWindowOpacityToAlpha(theme.opacity_percent));
 }
 
 void RubyWindow::DoPaint(HDC dc) {
@@ -753,22 +796,7 @@ void RubyWindow::DoPaint(HDC dc) {
   ::SetBkMode(dc, TRANSPARENT);
 
   HBRUSH bg_brush = ::CreateSolidBrush(ToColorRef(theme.background_color));
-  HPEN border_pen = ::CreatePen(PS_SOLID, 1, ToColorRef(theme.border_color));
-
-  HGDIOBJ old_brush = ::SelectObject(dc, bg_brush);
-  HGDIOBJ old_pen = ::SelectObject(dc, border_pen);
-
-  const int radius = ScaleCornerRadius(theme.corner_radius, dpi_);
-  if (radius <= 0) {
-    ::Rectangle(dc, rect.left, rect.top, rect.right, rect.bottom);
-  } else {
-    ::RoundRect(dc, rect.left, rect.top, rect.right, rect.bottom, radius * 2,
-                radius * 2);
-  }
-
-  ::SelectObject(dc, old_pen);
-  ::SelectObject(dc, old_brush);
-  ::DeleteObject(border_pen);
+  ::FillRect(dc, &rect, bg_brush);
   ::DeleteObject(bg_brush);
 
   HFONT old_font = nullptr;

--- a/src/renderer/win32/ruby_window.h
+++ b/src/renderer/win32/ruby_window.h
@@ -18,7 +18,8 @@ namespace renderer {
 namespace win32 {
 
 typedef ATL::CWinTraits<WS_POPUP,
-                        WS_EX_TOOLWINDOW | WS_EX_TOPMOST | WS_EX_NOACTIVATE>
+                        WS_EX_LAYERED | WS_EX_TOOLWINDOW | WS_EX_TOPMOST |
+                            WS_EX_NOACTIVATE>
     RubyWindowTraits;
 
 class RubyWindow
@@ -40,6 +41,10 @@ class RubyWindow
   void Initialize();
   void Destroy();
   void Hide();
+  // Reassert the ruby body at the top of the topmost band without moving or
+  // activating it. WindowManager calls this after candidate-family bodies are
+  // positioned so all renderer bodies remain above their custom shadows.
+  void RaiseToTopmostWithoutActivation();
   void OnUpdate(const commands::RendererCommand& command,
                 const LayoutManager& layout_manager,
                 const RECT* avoid_rect = nullptr);
@@ -52,6 +57,7 @@ class RubyWindow
   LRESULT OnPaint(UINT msg_id, WPARAM wparam, LPARAM lparam, BOOL& handled);
 
   void DoPaint(HDC dc);
+  bool RenderAndPresent();
   void ResetFont();
   void UpdateDpi(uint32_t dpi);
   void UpdateFont();

--- a/src/renderer/win32/win32_renderer_util.cc
+++ b/src/renderer/win32/win32_renderer_util.cc
@@ -110,10 +110,28 @@ double SignedDistanceFromRoundedRect(double x, double y, double width,
   const double qy = std::abs(y - half_height) - (half_height - radius);
   const double outside_x = std::max(qx, 0.0);
   const double outside_y = std::max(qy, 0.0);
-  const double outside_distance =
-      std::sqrt(outside_x * outside_x + outside_y * outside_y);
+  double outside_distance = 0.0;
+  if (outside_x > 0.0 || outside_y > 0.0) {
+    outside_distance =
+        std::sqrt(outside_x * outside_x + outside_y * outside_y);
+  }
   const double inside_distance = std::min(std::max(qx, qy), 0.0);
   return outside_distance + inside_distance - radius;
+}
+
+// Converts signed distance at a pixel center to one-pixel-wide antialias
+// coverage. A pixel centered at least half a pixel inside is fully covered; a
+// pixel centered at least half a pixel outside is fully transparent.
+double RoundedRectCoverage(double x, double y, double width, double height,
+                           double radius) {
+  return std::clamp(
+      0.5 - SignedDistanceFromRoundedRect(x, y, width, height, radius), 0.0,
+      1.0);
+}
+
+uint8_t ClampToByte(double value) {
+  return static_cast<uint8_t>(
+      std::clamp(std::lround(value), 0l, 255l));
 }
 
 constexpr double kPi = 3.14159265358979323846;
@@ -687,6 +705,170 @@ bool GetWorkingAreaFromPoint(const POINT& point, RECT* working_area) {
   return GetWorkingAreaFromPointImpl(point, working_area);
 }
 
+BYTE RendererWindowOpacityToAlpha(uint32_t opacity_percent) {
+  const uint32_t clamped =
+      std::clamp(opacity_percent, kMinOpacityPercent, kMaxOpacityPercent);
+  return static_cast<BYTE>(clamped * 255u / 100u);
+}
+
+int GetRendererWindowCornerRadiusInPixels(uint32_t logical_radius, uint32_t dpi,
+                                          int width, int height) {
+  if (logical_radius == 0 || width <= 0 || height <= 0) {
+    return 0;
+  }
+  const int scaled_radius =
+      std::max(0, ScaleLogicalPixel(static_cast<int>(logical_radius), dpi));
+  return std::min(scaled_radius, std::min(width, height) / 2);
+}
+
+HBITMAP CreateRendererLayeredWindowBitmap(HDC reference_dc, int width,
+                                          int height, uint32_t** pixels) {
+  if (pixels == nullptr) {
+    return nullptr;
+  }
+  *pixels = nullptr;
+  if (reference_dc == nullptr || width <= 0 || height <= 0) {
+    return nullptr;
+  }
+
+  BITMAPINFO bitmap_info = {};
+  bitmap_info.bmiHeader.biSize = sizeof(bitmap_info.bmiHeader);
+  bitmap_info.bmiHeader.biWidth = width;
+  bitmap_info.bmiHeader.biHeight = -height;  // top-down DIB
+  bitmap_info.bmiHeader.biPlanes = 1;
+  bitmap_info.bmiHeader.biBitCount = 32;
+  bitmap_info.bmiHeader.biCompression = BI_RGB;
+
+  void* bits = nullptr;
+  HBITMAP bitmap = ::CreateDIBSection(reference_dc, &bitmap_info, DIB_RGB_COLORS,
+                                      &bits, nullptr, 0);
+  if (bitmap == nullptr || bits == nullptr) {
+    if (bitmap != nullptr) {
+      ::DeleteObject(bitmap);
+    }
+    return nullptr;
+  }
+
+  *pixels = static_cast<uint32_t*>(bits);
+  return bitmap;
+}
+
+bool PresentRendererLayeredWindowBitmap(HWND hwnd, HBITMAP bitmap, int width,
+                                        int height, BYTE opacity) {
+  if (hwnd == nullptr || !::IsWindow(hwnd) || bitmap == nullptr || width <= 0 ||
+      height <= 0) {
+    return false;
+  }
+
+  RECT window_rect = {};
+  if (!::GetWindowRect(hwnd, &window_rect)) {
+    return false;
+  }
+
+  HDC screen_dc = ::GetDC(nullptr);
+  if (screen_dc == nullptr) {
+    return false;
+  }
+  HDC memory_dc = ::CreateCompatibleDC(screen_dc);
+  if (memory_dc == nullptr) {
+    ::ReleaseDC(nullptr, screen_dc);
+    return false;
+  }
+
+  HGDIOBJ old_bitmap = ::SelectObject(memory_dc, bitmap);
+  if (old_bitmap == nullptr || old_bitmap == HGDI_ERROR) {
+    ::DeleteDC(memory_dc);
+    ::ReleaseDC(nullptr, screen_dc);
+    return false;
+  }
+
+  POINT destination = {window_rect.left, window_rect.top};
+  POINT source = {0, 0};
+  SIZE size = {width, height};
+  BLENDFUNCTION blend = {AC_SRC_OVER, 0, opacity, AC_SRC_ALPHA};
+  const BOOL updated = ::UpdateLayeredWindow(
+      hwnd, screen_dc, &destination, &size, memory_dc, &source, 0, &blend,
+      ULW_ALPHA);
+  const DWORD update_error = updated ? ERROR_SUCCESS : ::GetLastError();
+
+  ::SelectObject(memory_dc, old_bitmap);
+  ::DeleteDC(memory_dc);
+  ::ReleaseDC(nullptr, screen_dc);
+
+  if (!updated) {
+    LOG(ERROR) << "UpdateLayeredWindow failed. Error: " << update_error;
+    return false;
+  }
+  return true;
+}
+
+void ApplyRoundedRectAlphaAndBorder(uint32_t* pixels, int width, int height,
+                                    int corner_radius, int border_width,
+                                    COLORREF border_color) {
+  if (pixels == nullptr || width <= 0 || height <= 0) {
+    return;
+  }
+
+  const double outer_width = static_cast<double>(width);
+  const double outer_height = static_cast<double>(height);
+  const double radius = std::clamp(
+      static_cast<double>(corner_radius), 0.0,
+      std::min(outer_width, outer_height) / 2.0);
+  const double border = std::clamp(
+      static_cast<double>(border_width), 0.0,
+      std::min(outer_width, outer_height) / 2.0);
+  const double inner_width = std::max(0.0, outer_width - border * 2.0);
+  const double inner_height = std::max(0.0, outer_height - border * 2.0);
+  const double inner_radius = std::max(0.0, radius - border);
+
+  const double border_r = static_cast<double>(GetRValue(border_color));
+  const double border_g = static_cast<double>(GetGValue(border_color));
+  const double border_b = static_cast<double>(GetBValue(border_color));
+
+  for (int y = 0; y < height; ++y) {
+    for (int x = 0; x < width; ++x) {
+      const double pixel_x = static_cast<double>(x) + 0.5;
+      const double pixel_y = static_cast<double>(y) + 0.5;
+      const double outer_coverage = RoundedRectCoverage(
+          pixel_x, pixel_y, outer_width, outer_height, radius);
+
+      double inner_coverage = 0.0;
+      if (border <= 0.0) {
+        inner_coverage = outer_coverage;
+      } else if (inner_width > 0.0 && inner_height > 0.0) {
+        inner_coverage = RoundedRectCoverage(
+            pixel_x - border, pixel_y - border, inner_width, inner_height,
+            inner_radius);
+        // Numerical noise must never make the nested inner shape cover more
+        // than the outer shape.
+        inner_coverage = std::min(inner_coverage, outer_coverage);
+      }
+
+      const double border_coverage = outer_coverage - inner_coverage;
+      const uint32_t source = pixels[y * width + x];
+      const double source_r = static_cast<double>((source >> 16) & 0xff);
+      const double source_g = static_cast<double>((source >> 8) & 0xff);
+      const double source_b = static_cast<double>(source & 0xff);
+
+      // PBGRA stores color channels already multiplied by alpha. The source
+      // candidate surface is opaque before this pass, so the two coverages can
+      // directly weight the content and analytical border colors.
+      const uint8_t alpha = ClampToByte(outer_coverage * 255.0);
+      const uint8_t red = ClampToByte(source_r * inner_coverage +
+                                      border_r * border_coverage);
+      const uint8_t green = ClampToByte(source_g * inner_coverage +
+                                        border_g * border_coverage);
+      const uint8_t blue = ClampToByte(source_b * inner_coverage +
+                                       border_b * border_coverage);
+
+      pixels[y * width + x] =
+          (static_cast<uint32_t>(alpha) << 24) |
+          (static_cast<uint32_t>(red) << 16) |
+          (static_cast<uint32_t>(green) << 8) | static_cast<uint32_t>(blue);
+    }
+  }
+}
+
 std::unique_ptr<WindowPositionEmulator> WindowPositionEmulator::Create() {
   return std::make_unique<WindowPositionEmulatorImpl>();
 }
@@ -718,10 +900,9 @@ void ApplyRendererWindowOpacity(HWND hwnd, uint32_t opacity_percent) {
   if (hwnd == nullptr) {
     return;
   }
-  opacity_percent = std::clamp(opacity_percent, kMinOpacityPercent,
-                               kMaxOpacityPercent);
+  const BYTE alpha = RendererWindowOpacityToAlpha(opacity_percent);
   LONG_PTR ex_style = ::GetWindowLongPtr(hwnd, GWL_EXSTYLE);
-  if (opacity_percent >= 100) {
+  if (alpha >= 255) {
     if ((ex_style & WS_EX_LAYERED) != 0) {
       ::SetWindowLongPtr(hwnd, GWL_EXSTYLE, ex_style & ~WS_EX_LAYERED);
       ::RedrawWindow(hwnd, nullptr, nullptr,
@@ -733,8 +914,6 @@ void ApplyRendererWindowOpacity(HWND hwnd, uint32_t opacity_percent) {
   if ((ex_style & WS_EX_LAYERED) == 0) {
     ::SetWindowLongPtr(hwnd, GWL_EXSTYLE, ex_style | WS_EX_LAYERED);
   }
-  const BYTE alpha = static_cast<BYTE>(
-      std::clamp(opacity_percent * 255u / 100u, 1u, 255u));
   ::SetLayeredWindowAttributes(hwnd, 0, alpha, LWA_ALPHA);
 }
 
@@ -754,8 +933,9 @@ void RendererShadowWindow::Hide() {
 }
 
 bool RendererShadowWindow::Update(HWND owner_window, const RECT& owner_rect,
-                                  uint32_t dpi, uint32_t owner_corner_radius,
-                                  const RendererWindowShadowStyle& style) {
+                                  uint32_t dpi, int owner_corner_radius_pixels,
+                                  const RendererWindowShadowStyle& style,
+                                  HWND z_order_anchor_window) {
   if (owner_window == nullptr || !::IsWindow(owner_window) ||
       !::IsWindowVisible(owner_window)) {
     Hide();
@@ -805,11 +985,9 @@ bool RendererShadowWindow::Update(HWND owner_window, const RECT& owner_rect,
   const int right_margin = shadow_size + std::max(shadow_dx, 0);
   const int top_margin = shadow_size + std::max(-shadow_dy, 0);
   const int bottom_margin = shadow_size + std::max(shadow_dy, 0);
-  const int corner_radius = static_cast<int>(
-      ScaleLogicalPixel(std::min(owner_corner_radius,
-                                 static_cast<uint32_t>(std::min(owner_width,
-                                                                owner_height) / 2)),
-                        dpi));
+  const int corner_radius =
+      std::clamp(owner_corner_radius_pixels, 0,
+                 std::min(owner_width, owner_height) / 2);
   const int width = owner_width + left_margin + right_margin;
   const int height = owner_height + top_margin + bottom_margin;
   if (width <= 0 || height <= 0) {
@@ -827,29 +1005,18 @@ bool RendererShadowWindow::Update(HWND owner_window, const RECT& owner_rect,
     return false;
   }
 
-  BITMAPINFO bitmap_info = {};
-  bitmap_info.bmiHeader.biSize = sizeof(bitmap_info.bmiHeader);
-  bitmap_info.bmiHeader.biWidth = width;
-  bitmap_info.bmiHeader.biHeight = -height;  // top-down DIB
-  bitmap_info.bmiHeader.biPlanes = 1;
-  bitmap_info.bmiHeader.biBitCount = 32;
-  bitmap_info.bmiHeader.biCompression = BI_RGB;
-
-  void* bits = nullptr;
-  HBITMAP bitmap = ::CreateDIBSection(screen_dc, &bitmap_info, DIB_RGB_COLORS,
-                                      &bits, nullptr, 0);
-  if (bitmap == nullptr || bits == nullptr) {
-    if (bitmap != nullptr) {
-      ::DeleteObject(bitmap);
-    }
+  uint32_t* pixels = nullptr;
+  HBITMAP bitmap =
+      CreateRendererLayeredWindowBitmap(screen_dc, width, height, &pixels);
+  if (bitmap == nullptr || pixels == nullptr) {
     ::DeleteDC(memory_dc);
     ::ReleaseDC(nullptr, screen_dc);
     return false;
   }
 
-  DrawShadowBitmap(static_cast<uint32_t*>(bits), width, height, owner_width,
-                   owner_height, shadow_size, shadow_dx, shadow_dy, left_margin,
-                   top_margin, corner_radius, shadow_opacity);
+  DrawShadowBitmap(pixels, width, height, owner_width, owner_height,
+                   shadow_size, shadow_dx, shadow_dy, left_margin, top_margin,
+                   corner_radius, shadow_opacity);
 
   HGDIOBJ old_bitmap = ::SelectObject(memory_dc, bitmap);
   POINT dst = {owner_rect.left - left_margin, owner_rect.top - top_margin};
@@ -870,8 +1037,21 @@ bool RendererShadowWindow::Update(HWND owner_window, const RECT& owner_rect,
     return false;
   }
 
-  ::SetWindowPos(hwnd_, owner_window, 0, 0, 0, 0,
-                 SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE | SWP_SHOWWINDOW);
+  HWND z_order_anchor = owner_window;
+  if (z_order_anchor_window != nullptr &&
+      ::IsWindow(z_order_anchor_window) &&
+      ::IsWindowVisible(z_order_anchor_window)) {
+    z_order_anchor = z_order_anchor_window;
+  }
+  if (!::SetWindowPos(
+          hwnd_, z_order_anchor, 0, 0, 0, 0,
+          SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE | SWP_SHOWWINDOW)) {
+    const DWORD error = ::GetLastError();
+    LOG(ERROR) << "SetWindowPos failed for renderer shadow Z-order. Error: "
+               << error;
+    Hide();
+    return false;
+  }
   return true;
 }
 

--- a/src/renderer/win32/win32_renderer_util.h
+++ b/src/renderer/win32/win32_renderer_util.h
@@ -97,9 +97,42 @@ struct RendererWindowShadowStyle {
   uint32_t distance = 0;
 };
 
-// Applies whole-window opacity. 100 removes WS_EX_LAYERED again so the default
-// opaque path remains the fast path. The value is clamped to [20, 100].
+// Converts a renderer-window opacity percentage to the Win32 alpha byte used
+// by layered-window APIs. Renderer-window opacity is clamped to [20, 100].
+BYTE RendererWindowOpacityToAlpha(uint32_t opacity_percent);
+
+// Converts a logical corner radius to physical pixels for a concrete window
+// size. The result is clamped so the rounded rectangle always remains valid.
+int GetRendererWindowCornerRadiusInPixels(uint32_t logical_radius, uint32_t dpi,
+                                          int width, int height);
+
+// Creates a top-down 32-bit DIB section suitable for per-pixel-alpha layered
+// windows. The caller owns the returned HBITMAP. |pixels| receives the BGRA
+// backing store and is set to nullptr on failure.
+HBITMAP CreateRendererLayeredWindowBitmap(HDC reference_dc, int width,
+                                          int height, uint32_t** pixels);
+
+// Presents a PBGRA bitmap through UpdateLayeredWindow. The bitmap size is also
+// used as the destination window size. |opacity| is applied as
+// SourceConstantAlpha so per-pixel coverage remains independent from the
+// renderer-window opacity setting.
+bool PresentRendererLayeredWindowBitmap(HWND hwnd, HBITMAP bitmap, int width,
+                                        int height, BYTE opacity);
+
+// Applies whole-window opacity to a conventional (non per-pixel-alpha) window.
+// 100 removes WS_EX_LAYERED again so the opaque path remains the fast path.
+// Per-pixel-alpha renderer windows (Candidate, Ruby, and Infolist) do not use
+// this API: their surfaces remain permanently layered and are presented with
+// UpdateLayeredWindow and SourceConstantAlpha.
 void ApplyRendererWindowOpacity(HWND hwnd, uint32_t opacity_percent);
+
+// Converts an already-rendered opaque BGRA/RGB DIB into a PBGRA surface for
+// UpdateLayeredWindow. The outer rounded-rectangle silhouette and its border
+// are antialiased from the same signed-distance geometry used by the renderer
+// shadow. |border_width| and |corner_radius| are physical pixels.
+void ApplyRoundedRectAlphaAndBorder(uint32_t* pixels, int width, int height,
+                                    int corner_radius, int border_width,
+                                    COLORREF border_color);
 
 class RendererShadowWindow {
  public:
@@ -110,9 +143,16 @@ class RendererShadowWindow {
 
   void Destroy();
   void Hide();
+  // |owner_corner_radius_pixels| is the already-scaled physical radius of the
+  // owner surface. Passing the final radius keeps body, border, and shadow on
+  // exactly the same rounded-rectangle geometry. If |z_order_anchor_window| is
+  // a visible renderer body, the shadow is placed behind that body instead of
+  // merely behind its own owner. This lets WindowManager keep every renderer
+  // body above every candidate-family shadow while preserving WS_EX_TOPMOST.
   bool Update(HWND owner_window, const RECT& owner_rect, uint32_t dpi,
-              uint32_t owner_corner_radius,
-              const RendererWindowShadowStyle& style);
+              int owner_corner_radius_pixels,
+              const RendererWindowShadowStyle& style,
+              HWND z_order_anchor_window = nullptr);
 
  private:
   HWND hwnd_ = nullptr;

--- a/src/renderer/win32/win32_renderer_util_test.cc
+++ b/src/renderer/win32/win32_renderer_util_test.cc
@@ -36,6 +36,7 @@
 #include <bit>
 #include <cstdint>
 #include <memory>
+#include <vector>
 
 #include "protocol/commands.pb.h"
 #include "protocol/renderer_command.pb.h"
@@ -270,6 +271,110 @@ TEST(Win32RendererUtilTest, GetCompositionTargetInPhysicalCoordsTest) {
         app_info, 22, &top_left, &line_height));
     EXPECT_EQ(static_cast<int>(22 * scale_factor), line_height);
   }
+}
+
+TEST(Win32RendererUtilTest, RendererWindowOpacityToAlphaClampsAndScales) {
+  EXPECT_EQ(51, RendererWindowOpacityToAlpha(0));
+  EXPECT_EQ(51, RendererWindowOpacityToAlpha(20));
+  EXPECT_EQ(127, RendererWindowOpacityToAlpha(50));
+  EXPECT_EQ(229, RendererWindowOpacityToAlpha(90));
+  EXPECT_EQ(252, RendererWindowOpacityToAlpha(99));
+  EXPECT_EQ(255, RendererWindowOpacityToAlpha(100));
+  EXPECT_EQ(255, RendererWindowOpacityToAlpha(999));
+}
+
+TEST(Win32RendererUtilTest, RendererWindowCornerRadiusScalesAcrossDpi) {
+  struct TestCase {
+    uint32_t logical_radius;
+    uint32_t dpi;
+    int expected_radius;
+  };
+  constexpr TestCase kCases[] = {
+      {0, 96, 0},   {0, 120, 0},  {0, 144, 0},  {0, 168, 0},
+      {0, 192, 0},  {4, 96, 4},   {4, 120, 5},  {4, 144, 6},
+      {4, 168, 7},  {4, 192, 8},  {6, 96, 6},   {6, 120, 8},
+      {6, 144, 9},  {6, 168, 11}, {6, 192, 12}, {8, 96, 8},
+      {8, 120, 10}, {8, 144, 12}, {8, 168, 14}, {8, 192, 16},
+      {12, 96, 12}, {12, 120, 15}, {12, 144, 18}, {12, 168, 21},
+      {12, 192, 24},
+  };
+  constexpr int kWidth = 200;
+  constexpr int kHeight = 100;
+
+  for (const TestCase& test_case : kCases) {
+    EXPECT_EQ(test_case.expected_radius,
+              GetRendererWindowCornerRadiusInPixels(
+                  test_case.logical_radius, test_case.dpi, kWidth, kHeight))
+        << "logical_radius=" << test_case.logical_radius
+        << " dpi=" << test_case.dpi;
+  }
+}
+
+TEST(Win32RendererUtilTest, RendererWindowCornerRadiusClampsToOwnerGeometry) {
+  EXPECT_EQ(0, GetRendererWindowCornerRadiusInPixels(0, 192, 20, 14));
+  EXPECT_EQ(0, GetRendererWindowCornerRadiusInPixels(12, 192, 0, 14));
+  EXPECT_EQ(0, GetRendererWindowCornerRadiusInPixels(12, 192, 20, 0));
+  EXPECT_EQ(7, GetRendererWindowCornerRadiusInPixels(12, 192, 20, 14));
+}
+
+TEST(Win32RendererUtilTest, RoundedRectMaskKeepsOpaqueInteriorAndBorder) {
+  constexpr int kWidth = 5;
+  constexpr int kHeight = 5;
+  constexpr uint32_t kContent = 0x00112233;
+  std::vector<uint32_t> pixels(kWidth * kHeight, kContent);
+
+  ApplyRoundedRectAlphaAndBorder(pixels.data(), kWidth, kHeight,
+                                 /*corner_radius=*/0, /*border_width=*/1,
+                                 RGB(0xaa, 0xbb, 0xcc));
+
+  EXPECT_EQ(0xffaabbccu, pixels[2]);
+  EXPECT_EQ(0xffaabbccu, pixels[2 * kWidth]);
+  EXPECT_EQ(0xff112233u, pixels[2 * kWidth + 2]);
+}
+
+TEST(Win32RendererUtilTest, RoundedRectMaskAntialiasesAndPremultiplies) {
+  constexpr int kWidth = 7;
+  constexpr int kHeight = 7;
+  std::vector<uint32_t> pixels(kWidth * kHeight, 0x00ffffffu);
+
+  ApplyRoundedRectAlphaAndBorder(pixels.data(), kWidth, kHeight,
+                                 /*corner_radius=*/3, /*border_width=*/0,
+                                 RGB(0, 0, 0));
+
+  EXPECT_EQ(0u, pixels[0]);
+  EXPECT_EQ(0xffffffffu, pixels[3]);
+  EXPECT_EQ(0xffffffffu, pixels[3 * kWidth + 3]);
+
+  const uint32_t edge = pixels[1];
+  const uint32_t alpha = (edge >> 24) & 0xff;
+  const uint32_t red = (edge >> 16) & 0xff;
+  const uint32_t green = (edge >> 8) & 0xff;
+  const uint32_t blue = edge & 0xff;
+  EXPECT_GT(alpha, 0u);
+  EXPECT_LT(alpha, 255u);
+  EXPECT_EQ(alpha, red);
+  EXPECT_EQ(alpha, green);
+  EXPECT_EQ(alpha, blue);
+
+  EXPECT_EQ(pixels[1], pixels[kWidth - 2]);
+  EXPECT_EQ(pixels[1], pixels[(kHeight - 1) * kWidth + 1]);
+  EXPECT_EQ(pixels[1], pixels[kHeight * kWidth - 2]);
+}
+
+TEST(Win32RendererUtilTest, RoundedRectMaskClampsOversizedRadius) {
+  constexpr int kWidth = 4;
+  constexpr int kHeight = 4;
+  std::vector<uint32_t> clamped(kWidth * kHeight, 0x00ffffffu);
+  std::vector<uint32_t> oversized(kWidth * kHeight, 0x00ffffffu);
+
+  ApplyRoundedRectAlphaAndBorder(clamped.data(), kWidth, kHeight,
+                                 /*corner_radius=*/2, /*border_width=*/0,
+                                 RGB(0, 0, 0));
+  ApplyRoundedRectAlphaAndBorder(oversized.data(), kWidth, kHeight,
+                                 /*corner_radius=*/100, /*border_width=*/0,
+                                 RGB(0, 0, 0));
+
+  EXPECT_EQ(clamped, oversized);
 }
 
 TEST(Win32RendererUtilTest, GetScalingFactorTest) {

--- a/src/renderer/win32/window_manager.cc
+++ b/src/renderer/win32/window_manager.cc
@@ -442,11 +442,23 @@ void WindowManager::UpdateLayout(const commands::RendererCommand& command) {
   main_window_->SetWindowPos(HWND_TOPMOST, main_window_rect.Left(),
                              main_window_rect.Top(), main_window_rect.Width(),
                              main_window_rect.Height(), set_windows_pos_flags);
-  if (is_live_conversion_passive_suggestion) {
-    main_window_->PresentCachedBitmapImmediately();
-    main_window_->RedrawImmediately();
-  }
-  main_window_->UpdateEffectWindows();
+  // CandidateWindow is a per-pixel-alpha layered window. Present the complete
+  // cached surface immediately for every candidate-like UI, not only passive
+  // live suggestions, so WM_PAINT scheduling cannot expose an empty/stale
+  // first frame.
+  main_window_->PresentCachedBitmapImmediately();
+
+  // The main candidate body is the bottom-most body in this renderer family.
+  // Secondary windows keep their shadows behind it, so no custom shadow can
+  // cover another renderer body while candidate UI is being updated.
+  const HWND main_window_handle = main_window_->GetWindowHandle();
+  infolist_window_->SetShadowZOrderAnchor(main_window_handle);
+  cascading_window_->SetShadowZOrderAnchor(main_window_handle);
+  // Ruby can be updated before the main candidate window. Reassert it now so
+  // main_window_ is the lowest visible renderer body before any secondary
+  // shadow is presented.
+  ruby_window_->RaiseToTopmostWithoutActivation();
+
   if (is_live_conversion_passive_suggestion) {
     last_live_conversion_passive_suggestion_visible_ = true;
     last_live_conversion_passive_suggestion_rect_ =
@@ -476,18 +488,20 @@ void WindowManager::UpdateLayout(const commands::RendererCommand& command) {
   if (infolist_visible && !cascading_visible) {
     if (candidate_changed) {
       infolist_window_->UpdateLayout(candidate_window);
-      infolist_window_->Invalidate();
     }
 
     // Align infolist window
     const Rect infolist_rect = WindowUtil::GetWindowRectForInfolistWindow(
         infolist_window_->GetLayoutSize(), main_window_rect, working_area);
+    // InfolistWindow is permanently layered. Its cached PBGRA surface is
+    // presented explicitly by UpdateEffectWindows(), so moving/resizing must
+    // not trigger the legacy WM_PAINT path.
     infolist_window_->MoveWindow(infolist_rect.Left(), infolist_rect.Top(),
                                  infolist_rect.Width(), infolist_rect.Height(),
-                                 TRUE);
+                                 FALSE);
     infolist_window_->SetWindowPos(
         HWND_TOPMOST, 0, 0, 0, 0,
-        SWP_NOACTIVATE | SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE);
+        SWP_NOACTIVATE | SWP_NOMOVE | SWP_NOSIZE);
     infolist_window_->UpdateEffectWindows();
 
     if (candidate_window.has_focused_index() &&
@@ -544,21 +558,20 @@ void WindowManager::UpdateLayout(const commands::RendererCommand& command) {
         HWND_TOPMOST, cascading_window_rect.Left(), cascading_window_rect.Top(),
         cascading_window_rect.Width(), cascading_window_rect.Height(),
         set_windows_pos_flags);
+    cascading_window_->PresentCachedBitmapImmediately();
     cascading_window_->UpdateEffectWindows();
     // This trick ensures that the window is certainly shown as 'inactivated'
     // in terms of visual effect on DWM-enabled desktop.
     cascading_window_->SendMessageW(WM_NCACTIVATE, FALSE);
-    if (candidate_changed) {
-      main_window_->Invalidate();
-      cascading_window_->Invalidate();
-    }
   } else {
     // no cascading window
-    if (candidate_changed) {
-      main_window_->Invalidate();
-    }
     cascading_window_->HideWithEffects();
   }
+
+  // Present the main shadow only after every secondary body has been positioned.
+  // main_window_ is the common Z-order anchor, so every candidate-family
+  // shadow stays below Infolist, cascade, and ruby surfaces.
+  main_window_->UpdateEffectWindows();
 }
 
 bool WindowManager::IsAvailable() const {


### PR DESCRIPTION
## 概要

Windows版rendererの候補ウィンドウ群について、角丸描画をper-pixel alphaベースへ移行し、境界のジャギーを解消しました。

あわせて、Candidate / Infolist / Ruby / Cascading candidateで角丸形状とshadow形状を共通化し、Infolist表示時にCandidate shadowが一瞬前面へ入り込むZ-order問題も修正しています。

## 背景

従来のCandidate/Rubyウィンドウでは、`CreateRoundRectRgn` / `SetWindowRgn` による二値的なwindow regionで角丸を実現していました。

この方式では角部分にper-pixel alphaを持てないため、特に高DPI環境や大きめのcorner radiusで輪郭のジャギーが目立つ状態でした。

また、rendererのshadowは独立したtopmost layered windowとして描画されていましたが、各shadowと他のrenderer bodyとのZ-order関係が明示的に管理されていなかったため、Infolistが連続表示される候補間を移動した際に、Candidate shadowがInfolist上へ一瞬重なることがありました。

## 変更内容

### 角丸描画をper-pixel alphaへ移行

Candidate / Infolist / Rubyを常時 `WS_EX_LAYERED` のwindowとし、top-down 32-bit DIBへ描画後、`UpdateLayeredWindow(ULW_ALPHA)` で表示する方式へ変更しました。

角丸境界はsigned-distanceベースでcoverageを計算し、PBGRAとしてアンチエイリアスを適用しています。

これにより、従来のHRGNによる二値的な角丸を廃止し、滑らかな輪郭を描画できるようになりました。

### body / border / shadowの角丸形状を統一

logical corner radiusをDPIと実ウィンドウサイズからphysical pixelへ変換する共通処理を追加しました。

同じ最終corner radiusを、

* window body
* border
* shadow

で共有することで、輪郭とshadowの曲率がずれないようにしています。

### window opacity処理をlayered window向けに整理

per-pixel alphaを使用するCandidate / Infolist / Rubyでは、`SetLayeredWindowAttributes` によるwindow opacity変更を使用せず、`UpdateLayeredWindow` の `SourceConstantAlpha` で全体opacityを適用するようにしました。

これにより、per-pixel alphaとwindow全体のopacityを同じcompositing pathで扱います。

### Ruby windowのlayered描画を修正

Ruby windowもCandidateと同じper-pixel-alpha方式へ移行しました。

移行時に、同一HBITMAPが複数のmemory DCへ同時にselectされる可能性がありRuby windowが表示されなくなる問題が見つかったため、描画用DCからbitmapを確実にdeselectしてから`UpdateLayeredWindow`へ渡すよう修正しています。

### Infolistのlayered描画を整理

Infolistも32-bit DIBへ事前描画し、角丸alphaとborderを適用してからlayered windowとして表示します。

layered化後に不要となった従来の`Invalidate()`およびrepaint付き`MoveWindow(..., TRUE)`経路も整理し、明示的なlayered surface presentationへ統一しました。

### renderer shadowのZ-orderを修正

Candidate / Infolist / Cascading candidateなどのshadowは独立したtopmost windowですが、従来は各owner windowの背後へ配置するだけで、他のrenderer bodyとの前後関係は保証されていませんでした。

main Candidate bodyをcandidate-familyのZ-order anchorとして使用し、secondary windowのshadowを必ずその背後へ配置するよう変更しました。

また、main Candidate shadowはInfolist/Cascadingのbody配置後に更新するよう順序を変更しています。

これにより、Infolist表示中にCandidate shadowが一瞬Infolist前面へ侵入するちらつきを解消しました。

shadowのZ-order更新に失敗した場合もsilent failureにせず、エラーログを出力してshadowを非表示にするようにしています。

## テスト

以下を確認しています。

### 自動テスト

* `//renderer/win32:win32_renderer_util_test`
* Candidate / Infolist / Ruby / WindowManager / renderer本体のbuild
* Windows `package` build
* `git diff --check`

角丸geometryについては、以下をunit testで確認しています。

* corner radius: `0 / 4 / 6 / 8 / 12`
* DPI: `96 / 120 / 144 / 168 / 192`

  * 100%
  * 125%
  * 150%
  * 175%
  * 200%
* oversized radiusのclamp
* rounded cornerのcoverage
* PBGRA premultiplication
* renderer opacityのalpha変換
