### PR TITLE
Add macOS renderer window effects

### DIFF
--- a/src/gui/config_dialog/config_dialog.cc
+++ b/src/gui/config_dialog/config_dialog.cc
@@ -2735,17 +2735,17 @@ void ConfigDialog::InitializeRendererAppearanceControls() {
                  "candidateWindowShadowSizeSpinBox",
                  "candidateWindowShadowOpacityPercentSpinBox",
                  "candidateWindowShadowDistanceSpinBox",
-                 "candidateWindowShadowAngleDegreesSpinBox", 12, 30, 6, 45);
+                 "candidateWindowShadowAngleDegreesSpinBox", 5, 10, 6, 45);
   add_shadow_row(2, tr("Suggestion window"),
                  "suggestWindowShadowSizeSpinBox",
                  "suggestWindowShadowOpacityPercentSpinBox",
                  "suggestWindowShadowDistanceSpinBox",
-                 "suggestWindowShadowAngleDegreesSpinBox", 12, 30, 6, 45);
+                 "suggestWindowShadowAngleDegreesSpinBox", 5, 10, 6, 45);
   add_shadow_row(3, tr("Ruby window"),
                  "rubyWindowShadowSizeSpinBox",
                  "rubyWindowShadowOpacityPercentSpinBox",
                  "rubyWindowShadowDistanceSpinBox",
-                 "rubyWindowShadowAngleDegreesSpinBox", 10, 28, 4, 90);
+                 "rubyWindowShadowAngleDegreesSpinBox", 5, 8, 3, 45);
 
   auto add_palette_button = [&](QGridLayout* layout, int row, int col,
                                 const QString& prefix, const char* suffix,
@@ -3721,15 +3721,15 @@ void ConfigDialog::ResetRendererAppearanceControls() {
       {"candidateWindowShadowSizeSpinBox",
        "candidateWindowShadowOpacityPercentSpinBox",
        "candidateWindowShadowAngleDegreesSpinBox",
-       "candidateWindowShadowDistanceSpinBox", 12, 30, 45, 6},
+       "candidateWindowShadowDistanceSpinBox", 5, 10, 45, 6},
       {"suggestWindowShadowSizeSpinBox",
        "suggestWindowShadowOpacityPercentSpinBox",
        "suggestWindowShadowAngleDegreesSpinBox",
-       "suggestWindowShadowDistanceSpinBox", 12, 30, 45, 6},
+       "suggestWindowShadowDistanceSpinBox", 5, 10, 45, 6},
       {"rubyWindowShadowSizeSpinBox",
        "rubyWindowShadowOpacityPercentSpinBox",
        "rubyWindowShadowAngleDegreesSpinBox",
-       "rubyWindowShadowDistanceSpinBox", 10, 28, 90, 4},
+       "rubyWindowShadowDistanceSpinBox", 5, 8, 45, 3},
   };
   for (const ShadowDefault& shadow_default : shadow_defaults) {
     if (QSpinBox* spin = FindSpinBox(this, shadow_default.size_name)) {

--- a/src/protocol/config.proto
+++ b/src/protocol/config.proto
@@ -526,7 +526,8 @@ message Config {
     optional uint32 border_color = 3 [default = 0x969696];
   }
 
-  // Candidate, prediction/suggestion, and ruby window appearance on Windows.
+  // Candidate, prediction/suggestion, and ruby window appearance on desktop
+  // renderers (Windows and macOS).
   // CONVERSION, TRANSLITERATION, and USAGE use the candidate window appearance.
   // PREDICTION and SUGGESTION use the suggest window appearance.
   // RubyWindow has its own compact palette.
@@ -564,18 +565,18 @@ message Config {
   // the custom shadow. Size and distance are logical pixels and are DPI-scaled
   // by the renderer. Angle is screen-space degrees: 0=right, 45=down-right,
   // 90=down. Distance 0 creates an even shadow on all sides.
-  optional uint32 candidate_window_shadow_size = 151 [default = 12];
-  optional uint32 candidate_window_shadow_opacity_percent = 152 [default = 30];
+  optional uint32 candidate_window_shadow_size = 151 [default = 5];
+  optional uint32 candidate_window_shadow_opacity_percent = 152 [default = 10];
   optional uint32 candidate_window_shadow_angle_degrees = 153 [default = 45];
   optional uint32 candidate_window_shadow_distance = 154 [default = 6];
-  optional uint32 suggest_window_shadow_size = 155 [default = 12];
-  optional uint32 suggest_window_shadow_opacity_percent = 156 [default = 30];
+  optional uint32 suggest_window_shadow_size = 155 [default = 5];
+  optional uint32 suggest_window_shadow_opacity_percent = 156 [default = 10];
   optional uint32 suggest_window_shadow_angle_degrees = 157 [default = 45];
   optional uint32 suggest_window_shadow_distance = 158 [default = 6];
-  optional uint32 ruby_window_shadow_size = 159 [default = 10];
-  optional uint32 ruby_window_shadow_opacity_percent = 160 [default = 28];
-  optional uint32 ruby_window_shadow_angle_degrees = 161 [default = 90];
-  optional uint32 ruby_window_shadow_distance = 162 [default = 4];
+  optional uint32 ruby_window_shadow_size = 159 [default = 5];
+  optional uint32 ruby_window_shadow_opacity_percent = 160 [default = 8];
+  optional uint32 ruby_window_shadow_angle_degrees = 161 [default = 45];
+  optional uint32 ruby_window_shadow_distance = 162 [default = 3];
 
   // Do not reuse these tags. A locally tested build assigned Ruby spacing to
   // them and could reinterpret unknown fields preserved in existing configs.

--- a/src/renderer/BUILD.bazel
+++ b/src/renderer/BUILD.bazel
@@ -114,6 +114,7 @@ mozc_cc_library(
     deps = [
         ":renderer_interface",
         ":renderer_style_handler",
+        ":window_effect_util",
         "//base:const",
         "//base:random",
         "//base:system_util",
@@ -194,6 +195,23 @@ mozc_cc_library(
 )
 
 mozc_cc_library(
+    name = "window_effect_util",
+    srcs = ["window_effect_util.cc"],
+    hdrs = ["window_effect_util.h"],
+    visibility = ["//renderer:__subpackages__"],
+)
+
+mozc_cc_test(
+    name = "window_effect_util_test",
+    size = "small",
+    srcs = ["window_effect_util_test.cc"],
+    deps = [
+        ":window_effect_util",
+        "//testing:gunit_main",
+    ],
+)
+
+mozc_cc_library(
     name = "renderer_interface",
     hdrs = ["renderer_interface.h"],
     visibility = [
@@ -257,6 +275,7 @@ mozc_cc_library(
         "//base:protobuf_util",
         "//base:text_normalizer",
         "//base/protobuf:text_format",
+        "//protocol:candidate_window_cc_proto",
         "//protocol:renderer_cc_proto",
         "@com_google_absl//absl/base:no_destructor",
         "@com_google_absl//absl/log:check",
@@ -270,6 +289,7 @@ mozc_cc_test(
     srcs = ["renderer_style_handler_test.cc"],
     deps = [
         ":renderer_style_handler",
+        "//protocol:candidate_window_cc_proto",
         "//protocol:renderer_cc_proto",
         "//testing:gunit_main",
     ],
@@ -311,6 +331,7 @@ mozc_objc_library(
         "mac/InfolistView.mm",
         "mac/InfolistWindow.mm",
         "mac/RendererBaseWindow.mm",
+        "mac/RendererShadowWindow.mm",
         "mac/RubyWindow.mm",
         "mac/mac_server.mm",
         "mac/mac_server_send_command.mm",
@@ -323,6 +344,7 @@ mozc_objc_library(
         "mac/InfolistView.h",
         "mac/InfolistWindow.h",
         "mac/RendererBaseWindow.h",
+        "mac/RendererShadowWindow.h",
         "mac/RubyWindow.h",
         "mac/mac_server.h",
         "mac/mac_server_send_command.h",
@@ -338,6 +360,7 @@ mozc_objc_library(
         ":renderer_server",
         ":renderer_style_handler",
         ":table_layout",
+        ":window_effect_util",
         ":window_util",
         "//base:const",
         "//base:coordinates",

--- a/src/renderer/mac/CandidateView.mm
+++ b/src/renderer/mac/CandidateView.mm
@@ -84,6 +84,7 @@ using mozc::renderer::mac::MacViewUtil;
   mozc::commands::CandidateWindow candidate_window_;
   mozc::renderer::TableLayout tableLayout_;
   mozc::renderer::RendererStyle style_;
+  CGFloat cornerRadius_;
 
   // The row which has focused background.
   int focusedRow_;
@@ -111,6 +112,9 @@ using mozc::renderer::mac::MacViewUtil;
           RendererStyleHandler::RendererStyleType::kCandidate, &style_)) {
     RendererStyleHandler::GetDefaultRendererStyle(&style_);
   }
+  cornerRadius_ = static_cast<CGFloat>(
+      RendererStyleHandler::GetCandidateWindowCornerRadius(
+          RendererStyleHandler::RendererStyleType::kCandidate));
   [self updateStyleDependentResources];
 
   // Default line width is specified as 1.0 pt, but the renderer expects
@@ -120,21 +124,16 @@ using mozc::renderer::mac::MacViewUtil;
 }
 
 - (void)reloadStyleForCandidateWindow {
-  // Prediction is the focused continuation of suggestion UI, so both
-  // categories share the suggestion appearance bucket.
-  const bool use_suggestion_style =
-      candidate_window_.category() == mozc::commands::SUGGESTION ||
-      candidate_window_.category() == mozc::commands::PREDICTION;
-
   const RendererStyleHandler::RendererStyleType style_type =
-      use_suggestion_style
-          ? RendererStyleHandler::RendererStyleType::kSuggestion
-          : RendererStyleHandler::RendererStyleType::kCandidate;
+      RendererStyleHandler::GetRendererStyleTypeForCandidateWindow(
+          candidate_window_);
 
   if (!RendererStyleHandler::GetRendererStyleForWindowType(style_type,
                                                             &style_)) {
     RendererStyleHandler::GetDefaultRendererStyle(&style_);
   }
+  cornerRadius_ = static_cast<CGFloat>(
+      RendererStyleHandler::GetCandidateWindowCornerRadius(style_type));
 
   [self updateStyleDependentResources];
 }
@@ -305,13 +304,30 @@ using mozc::renderer::mac::MacViewUtil;
 
 - (void)drawRect:(NSRect)rect {
   if (!Category_IsValid(candidate_window_.category())) {
-    LOG(WARNING) << "Unknown candidates category: " << candidate_window_.category();
+    LOG(WARNING) << "Unknown candidates category: "
+                 << candidate_window_.category();
     return;
   }
 
+  // The NSPanel is transparent so the rounded silhouette must explicitly
+  // clear stale pixels before drawing a new frame.
+  NSRectFillUsingOperation(self.bounds, NSCompositingOperationClear);
+
+  const NSRect pathBounds = NSInsetRect(self.bounds, 0.5, 0.5);
+  const CGFloat maximumRadius = std::max<CGFloat>(
+      0.0, std::min(NSWidth(pathBounds), NSHeight(pathBounds)) / 2.0);
+  const CGFloat effectiveRadius =
+      std::min(std::max<CGFloat>(cornerRadius_, 0.0), maximumRadius);
+  NSBezierPath *windowPath =
+      [NSBezierPath bezierPathWithRoundedRect:pathBounds
+                                     xRadius:effectiveRadius
+                                     yRadius:effectiveRadius];
+
+  [NSGraphicsContext saveGraphicsState];
+  [windowPath addClip];
+
   // Paint the complete view before drawing individual cells. Otherwise,
-  // column gaps and unused layout regions expose the NSPanel's default
-  // white background when a dark renderer style is active.
+  // column gaps and unused layout regions would remain transparent.
   if (style_.candidate_style().has_background_color()) {
     [MacViewUtil::ToNSColor(
         style_.candidate_style().background_color()) set];
@@ -329,10 +345,12 @@ using mozc::renderer::mac::MacViewUtil;
   }
   [self drawFooter];
 
-  // Draw the window border at last
-  [MacViewUtil::ToNSColor(style_.border_color()) set];
-  const mozc::Size windowSize = tableLayout_.GetTotalSize();
-  [NSBezierPath strokeRect:NSMakeRect(0.5, 0.5, windowSize.width - 1, windowSize.height - 1)];
+  [NSGraphicsContext restoreGraphicsState];
+
+  // Draw the rounded outer border last so it remains crisp at the clip edge.
+  [MacViewUtil::ToNSColor(style_.border_color()) setStroke];
+  [windowPath setLineWidth:1.0];
+  [windowPath stroke];
 }
 
 #pragma mark drawing aux methods

--- a/src/renderer/mac/CandidateWindow.mm
+++ b/src/renderer/mac/CandidateWindow.mm
@@ -36,6 +36,7 @@
 #include "base/coordinates.h"
 #include "protocol/commands.pb.h"
 #include "renderer/mac/CandidateWindow.h"
+#include "renderer/renderer_style_handler.h"
 
 namespace mozc {
 namespace renderer {
@@ -56,6 +57,9 @@ void CandidateWindow::SetSendCommandInterface(
 
 void CandidateWindow::InitWindow() {
   RendererBaseWindow::InitWindow();
+  [window_ setOpaque:NO];
+  [window_ setHasShadow:NO];
+  [window_ setBackgroundColor:NSColor.clearColor];
   const CandidateView* candidate_view = (CandidateView*)view_;
   [candidate_view setSendCommandInterface:command_sender_];
 }
@@ -78,6 +82,17 @@ void CandidateWindow::SetCandidateWindow(const commands::CandidateWindow& candid
   [candidate_view setNeedsDisplay:YES];
   NSSize size = [candidate_view updateLayout];
   ResizeWindow(size.width, size.height);
+
+  const RendererStyleHandler::RendererStyleType style_type =
+      RendererStyleHandler::GetRendererStyleTypeForCandidateWindow(
+          candidate_window);
+  const RendererStyleHandler::CandidateWindowEffectStyle effect_style =
+      RendererStyleHandler::GetCandidateWindowEffectStyle(style_type);
+  SetWindowEffects(
+      effect_style.opacity_percent,
+      static_cast<CGFloat>(
+          RendererStyleHandler::GetCandidateWindowCornerRadius(style_type)),
+      effect_style.shadow);
 }
 
 void CandidateWindow::ResetView() {

--- a/src/renderer/mac/InfolistView.mm
+++ b/src/renderer/mac/InfolistView.mm
@@ -27,6 +27,8 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+#include <algorithm>
+#include <new>
 #include <set>
 
 #import "renderer/mac/InfolistView.h"
@@ -48,6 +50,8 @@ using mozc::renderer::mac::MacViewUtil;
 
 // Private method declarations.
 @interface InfolistView ()
+- (void)reloadStyle;
+
 // Draw the |row|-th row and return the height of it.
 // If draw_flag is true, it does not draw but only calculate the size.
 - (CGFloat)drawRow:(int)row ypos:(CGFloat)ypos draw_flag:(bool)draw_flag;
@@ -63,11 +67,10 @@ using mozc::renderer::mac::MacViewUtil;
 - (id)initWithFrame:(NSRect)frame {
   self = [super initWithFrame:frame];
   if (self) {
-    RendererStyle *style = new (std::nothrow) RendererStyle;
-    if (style) {
-      RendererStyleHandler::GetRendererStyle(style);
+    style_ = new (std::nothrow) RendererStyle;
+    if (style_ != nullptr) {
+      [self reloadStyle];
     }
-    style_ = style;
   }
 
   if (!style_) {
@@ -76,8 +79,24 @@ using mozc::renderer::mac::MacViewUtil;
   return self;
 }
 
+- (void)dealloc {
+  delete style_;
+  style_ = nullptr;
+}
+
+- (void)reloadStyle {
+  if (style_ == nullptr) {
+    return;
+  }
+  if (!RendererStyleHandler::GetRendererStyleForWindowType(
+          RendererStyleHandler::RendererStyleType::kCandidate, style_)) {
+    RendererStyleHandler::GetDefaultRendererStyle(style_);
+  }
+}
+
 - (void)setCandidateWindow:(const CandidateWindow *)candidate_window {
   candidate_window_.CopyFrom(*candidate_window);
+  [self reloadStyle];
 }
 
 - (BOOL)isFlipped {
@@ -189,13 +208,6 @@ using mozc::renderer::mac::MacViewUtil;
   }
   ypos += infostyle.window_border();
 
-  if (draw_flag) {
-    [MacViewUtil::ToNSColor(infostyle.border_color()) set];
-    [NSBezierPath setDefaultLineWidth:infostyle.window_border()];
-    [NSBezierPath setDefaultLineJoinStyle:NSLineJoinStyleMiter];
-    [NSBezierPath strokeRect:NSMakeRect(0.5, 0.5, infostyle.window_width() - 1, ypos - 1)];
-  }
-
   return NSMakeSize(infostyle.window_width(), ypos);
 }
 
@@ -204,7 +216,48 @@ using mozc::renderer::mac::MacViewUtil;
 }
 
 - (void)drawRect:(NSRect)rect {
+  if (style_ == nullptr) {
+    return;
+  }
+
+  NSRectFillUsingOperation(self.bounds, NSCompositingOperationClear);
+
+  const RendererStyle::InfolistStyle &infostyle = style_->infolist_style();
+  const CGFloat borderWidth =
+      std::max<CGFloat>(1.0, infostyle.window_border());
+  const NSRect pathBounds =
+      NSInsetRect(self.bounds, borderWidth / 2.0, borderWidth / 2.0);
+  const CGFloat configuredRadius = static_cast<CGFloat>(
+      RendererStyleHandler::GetCandidateWindowCornerRadius(
+          RendererStyleHandler::RendererStyleType::kCandidate));
+  const CGFloat maximumRadius = std::max<CGFloat>(
+      0.0, std::min(NSWidth(pathBounds), NSHeight(pathBounds)) / 2.0);
+  const CGFloat effectiveRadius =
+      std::min(std::max<CGFloat>(configuredRadius, 0.0), maximumRadius);
+  NSBezierPath *windowPath =
+      [NSBezierPath bezierPathWithRoundedRect:pathBounds
+                                     xRadius:effectiveRadius
+                                     yRadius:effectiveRadius];
+
+  [NSGraphicsContext saveGraphicsState];
+  [windowPath addClip];
+  [NSBezierPath setDefaultLineWidth:infostyle.window_border()];
+  [NSBezierPath setDefaultLineJoinStyle:NSLineJoinStyleMiter];
+
+  if (infostyle.title_style().has_background_color()) {
+    [MacViewUtil::ToNSColor(
+        infostyle.title_style().background_color()) setFill];
+  } else {
+    [NSColor.whiteColor setFill];
+  }
+  [NSBezierPath fillRect:self.bounds];
   [self drawView:true];
+
+  [NSGraphicsContext restoreGraphicsState];
+
+  [MacViewUtil::ToNSColor(infostyle.border_color()) setStroke];
+  [windowPath setLineWidth:borderWidth];
+  [windowPath stroke];
 }
 
 @end

--- a/src/renderer/mac/InfolistWindow.h
+++ b/src/renderer/mac/InfolistWindow.h
@@ -59,6 +59,7 @@ class InfolistWindow : public RendererBaseWindow {
   void onTimer(NSTimer *timer);
 
  private:
+  void InitWindow() override;
   InfolistWindowTimerHandler *timer_handler_;
   NSTimer *lasttimer_;
   bool visible_;

--- a/src/renderer/mac/InfolistWindow.mm
+++ b/src/renderer/mac/InfolistWindow.mm
@@ -37,6 +37,7 @@
 #include "client/client_interface.h"
 #include "protocol/commands.pb.h"
 #include "renderer/mac/InfolistWindow.h"
+#include "renderer/renderer_style_handler.h"
 
 using mozc::commands::CandidateWindow;
 using mozc::commands::Output;
@@ -69,7 +70,8 @@ namespace mozc {
 namespace renderer {
 namespace mac {
 
-InfolistWindow::InfolistWindow() : lasttimer_(nullptr), command_sender_(nullptr) {
+InfolistWindow::InfolistWindow()
+    : lasttimer_(nullptr), visible_(false), command_sender_(nullptr) {
   timer_handler_ = [[InfolistWindowTimerHandler alloc] initWithInfolistWindow:this];
 }
 
@@ -92,6 +94,22 @@ void InfolistWindow::SetCandidateWindow(const CandidateWindow& candidate_window)
   [infolist_view setNeedsDisplay:YES];
   NSSize size = [infolist_view updateLayout];
   ResizeWindow(size.width, size.height);
+
+  const RendererStyleHandler::CandidateWindowEffectStyle effect_style =
+      RendererStyleHandler::GetCandidateWindowEffectStyle(
+          RendererStyleHandler::RendererStyleType::kCandidate);
+  SetWindowEffects(
+      effect_style.opacity_percent,
+      static_cast<CGFloat>(RendererStyleHandler::GetCandidateWindowCornerRadius(
+          RendererStyleHandler::RendererStyleType::kCandidate)),
+      effect_style.shadow);
+}
+
+void InfolistWindow::InitWindow() {
+  RendererBaseWindow::InitWindow();
+  [window_ setOpaque:NO];
+  [window_ setHasShadow:NO];
+  [window_ setBackgroundColor:NSColor.clearColor];
 }
 
 void InfolistWindow::DelayHide(int delay) {

--- a/src/renderer/mac/RendererBaseWindow.h
+++ b/src/renderer/mac/RendererBaseWindow.h
@@ -34,6 +34,8 @@
 
 #include <cstdint>
 
+#include "renderer/mac/RendererShadowWindow.h"
+#include "renderer/renderer_style_handler.h"
 
 namespace mozc {
 namespace renderer {
@@ -58,8 +60,20 @@ class RendererBaseWindow {
   NSView *view_;
   virtual void InitWindow();
 
+  // Applies whole-window opacity and the custom renderer shadow while keeping
+  // the owner NSPanel geometry unchanged. |corner_radius| is in Cocoa points.
+  void SetWindowEffects(
+      uint32_t opacity_percent, CGFloat corner_radius,
+      const RendererStyleHandler::WindowShadowStyle &shadow_style);
+
  private:
   virtual void ResetView();
+  void UpdateShadowWindow();
+
+  RendererShadowWindow shadow_window_;
+  bool window_effects_configured_;
+  CGFloat effect_corner_radius_;
+  RendererStyleHandler::WindowShadowStyle shadow_style_;
   NSInteger window_level_;
 };
 

--- a/src/renderer/mac/RendererBaseWindow.mm
+++ b/src/renderer/mac/RendererBaseWindow.mm
@@ -31,6 +31,7 @@
 #include <Cocoa/Cocoa.h>
 #include <objc/message.h>
 
+#include <algorithm>
 #include <cstdint>
 
 #include "absl/log/log.h"
@@ -38,12 +39,19 @@
 #include "base/mac/mac_util.h"
 #include "protocol/commands.pb.h"
 #include "renderer/mac/RendererBaseWindow.h"
+#include "renderer/renderer_style_handler.h"
 
 namespace mozc {
 namespace renderer {
 namespace mac {
 
-RendererBaseWindow::RendererBaseWindow() : window_level_(NSPopUpMenuWindowLevel) {}
+RendererBaseWindow::RendererBaseWindow()
+    : window_(nil),
+      view_(nil),
+      window_effects_configured_(false),
+      effect_corner_radius_(0.0),
+      shadow_style_(),
+      window_level_(NSPopUpMenuWindowLevel) {}
 
 void RendererBaseWindow::InitWindow() {
   if (window_) {
@@ -68,7 +76,12 @@ void RendererBaseWindow::InitWindow() {
   [window_ orderOut:window_];
 }
 
-RendererBaseWindow::~RendererBaseWindow() { [window_ close]; }
+RendererBaseWindow::~RendererBaseWindow() {
+  shadow_window_.Hide();
+  if (window_ != nil) {
+    [window_ close];
+  }
+}
 
 Size RendererBaseWindow::GetWindowSize() const {
   if (!window_) {
@@ -79,6 +92,7 @@ Size RendererBaseWindow::GetWindowSize() const {
 }
 
 void RendererBaseWindow::Hide() {
+  shadow_window_.Hide();
   if (window_) {
     [window_ orderOut:window_];
   }
@@ -89,6 +103,7 @@ void RendererBaseWindow::Show() {
     InitWindow();
   }
   [window_ orderFront:window_];
+  UpdateShadowWindow();
 }
 
 bool RendererBaseWindow::IsVisible() {
@@ -103,23 +118,60 @@ void RendererBaseWindow::ResetView() {
 }
 
 void RendererBaseWindow::MoveWindow(const NSPoint &point) {
+  if (!window_) {
+    return;
+  }
   NSRect rect = [window_ frame];
   rect.origin.x = point.x;
   rect.origin.y = point.y;
   [window_ setFrame:rect display:FALSE];
+  UpdateShadowWindow();
 }
 
 void RendererBaseWindow::ResizeWindow(int32_t width, int32_t height) {
+  if (!window_) {
+    return;
+  }
   NSRect rect = [window_ frame];
   rect.size.width = width;
   rect.size.height = height;
   [window_ setFrame:rect display:FALSE];
+  UpdateShadowWindow();
 }
 
 void RendererBaseWindow::SetWindowLevel(NSInteger window_level) {
   if (window_level_ != window_level) {
     window_level_ = window_level;
-    [window_ setLevel:window_level_];
+    if (window_) {
+      [window_ setLevel:window_level_];
+    }
+  }
+}
+
+void RendererBaseWindow::SetWindowEffects(
+    uint32_t opacity_percent, CGFloat corner_radius,
+    const RendererStyleHandler::WindowShadowStyle &shadow_style) {
+  if (!window_) {
+    return;
+  }
+
+  [window_ setAlphaValue:std::clamp<CGFloat>(
+      static_cast<CGFloat>(opacity_percent) / 100.0, 0.0, 1.0)];
+  [window_ setHasShadow:NO];
+
+  window_effects_configured_ = true;
+  effect_corner_radius_ = std::max<CGFloat>(0.0, corner_radius);
+  shadow_style_ = shadow_style;
+  UpdateShadowWindow();
+}
+
+void RendererBaseWindow::UpdateShadowWindow() {
+  if (!window_effects_configured_ || !window_) {
+    shadow_window_.Hide();
+    return;
+  }
+  if (!shadow_window_.Update(window_, effect_corner_radius_, shadow_style_)) {
+    LOG(ERROR) << "Failed to update macOS renderer shadow window.";
   }
 }
 

--- a/src/renderer/mac/RendererShadowWindow.h
+++ b/src/renderer/mac/RendererShadowWindow.h
@@ -27,36 +27,53 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#ifndef MOZC_RENDERER_MAC_INFOLIST_VIEW_H_
-#define MOZC_RENDERER_MAC_INFOLIST_VIEW_H_
+#ifndef MOZC_RENDERER_MAC_RENDERER_SHADOW_WINDOW_H_
+#define MOZC_RENDERER_MAC_RENDERER_SHADOW_WINDOW_H_
 
 #import <Cocoa/Cocoa.h>
 
-#include "protocol/candidate_window.pb.h"
-#include "protocol/renderer_command.pb.h"
+#include <cstdint>
+
+#include "renderer/renderer_style_handler.h"
+#include "renderer/window_effect_util.h"
+
+@class MozcRendererShadowView;
 
 namespace mozc {
 namespace renderer {
-class RendererStyle;
-}  // namespace mozc::renderer
+namespace mac {
+
+// Owns the transparent visual-only panel used for renderer shadows on macOS.
+// The owner NSWindow keeps the logical renderer geometry used by WindowUtil;
+// this panel is deliberately excluded from positioning and collision logic.
+class RendererShadowWindow {
+ public:
+  RendererShadowWindow();
+  RendererShadowWindow(const RendererShadowWindow &) = delete;
+  RendererShadowWindow &operator=(const RendererShadowWindow &) = delete;
+  ~RendererShadowWindow();
+
+  void Hide();
+  // Updates shadow pixels and geometry from the current owner frame. The
+  // corner radius is expressed in Cocoa points. Pixel data is regenerated only
+  // when rendering inputs change. If the owner is visible, the shadow is also
+  // presented. Returns false only when an enabled shadow cannot be rendered.
+  bool Update(NSWindow *owner_window, CGFloat owner_corner_radius,
+              const RendererStyleHandler::WindowShadowStyle &style);
+
+ private:
+  void EnsureWindow();
+
+  NSPanel *window_;
+  MozcRendererShadowView *view_;
+  bool cached_image_valid_;
+  WindowShadowGeometry cached_geometry_;
+  uint32_t cached_opacity_percent_;
+  CGFloat cached_backing_scale_;
+};
+
+}  // namespace mac
+}  // namespace renderer
 }  // namespace mozc
 
-// InfolistView is an NSView subclass to draw the infolist window
-// according to the current candidates.
-@interface InfolistView : NSView {
- @private
-  mozc::commands::CandidateWindow candidate_window_;
-  mozc::renderer::RendererStyle *style_;
-  // The row which has focused background.
-  int focusedRow_;
-}
-
-// setCandidateWindow: sets the candidate window to be rendered.
-- (void)setCandidateWindow:(const mozc::commands::CandidateWindow *)candidate_window;
-
-// Checks the |candidates_| and recalculates the layout.
-// It also returns the size which is necessary to draw all GUI elements.
-- (NSSize)updateLayout;
-@end
-
-#endif  // MOZC_RENDERER_MAC_INFOLIST_VIEW_H_
+#endif  // MOZC_RENDERER_MAC_RENDERER_SHADOW_WINDOW_H_

--- a/src/renderer/mac/RendererShadowWindow.mm
+++ b/src/renderer/mac/RendererShadowWindow.mm
@@ -1,0 +1,303 @@
+// Copyright 2010-2021, Google Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "renderer/mac/RendererShadowWindow.h"
+
+#import <Cocoa/Cocoa.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <vector>
+
+#include "absl/log/log.h"
+#include "renderer/window_effect_util.h"
+
+@interface MozcRendererShadowView : NSView
+- (void)setShadowImage:(NSImage *)image;
+@end
+
+@implementation MozcRendererShadowView {
+  NSImage *image_;
+}
+
+- (BOOL)isOpaque {
+  return NO;
+}
+
+- (BOOL)isFlipped {
+  return YES;
+}
+
+- (void)setShadowImage:(NSImage *)image {
+  image_ = image;
+  [self setNeedsDisplay:YES];
+}
+
+- (void)drawRect:(NSRect)dirtyRect {
+  [super drawRect:dirtyRect];
+  NSRectFillUsingOperation(self.bounds, NSCompositingOperationClear);
+  if (image_ == nil) {
+    return;
+  }
+  [image_ drawInRect:self.bounds
+            fromRect:NSMakeRect(0, 0, image_.size.width, image_.size.height)
+           operation:NSCompositingOperationSourceOver
+            fraction:1.0
+      respectFlipped:YES
+               hints:nil];
+}
+
+@end
+
+namespace mozc {
+namespace renderer {
+namespace mac {
+namespace {
+
+// CandidateController assigns all renderer body panels levels from
+// NSPopUpMenuWindowLevel - 1 through NSPopUpMenuWindowLevel + 2. Reserve the
+// immediately lower level for visual-only shadows so no shadow can cover a
+// renderer body.
+constexpr NSInteger kRendererShadowWindowLevel = NSPopUpMenuWindowLevel - 2;
+
+int ScaleToBackingPixels(CGFloat value, CGFloat backing_scale) {
+  return std::max(
+      0, static_cast<int>(std::lround(
+             value * std::max<CGFloat>(1.0, backing_scale))));
+}
+
+NSImage *CreateShadowImage(const WindowShadowGeometry &geometry,
+                           uint32_t opacity_percent,
+                           CGFloat backing_scale) {
+  if (!geometry.enabled() || opacity_percent == 0) {
+    return nil;
+  }
+
+  const int64_t pixel_count =
+      static_cast<int64_t>(geometry.width) * geometry.height;
+  if (pixel_count <= 0 ||
+      static_cast<uint64_t>(pixel_count) >
+          std::numeric_limits<size_t>::max() / 4) {
+    return nil;
+  }
+
+  std::vector<uint8_t> alpha(static_cast<size_t>(pixel_count));
+  if (!RenderWindowShadowAlphaMask(geometry, opacity_percent, alpha.data(),
+                                   alpha.size())) {
+    return nil;
+  }
+
+  const NSInteger bytes_per_row = static_cast<NSInteger>(geometry.width) * 4;
+  NSBitmapImageRep *representation = [[NSBitmapImageRep alloc]
+      initWithBitmapDataPlanes:nullptr
+                    pixelsWide:geometry.width
+                    pixelsHigh:geometry.height
+                 bitsPerSample:8
+               samplesPerPixel:4
+                      hasAlpha:YES
+                      isPlanar:NO
+                colorSpaceName:NSDeviceRGBColorSpace
+                   bitmapFormat:0
+                    bytesPerRow:bytes_per_row
+                   bitsPerPixel:32];
+  if (representation == nil || [representation bitmapData] == nullptr) {
+    return nil;
+  }
+
+  // The default NSBitmapImageRep format stores RGB followed by premultiplied
+  // alpha. Black remains (0, 0, 0) under premultiplication, so only the alpha
+  // byte needs to vary.
+  uint8_t *bitmap = [representation bitmapData];
+  for (size_t i = 0; i < static_cast<size_t>(pixel_count); ++i) {
+    bitmap[i * 4 + 0] = 0;
+    bitmap[i * 4 + 1] = 0;
+    bitmap[i * 4 + 2] = 0;
+    bitmap[i * 4 + 3] = alpha[i];
+  }
+
+  const CGFloat scale = std::max<CGFloat>(1.0, backing_scale);
+  const NSSize point_size =
+      NSMakeSize(static_cast<CGFloat>(geometry.width) / scale,
+                 static_cast<CGFloat>(geometry.height) / scale);
+  [representation setSize:point_size];
+
+  NSImage *image = [[NSImage alloc] initWithSize:point_size];
+  [image addRepresentation:representation];
+  return image;
+}
+
+}  // namespace
+
+RendererShadowWindow::RendererShadowWindow()
+    : window_(nil),
+      view_(nil),
+      cached_image_valid_(false),
+      cached_geometry_(),
+      cached_opacity_percent_(0),
+      cached_backing_scale_(0.0) {}
+
+RendererShadowWindow::~RendererShadowWindow() {
+  if (window_ != nil) {
+    [window_ orderOut:nil];
+    [window_ close];
+  }
+}
+
+void RendererShadowWindow::EnsureWindow() {
+  if (window_ != nil) {
+    return;
+  }
+
+  window_ = [[NSPanel alloc]
+      initWithContentRect:NSMakeRect(0, 0, 1, 1)
+                styleMask:(NSWindowStyleMaskBorderless |
+                           NSWindowStyleMaskNonactivatingPanel)
+                  backing:NSBackingStoreBuffered
+                    defer:YES];
+  view_ = [[MozcRendererShadowView alloc]
+      initWithFrame:NSMakeRect(0, 0, 1, 1)];
+  [window_ setContentView:view_];
+  [window_ setOpaque:NO];
+  [window_ setHasShadow:NO];
+  [window_ setBackgroundColor:NSColor.clearColor];
+  [window_ setIgnoresMouseEvents:YES];
+  [window_ setFloatingPanel:YES];
+  [window_ setWorksWhenModal:YES];
+  [window_ setReleasedWhenClosed:NO];
+  [window_ setDisplaysWhenScreenProfileChanges:YES];
+  [window_ setLevel:kRendererShadowWindowLevel];
+  [window_ orderOut:nil];
+}
+
+void RendererShadowWindow::Hide() {
+  if (window_ != nil) {
+    [window_ orderOut:nil];
+  }
+}
+
+bool RendererShadowWindow::Update(
+    NSWindow *owner_window, CGFloat owner_corner_radius,
+    const RendererStyleHandler::WindowShadowStyle &style) {
+  if (owner_window == nil) {
+    Hide();
+    return true;
+  }
+
+  const uint32_t shadow_size = std::min(style.size, kMaxWindowShadowSize);
+  const uint32_t shadow_distance =
+      std::min(style.distance, kMaxWindowShadowDistance);
+  const uint32_t shadow_opacity =
+      std::min(style.opacity_percent, kMaxWindowShadowOpacityPercent);
+  if (shadow_size == 0 || shadow_opacity == 0) {
+    Hide();
+    return true;
+  }
+
+  const NSRect owner_frame = [owner_window frame];
+  if (NSWidth(owner_frame) <= 0.0 || NSHeight(owner_frame) <= 0.0) {
+    Hide();
+    return true;
+  }
+
+  const CGFloat backing_scale =
+      std::max<CGFloat>(1.0, [owner_window backingScaleFactor]);
+  const int owner_width =
+      ScaleToBackingPixels(NSWidth(owner_frame), backing_scale);
+  const int owner_height =
+      ScaleToBackingPixels(NSHeight(owner_frame), backing_scale);
+  const int shadow_size_pixels =
+      ScaleToBackingPixels(static_cast<CGFloat>(shadow_size), backing_scale);
+  const int shadow_distance_pixels =
+      ScaleToBackingPixels(static_cast<CGFloat>(shadow_distance), backing_scale);
+  const int corner_radius_pixels =
+      ScaleToBackingPixels(std::max<CGFloat>(0.0, owner_corner_radius),
+                           backing_scale);
+
+  const WindowShadowGeometry geometry = ComputeWindowShadowGeometry(
+      owner_width, owner_height, shadow_size_pixels, shadow_distance_pixels,
+      style.angle_degrees, corner_radius_pixels);
+  if (!geometry.enabled()) {
+    Hide();
+    return true;
+  }
+
+  EnsureWindow();
+  if (!cached_image_valid_ || geometry != cached_geometry_ ||
+      shadow_opacity != cached_opacity_percent_ ||
+      backing_scale != cached_backing_scale_) {
+    NSImage *image =
+        CreateShadowImage(geometry, shadow_opacity, backing_scale);
+    if (image == nil) {
+      LOG(ERROR) << "Failed to create macOS renderer shadow bitmap.";
+      cached_image_valid_ = false;
+      Hide();
+      return false;
+    }
+    [view_ setShadowImage:image];
+    cached_geometry_ = geometry;
+    cached_opacity_percent_ = shadow_opacity;
+    cached_backing_scale_ = backing_scale;
+    cached_image_valid_ = true;
+  }
+
+  [window_ setCollectionBehavior:
+      ([owner_window collectionBehavior] |
+       NSWindowCollectionBehaviorTransient |
+       NSWindowCollectionBehaviorIgnoresCycle)];
+  const CGFloat scale = std::max<CGFloat>(1.0, backing_scale);
+  const CGFloat left_margin = geometry.left_margin / scale;
+  const CGFloat right_margin = geometry.right_margin / scale;
+  const CGFloat top_margin = geometry.top_margin / scale;
+  const CGFloat bottom_margin = geometry.bottom_margin / scale;
+  const NSRect shadow_frame =
+      NSMakeRect(NSMinX(owner_frame) - left_margin,
+                 NSMinY(owner_frame) - bottom_margin,
+                 NSWidth(owner_frame) + left_margin + right_margin,
+                 NSHeight(owner_frame) + top_margin + bottom_margin);
+
+  [window_ setFrame:shadow_frame display:NO];
+  [view_ setFrame:NSMakeRect(0, 0, NSWidth(shadow_frame),
+                            NSHeight(shadow_frame))];
+
+  if ([owner_window isVisible]) {
+    // Levels dominate same-level ordering, so this can come to the front of
+    // the shadow level without covering any renderer body.
+    [window_ orderFront:nil];
+  } else {
+    [window_ orderOut:nil];
+  }
+  return true;
+}
+
+}  // namespace mac
+}  // namespace renderer
+}  // namespace mozc

--- a/src/renderer/mac/RubyWindow.mm
+++ b/src/renderer/mac/RubyWindow.mm
@@ -148,6 +148,7 @@ void SetRgbColor(uint32_t rgb,
 
 - (void)drawRect:(NSRect)dirtyRect {
   [super drawRect:dirtyRect];
+  NSRectFillUsingOperation(self.bounds, NSCompositingOperationClear);
 
   const NSRect pathBounds = NSInsetRect(self.bounds, 0.5, 0.5);
   const CGFloat maximumRadius =
@@ -252,12 +253,12 @@ bool RubyWindow::Update(const commands::RendererCommand &command) {
   }
 
   RubyView *ruby_view = (RubyView *)view_;
+  const CGFloat corner_radius =
+      ScaleMetric(appearance.corner_radius, appearance.size_percent);
   [ruby_view
       setBackgroundColor:ToNSColor(appearance.background_color)
              borderColor:ToNSColor(appearance.border_color)
-            cornerRadius:ScaleMetric(
-                             appearance.corner_radius,
-                             appearance.size_percent)
+            cornerRadius:corner_radius
        horizontalPadding:ScaleWindowsRubySpacingToCocoaPoints(
                              appearance.horizontal_padding,
                              appearance.size_percent)
@@ -273,15 +274,12 @@ bool RubyWindow::Update(const commands::RendererCommand &command) {
           appearance.composition_gap,
           appearance.size_percent));
 
-  [window_ setAlphaValue:std::clamp<CGFloat>(
-      static_cast<CGFloat>(appearance.opacity_percent) / 100.0,
-      0.0,
-      1.0)];
-
   const NSSize size = [ruby_view preferredSize];
   ResizeWindow(
       static_cast<int32_t>(ceil(size.width)),
       static_cast<int32_t>(ceil(size.height)));
+  SetWindowEffects(appearance.opacity_percent, corner_radius,
+                   appearance.shadow);
   return true;
 }
 
@@ -292,7 +290,7 @@ int32_t RubyWindow::GetCompositionGap() const {
 void RubyWindow::InitWindow() {
   RendererBaseWindow::InitWindow();
   [window_ setOpaque:NO];
-  [window_ setHasShadow:YES];
+  [window_ setHasShadow:NO];
   [window_ setBackgroundColor:NSColor.clearColor];
   [window_ setIgnoresMouseEvents:YES];
 }

--- a/src/renderer/renderer_server.cc
+++ b/src/renderer/renderer_server.cc
@@ -51,6 +51,7 @@
 #include "protocol/renderer_command.pb.h"
 #include "renderer/renderer_interface.h"
 #include "renderer/renderer_style_handler.h"
+#include "renderer/window_effect_util.h"
 
 #ifdef _WIN32
 #include <windows.h>
@@ -92,9 +93,6 @@ constexpr uint32_t kMinWindowSizePercent = 80;
 constexpr uint32_t kMaxWindowSizePercent = 200;
 constexpr uint32_t kMinWindowOpacityPercent = 20;
 constexpr uint32_t kMaxWindowOpacityPercent = 100;
-constexpr uint32_t kMaxShadowSize = 96;
-constexpr uint32_t kMaxShadowDistance = 96;
-constexpr uint32_t kMaxShadowOpacityPercent = 100;
 constexpr uint32_t kMaxRubyHorizontalPadding = 40;
 constexpr uint32_t kMaxRubyVerticalPadding = 24;
 constexpr uint32_t kMaxRubyCompositionGap = 32;
@@ -155,11 +153,11 @@ RendererStyleHandler::WindowShadowStyle BuildShadowStyle(
     uint32_t size, uint32_t opacity_percent, uint32_t angle_degrees,
     uint32_t distance) {
   RendererStyleHandler::WindowShadowStyle style;
-  style.size = std::clamp(size, 0u, kMaxShadowSize);
+  style.size = std::clamp(size, 0u, kMaxWindowShadowSize);
   style.opacity_percent =
-      std::clamp(opacity_percent, 0u, kMaxShadowOpacityPercent);
+      std::clamp(opacity_percent, 0u, kMaxWindowShadowOpacityPercent);
   style.angle_degrees = angle_degrees % 360u;
-  style.distance = std::clamp(distance, 0u, kMaxShadowDistance);
+  style.distance = std::clamp(distance, 0u, kMaxWindowShadowDistance);
   return style;
 }
 

--- a/src/renderer/renderer_server_test.cc
+++ b/src/renderer/renderer_server_test.cc
@@ -197,6 +197,105 @@ TEST_F(RendererServerTest, AppliesIndependentFontWeightsWithNormalization) {
   EXPECT_EQ(900u, RendererStyleHandler::GetRubyWindowStyle().font_weight);
 }
 
+TEST_F(RendererServerTest, UsesWindowEffectDefaultsWhenFieldsAreAbsent) {
+  config::Config input = config::ConfigHandler::DefaultConfig();
+  input.clear_candidate_window_shadow_size();
+  input.clear_candidate_window_shadow_opacity_percent();
+  input.clear_candidate_window_shadow_angle_degrees();
+  input.clear_candidate_window_shadow_distance();
+  input.clear_suggest_window_shadow_size();
+  input.clear_suggest_window_shadow_opacity_percent();
+  input.clear_suggest_window_shadow_angle_degrees();
+  input.clear_suggest_window_shadow_distance();
+  input.clear_ruby_window_shadow_size();
+  input.clear_ruby_window_shadow_opacity_percent();
+  input.clear_ruby_window_shadow_angle_degrees();
+  input.clear_ruby_window_shadow_distance();
+  config::ConfigHandler::SetConfig(input);
+
+  TestRendererServer server;
+
+  const auto candidate_effect =
+      RendererStyleHandler::GetCandidateWindowEffectStyle(
+          RendererStyleHandler::RendererStyleType::kCandidate);
+  EXPECT_EQ(5u, candidate_effect.shadow.size);
+  EXPECT_EQ(10u, candidate_effect.shadow.opacity_percent);
+  EXPECT_EQ(45u, candidate_effect.shadow.angle_degrees);
+  EXPECT_EQ(6u, candidate_effect.shadow.distance);
+
+  const auto suggestion_effect =
+      RendererStyleHandler::GetCandidateWindowEffectStyle(
+          RendererStyleHandler::RendererStyleType::kSuggestion);
+  EXPECT_EQ(5u, suggestion_effect.shadow.size);
+  EXPECT_EQ(10u, suggestion_effect.shadow.opacity_percent);
+  EXPECT_EQ(45u, suggestion_effect.shadow.angle_degrees);
+  EXPECT_EQ(6u, suggestion_effect.shadow.distance);
+
+  const RendererStyleHandler::RubyWindowStyle ruby =
+      RendererStyleHandler::GetRubyWindowStyle();
+  EXPECT_EQ(5u, ruby.shadow.size);
+  EXPECT_EQ(8u, ruby.shadow.opacity_percent);
+  EXPECT_EQ(45u, ruby.shadow.angle_degrees);
+  EXPECT_EQ(3u, ruby.shadow.distance);
+}
+
+TEST_F(RendererServerTest, AppliesWindowEffectsWithClamping) {
+  config::Config input = config::ConfigHandler::DefaultConfig();
+  input.set_candidate_window_custom_corner_radius(999);
+  input.set_suggest_window_custom_corner_radius(23);
+  input.set_ruby_window_custom_corner_radius(999);
+  input.set_candidate_window_opacity_percent(0);
+  input.set_suggest_window_opacity_percent(999);
+  input.set_ruby_window_opacity_percent(1);
+  input.set_candidate_window_shadow_size(999);
+  input.set_candidate_window_shadow_opacity_percent(999);
+  input.set_candidate_window_shadow_angle_degrees(725);
+  input.set_candidate_window_shadow_distance(999);
+  input.set_suggest_window_shadow_size(0);
+  input.set_suggest_window_shadow_opacity_percent(0);
+  input.set_suggest_window_shadow_angle_degrees(450);
+  input.set_suggest_window_shadow_distance(17);
+  input.set_ruby_window_shadow_size(11);
+  input.set_ruby_window_shadow_opacity_percent(37);
+  input.set_ruby_window_shadow_angle_degrees(999);
+  input.set_ruby_window_shadow_distance(999);
+  config::ConfigHandler::SetConfig(input);
+
+  TestRendererServer server;
+
+  EXPECT_EQ(24u, RendererStyleHandler::GetCandidateWindowCornerRadius(
+                     RendererStyleHandler::RendererStyleType::kCandidate));
+  EXPECT_EQ(23u, RendererStyleHandler::GetCandidateWindowCornerRadius(
+                     RendererStyleHandler::RendererStyleType::kSuggestion));
+
+  const auto candidate_effect =
+      RendererStyleHandler::GetCandidateWindowEffectStyle(
+          RendererStyleHandler::RendererStyleType::kCandidate);
+  EXPECT_EQ(20u, candidate_effect.opacity_percent);
+  EXPECT_EQ(96u, candidate_effect.shadow.size);
+  EXPECT_EQ(100u, candidate_effect.shadow.opacity_percent);
+  EXPECT_EQ(5u, candidate_effect.shadow.angle_degrees);
+  EXPECT_EQ(96u, candidate_effect.shadow.distance);
+
+  const auto suggestion_effect =
+      RendererStyleHandler::GetCandidateWindowEffectStyle(
+          RendererStyleHandler::RendererStyleType::kSuggestion);
+  EXPECT_EQ(100u, suggestion_effect.opacity_percent);
+  EXPECT_EQ(0u, suggestion_effect.shadow.size);
+  EXPECT_EQ(0u, suggestion_effect.shadow.opacity_percent);
+  EXPECT_EQ(90u, suggestion_effect.shadow.angle_degrees);
+  EXPECT_EQ(17u, suggestion_effect.shadow.distance);
+
+  const RendererStyleHandler::RubyWindowStyle ruby =
+      RendererStyleHandler::GetRubyWindowStyle();
+  EXPECT_EQ(24u, ruby.corner_radius);
+  EXPECT_EQ(20u, ruby.opacity_percent);
+  EXPECT_EQ(11u, ruby.shadow.size);
+  EXPECT_EQ(37u, ruby.shadow.opacity_percent);
+  EXPECT_EQ(279u, ruby.shadow.angle_degrees);
+  EXPECT_EQ(96u, ruby.shadow.distance);
+}
+
 TEST_F(RendererServerTest, AppliesRubySpacingConfigWithClamping) {
   config::Config input = config::ConfigHandler::DefaultConfig();
   input.set_ruby_window_horizontal_padding(999);

--- a/src/renderer/renderer_style_handler.cc
+++ b/src/renderer/renderer_style_handler.cc
@@ -40,6 +40,7 @@
 #include "base/protobuf/text_format.h"
 #include "base/protobuf_util.h"
 #include "base/text_normalizer.h"
+#include "protocol/candidate_window.pb.h"
 #include "protocol/renderer_style.pb.h"
 
 namespace mozc {
@@ -393,6 +394,16 @@ bool RendererStyleHandler::GetRendererStyle(RendererStyle* style) {
 
 bool RendererStyleHandler::SetRendererStyle(const RendererStyle& style) {
   return GetRendererStyleHandlerImpl()->SetRendererStyle(style);
+}
+
+RendererStyleHandler::RendererStyleType
+RendererStyleHandler::GetRendererStyleTypeForCandidateWindow(
+    const commands::CandidateWindow& candidate_window) {
+  const bool use_suggestion_style =
+      candidate_window.category() == commands::SUGGESTION ||
+      candidate_window.category() == commands::PREDICTION;
+  return use_suggestion_style ? RendererStyleType::kSuggestion
+                              : RendererStyleType::kCandidate;
 }
 
 bool RendererStyleHandler::GetRendererStyleForWindowType(

--- a/src/renderer/renderer_style_handler.h
+++ b/src/renderer/renderer_style_handler.h
@@ -36,6 +36,10 @@
 #include "protocol/renderer_style.pb.h"
 
 namespace mozc {
+namespace commands {
+class CandidateWindow;
+}  // namespace commands
+
 namespace renderer {
 
 // this is pure static class
@@ -47,6 +51,12 @@ class RendererStyleHandler {
     kCandidate,
     kSuggestion,
   };
+
+  // Maps candidate-window categories to the appearance bucket used by both
+  // renderer platforms. PREDICTION and SUGGESTION share the suggestion
+  // appearance; the remaining categories use the candidate appearance.
+  static RendererStyleType GetRendererStyleTypeForCandidateWindow(
+      const commands::CandidateWindow& candidate_window);
 
   struct WindowShadowStyle {
     uint32_t size = 12;

--- a/src/renderer/renderer_style_handler_test.cc
+++ b/src/renderer/renderer_style_handler_test.cc
@@ -31,6 +31,7 @@
 
 #include <cstdint>
 
+#include "protocol/candidate_window.pb.h"
 #include "protocol/renderer_style.pb.h"
 #include "testing/gunit.h"
 
@@ -124,6 +125,35 @@ TEST(RendererStyleHandlerTest,
   EXPECT_TRUE(style.gap1_style().has_background_color());
   EXPECT_EQ(Rgb(style.candidate_style().background_color()),
             Rgb(style.gap1_style().background_color()));
+}
+
+TEST(RendererStyleHandlerTest, CandidateWindowCategorySelectsAppearanceBucket) {
+  commands::CandidateWindow candidate;
+
+  candidate.set_category(commands::CONVERSION);
+  EXPECT_EQ(RendererStyleHandler::RendererStyleType::kCandidate,
+            RendererStyleHandler::GetRendererStyleTypeForCandidateWindow(
+                candidate));
+
+  candidate.set_category(commands::TRANSLITERATION);
+  EXPECT_EQ(RendererStyleHandler::RendererStyleType::kCandidate,
+            RendererStyleHandler::GetRendererStyleTypeForCandidateWindow(
+                candidate));
+
+  candidate.set_category(commands::USAGE);
+  EXPECT_EQ(RendererStyleHandler::RendererStyleType::kCandidate,
+            RendererStyleHandler::GetRendererStyleTypeForCandidateWindow(
+                candidate));
+
+  candidate.set_category(commands::SUGGESTION);
+  EXPECT_EQ(RendererStyleHandler::RendererStyleType::kSuggestion,
+            RendererStyleHandler::GetRendererStyleTypeForCandidateWindow(
+                candidate));
+
+  candidate.set_category(commands::PREDICTION);
+  EXPECT_EQ(RendererStyleHandler::RendererStyleType::kSuggestion,
+            RendererStyleHandler::GetRendererStyleTypeForCandidateWindow(
+                candidate));
 }
 
 TEST(RendererStyleHandlerTest, ApplyCandidateWindowSize) {

--- a/src/renderer/win32/BUILD.bazel
+++ b/src/renderer/win32/BUILD.bazel
@@ -332,6 +332,7 @@ mozc_cc_library(
         "//bazel/win32:gdi32",
         "//bazel/win32:user32",
         "//protocol:renderer_cc_proto",
+        "//renderer:window_effect_util",
         "@com_google_absl//absl/log",
         "@com_google_absl//absl/log:check",
     ],

--- a/src/renderer/win32/candidate_window.cc
+++ b/src/renderer/win32/candidate_window.cc
@@ -101,13 +101,8 @@ COLORREF ToColorRef(const RendererStyle::RGBAColor& color) {
 
 RendererStyleHandler::RendererStyleType GetRendererStyleType(
     const commands::CandidateWindow& candidate_window) {
-  // PREDICTION is the user-visible continuation of suggestion UI, so it uses
-  // the same appearance bucket as SUGGESTION.
-  const bool use_suggestion_style =
-      candidate_window.category() == commands::SUGGESTION ||
-      candidate_window.category() == commands::PREDICTION;
-  return use_suggestion_style ? RendererStyleHandler::RendererStyleType::kSuggestion
-                              : RendererStyleHandler::RendererStyleType::kCandidate;
+  return RendererStyleHandler::GetRendererStyleTypeForCandidateWindow(
+      candidate_window);
 }
 
 RendererStyle GetCurrentRendererStyle(

--- a/src/renderer/win32/win32_renderer_util.cc
+++ b/src/renderer/win32/win32_renderer_util.cc
@@ -49,6 +49,7 @@
 #include "absl/log/log.h"
 #include "base/win32/win_util.h"
 #include "protocol/renderer_command.pb.h"
+#include "renderer/window_effect_util.h"
 
 namespace mozc {
 namespace renderer {
@@ -61,9 +62,6 @@ constexpr wchar_t kRendererShadowWindowClassName[] =
 constexpr uint32_t kDefaultDpi = 96;
 constexpr uint32_t kMinOpacityPercent = 20;
 constexpr uint32_t kMaxOpacityPercent = 100;
-constexpr uint32_t kMaxShadowSize = 96;
-constexpr uint32_t kMaxShadowDistance = 96;
-constexpr uint32_t kMaxShadowOpacityPercent = 100;
 
 LRESULT CALLBACK ShadowWindowProc(HWND hwnd, UINT message, WPARAM wparam,
                                   LPARAM lparam) {
@@ -99,89 +97,27 @@ uint32_t ScaleLogicalPixel(uint32_t value, uint32_t dpi) {
                                                static_cast<int>(value), dpi)));
 }
 
-// Signed distance from a rounded rectangle.  Negative means inside the owner
-// shape.  Positive means outside and is used as the shadow falloff distance.
-double SignedDistanceFromRoundedRect(double x, double y, double width,
-                                     double height, double radius) {
-  radius = std::max(0.0, std::min(radius, std::min(width, height) / 2.0));
-  const double half_width = width / 2.0;
-  const double half_height = height / 2.0;
-  const double qx = std::abs(x - half_width) - (half_width - radius);
-  const double qy = std::abs(y - half_height) - (half_height - radius);
-  const double outside_x = std::max(qx, 0.0);
-  const double outside_y = std::max(qy, 0.0);
-  double outside_distance = 0.0;
-  if (outside_x > 0.0 || outside_y > 0.0) {
-    outside_distance =
-        std::sqrt(outside_x * outside_x + outside_y * outside_y);
-  }
-  const double inside_distance = std::min(std::max(qx, qy), 0.0);
-  return outside_distance + inside_distance - radius;
-}
-
-// Converts signed distance at a pixel center to one-pixel-wide antialias
-// coverage. A pixel centered at least half a pixel inside is fully covered; a
-// pixel centered at least half a pixel outside is fully transparent.
-double RoundedRectCoverage(double x, double y, double width, double height,
-                           double radius) {
-  return std::clamp(
-      0.5 - SignedDistanceFromRoundedRect(x, y, width, height, radius), 0.0,
-      1.0);
-}
-
 uint8_t ClampToByte(double value) {
   return static_cast<uint8_t>(
       std::clamp(std::lround(value), 0l, 255l));
 }
 
-constexpr double kPi = 3.14159265358979323846;
-
-void DrawShadowBitmap(uint32_t* pixels, int width, int height, int owner_width,
-                      int owner_height, int shadow_size, int shadow_dx,
-                      int shadow_dy, int owner_left, int owner_top,
-                      int owner_corner_radius, uint32_t opacity_percent) {
-  if (pixels == nullptr || width <= 0 || height <= 0 || owner_width <= 0 ||
-      owner_height <= 0 || shadow_size <= 0 || opacity_percent == 0) {
+void DrawShadowBitmap(uint32_t* pixels,
+                      const WindowShadowGeometry& geometry,
+                      uint32_t opacity_percent) {
+  if (pixels == nullptr || !geometry.enabled() || opacity_percent == 0) {
     return;
   }
 
-  std::memset(pixels, 0, sizeof(uint32_t) * width * height);
-  const uint32_t max_alpha =
-      std::clamp(opacity_percent, 0u, kMaxShadowOpacityPercent) * 255u / 100u;
-  const double corner_radius = static_cast<double>(owner_corner_radius);
-  const double falloff = static_cast<double>(std::max(1, shadow_size));
-
-  for (int y = 0; y < height; ++y) {
-    for (int x = 0; x < width; ++x) {
-      const double owner_x = static_cast<double>(x - owner_left) + 0.5;
-      const double owner_y = static_cast<double>(y - owner_top) + 0.5;
-      const double owner_distance = SignedDistanceFromRoundedRect(
-          owner_x, owner_y, owner_width, owner_height, corner_radius);
-      if (owner_distance <= 0.0) {
-        continue;
-      }
-
-      const double shadow_x =
-          static_cast<double>(x - owner_left - shadow_dx) + 0.5;
-      const double shadow_y =
-          static_cast<double>(y - owner_top - shadow_dy) + 0.5;
-      const double shadow_distance = SignedDistanceFromRoundedRect(
-          shadow_x, shadow_y, owner_width, owner_height, corner_radius);
-
-      double normalized = 0.0;
-      if (shadow_distance > 0.0) {
-        normalized = shadow_distance / falloff;
-      }
-      if (normalized > 1.0) {
-        continue;
-      }
-
-      // A smooth, monotonic falloff avoids the visible seams produced by
-      // independent top/right/bottom/left gradient bands.
-      const double t = 1.0 - std::clamp(normalized, 0.0, 1.0);
-      const uint32_t alpha = static_cast<uint32_t>(std::lround(
-          static_cast<double>(max_alpha) * t * t * (3.0 - 2.0 * t)));
-      pixels[y * width + x] = (alpha << 24);  // PBGRA black.
+  const size_t pixel_count =
+      static_cast<size_t>(geometry.width) * geometry.height;
+  std::memset(pixels, 0, sizeof(uint32_t) * pixel_count);
+  for (int y = 0; y < geometry.height; ++y) {
+    for (int x = 0; x < geometry.width; ++x) {
+      const uint8_t alpha =
+          ComputeWindowShadowAlpha(geometry, x, y, opacity_percent);
+      pixels[static_cast<size_t>(y) * geometry.width + x] =
+          static_cast<uint32_t>(alpha) << 24;  // PBGRA black.
     }
   }
 }
@@ -945,12 +881,12 @@ bool RendererShadowWindow::Update(HWND owner_window, const RECT& owner_rect,
   const int owner_width = owner_rect.right - owner_rect.left;
   const int owner_height = owner_rect.bottom - owner_rect.top;
   const uint32_t logical_shadow_size =
-      std::clamp(style.size, 0u, kMaxShadowSize);
+      std::clamp(style.size, 0u, kMaxWindowShadowSize);
   const uint32_t logical_shadow_distance =
-      std::clamp(style.distance, 0u, kMaxShadowDistance);
+      std::clamp(style.distance, 0u, kMaxWindowShadowDistance);
   const uint32_t shadow_angle = style.angle_degrees % 360u;
   const uint32_t shadow_opacity =
-      std::clamp(style.opacity_percent, 0u, kMaxShadowOpacityPercent);
+      std::clamp(style.opacity_percent, 0u, kMaxWindowShadowOpacityPercent);
   if (owner_width <= 0 || owner_height <= 0 || logical_shadow_size == 0 ||
       shadow_opacity == 0) {
     Hide();
@@ -976,21 +912,10 @@ bool RendererShadowWindow::Update(HWND owner_window, const RECT& owner_rect,
       ScaleLogicalPixel(logical_shadow_size, dpi));
   const int shadow_distance = static_cast<int>(
       ScaleLogicalPixel(logical_shadow_distance, dpi));
-  const double radians = static_cast<double>(shadow_angle) * kPi / 180.0;
-  const int shadow_dx =
-      static_cast<int>(std::lround(std::cos(radians) * shadow_distance));
-  const int shadow_dy =
-      static_cast<int>(std::lround(std::sin(radians) * shadow_distance));
-  const int left_margin = shadow_size + std::max(-shadow_dx, 0);
-  const int right_margin = shadow_size + std::max(shadow_dx, 0);
-  const int top_margin = shadow_size + std::max(-shadow_dy, 0);
-  const int bottom_margin = shadow_size + std::max(shadow_dy, 0);
-  const int corner_radius =
-      std::clamp(owner_corner_radius_pixels, 0,
-                 std::min(owner_width, owner_height) / 2);
-  const int width = owner_width + left_margin + right_margin;
-  const int height = owner_height + top_margin + bottom_margin;
-  if (width <= 0 || height <= 0) {
+  const WindowShadowGeometry geometry = ComputeWindowShadowGeometry(
+      owner_width, owner_height, shadow_size, shadow_distance, shadow_angle,
+      owner_corner_radius_pixels);
+  if (!geometry.enabled()) {
     Hide();
     return true;
   }
@@ -1006,22 +931,21 @@ bool RendererShadowWindow::Update(HWND owner_window, const RECT& owner_rect,
   }
 
   uint32_t* pixels = nullptr;
-  HBITMAP bitmap =
-      CreateRendererLayeredWindowBitmap(screen_dc, width, height, &pixels);
+  HBITMAP bitmap = CreateRendererLayeredWindowBitmap(
+      screen_dc, geometry.width, geometry.height, &pixels);
   if (bitmap == nullptr || pixels == nullptr) {
     ::DeleteDC(memory_dc);
     ::ReleaseDC(nullptr, screen_dc);
     return false;
   }
 
-  DrawShadowBitmap(pixels, width, height, owner_width, owner_height,
-                   shadow_size, shadow_dx, shadow_dy, left_margin, top_margin,
-                   corner_radius, shadow_opacity);
+  DrawShadowBitmap(pixels, geometry, shadow_opacity);
 
   HGDIOBJ old_bitmap = ::SelectObject(memory_dc, bitmap);
-  POINT dst = {owner_rect.left - left_margin, owner_rect.top - top_margin};
+  POINT dst = {owner_rect.left - geometry.left_margin,
+               owner_rect.top - geometry.top_margin};
   POINT src = {0, 0};
-  SIZE size = {width, height};
+  SIZE size = {geometry.width, geometry.height};
   BLENDFUNCTION blend = {AC_SRC_OVER, 0, 255, AC_SRC_ALPHA};
   const BOOL updated = ::UpdateLayeredWindow(hwnd_, screen_dc, &dst, &size,
                                              memory_dc, &src, 0, &blend,

--- a/src/renderer/window_effect_util.cc
+++ b/src/renderer/window_effect_util.cc
@@ -1,0 +1,193 @@
+// Copyright 2010-2021, Google Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "renderer/window_effect_util.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <limits>
+
+namespace mozc {
+namespace renderer {
+namespace {
+
+constexpr double kPi = 3.14159265358979323846;
+
+}  // namespace
+
+double SignedDistanceFromRoundedRect(double x, double y, double width,
+                                     double height, double radius) {
+  radius = std::max(0.0, std::min(radius, std::min(width, height) / 2.0));
+  const double half_width = width / 2.0;
+  const double half_height = height / 2.0;
+  const double qx = std::abs(x - half_width) - (half_width - radius);
+  const double qy = std::abs(y - half_height) - (half_height - radius);
+  const double outside_x = std::max(qx, 0.0);
+  const double outside_y = std::max(qy, 0.0);
+  double outside_distance = 0.0;
+  if (outside_x > 0.0 || outside_y > 0.0) {
+    outside_distance =
+        std::sqrt(outside_x * outside_x + outside_y * outside_y);
+  }
+  const double inside_distance = std::min(std::max(qx, qy), 0.0);
+  return outside_distance + inside_distance - radius;
+}
+
+double RoundedRectCoverage(double x, double y, double width, double height,
+                           double radius) {
+  return std::clamp(
+      0.5 - SignedDistanceFromRoundedRect(x, y, width, height, radius), 0.0,
+      1.0);
+}
+
+WindowShadowGeometry ComputeWindowShadowGeometry(
+    int owner_width, int owner_height, int shadow_size, int shadow_distance,
+    uint32_t angle_degrees, int owner_corner_radius) {
+  WindowShadowGeometry geometry;
+  geometry.owner_width = std::max(owner_width, 0);
+  geometry.owner_height = std::max(owner_height, 0);
+  geometry.shadow_size = std::max(shadow_size, 0);
+  geometry.corner_radius =
+      std::clamp(owner_corner_radius, 0,
+                 std::min(geometry.owner_width, geometry.owner_height) / 2);
+
+  if (geometry.owner_width <= 0 || geometry.owner_height <= 0 ||
+      geometry.shadow_size <= 0) {
+    return geometry;
+  }
+
+  const int distance = std::max(shadow_distance, 0);
+  const double radians =
+      static_cast<double>(angle_degrees % 360u) * kPi / 180.0;
+  geometry.shadow_dx =
+      static_cast<int>(std::lround(std::cos(radians) * distance));
+  geometry.shadow_dy =
+      static_cast<int>(std::lround(std::sin(radians) * distance));
+
+  geometry.left_margin =
+      geometry.shadow_size + std::max(-geometry.shadow_dx, 0);
+  geometry.right_margin =
+      geometry.shadow_size + std::max(geometry.shadow_dx, 0);
+  geometry.top_margin =
+      geometry.shadow_size + std::max(-geometry.shadow_dy, 0);
+  geometry.bottom_margin =
+      geometry.shadow_size + std::max(geometry.shadow_dy, 0);
+  geometry.owner_left = geometry.left_margin;
+  geometry.owner_top = geometry.top_margin;
+
+  const int64_t width = static_cast<int64_t>(geometry.owner_width) +
+                        geometry.left_margin + geometry.right_margin;
+  const int64_t height = static_cast<int64_t>(geometry.owner_height) +
+                         geometry.top_margin + geometry.bottom_margin;
+  if (width <= 0 || height <= 0 ||
+      width > std::numeric_limits<int>::max() ||
+      height > std::numeric_limits<int>::max()) {
+    return WindowShadowGeometry();
+  }
+  geometry.width = static_cast<int>(width);
+  geometry.height = static_cast<int>(height);
+  return geometry;
+}
+
+uint8_t ComputeWindowShadowAlpha(const WindowShadowGeometry &geometry, int x,
+                                 int y, uint32_t opacity_percent) {
+  if (!geometry.enabled() || x < 0 || y < 0 || x >= geometry.width ||
+      y >= geometry.height || opacity_percent == 0) {
+    return 0;
+  }
+
+  const double owner_x =
+      static_cast<double>(x - geometry.owner_left) + 0.5;
+  const double owner_y =
+      static_cast<double>(y - geometry.owner_top) + 0.5;
+  const double owner_distance = SignedDistanceFromRoundedRect(
+      owner_x, owner_y, geometry.owner_width, geometry.owner_height,
+      geometry.corner_radius);
+  if (owner_distance <= 0.0) {
+    return 0;
+  }
+
+  const double shadow_x =
+      static_cast<double>(x - geometry.owner_left - geometry.shadow_dx) + 0.5;
+  const double shadow_y =
+      static_cast<double>(y - geometry.owner_top - geometry.shadow_dy) + 0.5;
+  const double shadow_distance = SignedDistanceFromRoundedRect(
+      shadow_x, shadow_y, geometry.owner_width, geometry.owner_height,
+      geometry.corner_radius);
+
+  double normalized = 0.0;
+  if (shadow_distance > 0.0) {
+    normalized = shadow_distance / static_cast<double>(geometry.shadow_size);
+  }
+  if (normalized > 1.0) {
+    return 0;
+  }
+
+  const double t = 1.0 - std::clamp(normalized, 0.0, 1.0);
+  const uint32_t max_alpha =
+      std::clamp(opacity_percent, 0u, kMaxWindowShadowOpacityPercent) * 255u / 100u;
+  return static_cast<uint8_t>(std::clamp(
+      std::lround(static_cast<double>(max_alpha) * t * t * (3.0 - 2.0 * t)),
+      0l, 255l));
+}
+
+bool RenderWindowShadowAlphaMask(const WindowShadowGeometry &geometry,
+                                 uint32_t opacity_percent,
+                                 uint8_t *destination,
+                                 size_t destination_size) {
+  if (destination == nullptr || geometry.width < 0 || geometry.height < 0) {
+    return false;
+  }
+  const int64_t required =
+      static_cast<int64_t>(geometry.width) * geometry.height;
+  if (required < 0 || static_cast<uint64_t>(required) > destination_size) {
+    return false;
+  }
+  if (required == 0) {
+    return true;
+  }
+
+  std::memset(destination, 0, static_cast<size_t>(required));
+  if (!geometry.enabled() || opacity_percent == 0) {
+    return true;
+  }
+
+  for (int y = 0; y < geometry.height; ++y) {
+    for (int x = 0; x < geometry.width; ++x) {
+      destination[static_cast<size_t>(y) * geometry.width + x] =
+          ComputeWindowShadowAlpha(geometry, x, y, opacity_percent);
+    }
+  }
+  return true;
+}
+
+}  // namespace renderer
+}  // namespace mozc

--- a/src/renderer/window_effect_util.h
+++ b/src/renderer/window_effect_util.h
@@ -1,0 +1,120 @@
+// Copyright 2010-2021, Google Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#ifndef MOZC_RENDERER_WINDOW_EFFECT_UTIL_H_
+#define MOZC_RENDERER_WINDOW_EFFECT_UTIL_H_
+
+#include <cstddef>
+#include <cstdint>
+
+namespace mozc {
+namespace renderer {
+
+inline constexpr uint32_t kMaxWindowShadowSize = 96;
+inline constexpr uint32_t kMaxWindowShadowDistance = 96;
+inline constexpr uint32_t kMaxWindowShadowOpacityPercent = 100;
+
+// Pixel-space geometry for a renderer shadow. Coordinates use screen-space
+// orientation: positive X points right and positive Y points down.
+struct WindowShadowGeometry {
+  int owner_width = 0;
+  int owner_height = 0;
+  int shadow_size = 0;
+  int shadow_dx = 0;
+  int shadow_dy = 0;
+  int left_margin = 0;
+  int right_margin = 0;
+  int top_margin = 0;
+  int bottom_margin = 0;
+  int owner_left = 0;
+  int owner_top = 0;
+  int corner_radius = 0;
+  int width = 0;
+  int height = 0;
+
+  bool enabled() const {
+    return owner_width > 0 && owner_height > 0 && shadow_size > 0 &&
+           width > 0 && height > 0;
+  }
+
+  bool operator==(const WindowShadowGeometry &other) const {
+    return owner_width == other.owner_width &&
+           owner_height == other.owner_height &&
+           shadow_size == other.shadow_size && shadow_dx == other.shadow_dx &&
+           shadow_dy == other.shadow_dy &&
+           left_margin == other.left_margin &&
+           right_margin == other.right_margin &&
+           top_margin == other.top_margin &&
+           bottom_margin == other.bottom_margin &&
+           owner_left == other.owner_left && owner_top == other.owner_top &&
+           corner_radius == other.corner_radius && width == other.width &&
+           height == other.height;
+  }
+
+  bool operator!=(const WindowShadowGeometry &other) const {
+    return !(*this == other);
+  }
+};
+
+// Signed distance from a rounded rectangle. Negative means inside the shape;
+// positive means outside it.
+double SignedDistanceFromRoundedRect(double x, double y, double width,
+                                     double height, double radius);
+
+// Converts signed distance at a pixel center to one-pixel-wide antialias
+// coverage in [0, 1].
+double RoundedRectCoverage(double x, double y, double width, double height,
+                           double radius);
+
+// Computes the exact shadow bitmap geometry used by renderer platforms.
+// |shadow_size|, |shadow_distance|, and |owner_corner_radius| are already
+// scaled to physical pixels by the caller. The angle is screen-space degrees:
+// 0=right, 45=down-right, 90=down.
+WindowShadowGeometry ComputeWindowShadowGeometry(
+    int owner_width, int owner_height, int shadow_size, int shadow_distance,
+    uint32_t angle_degrees, int owner_corner_radius);
+
+// Returns the alpha for one pixel in a shadow bitmap. The owner body itself is
+// always transparent in the shadow bitmap so a shadow window can safely sit
+// behind the corresponding renderer body.
+uint8_t ComputeWindowShadowAlpha(const WindowShadowGeometry &geometry, int x,
+                                 int y, uint32_t opacity_percent);
+
+// Renders a tightly packed alpha mask of size geometry.width*geometry.height.
+// The destination must contain at least |destination_size| bytes. Returns false
+// for invalid parameters. Disabled geometry produces an all-zero mask.
+bool RenderWindowShadowAlphaMask(const WindowShadowGeometry &geometry,
+                                 uint32_t opacity_percent,
+                                 uint8_t *destination,
+                                 size_t destination_size);
+
+}  // namespace renderer
+}  // namespace mozc
+
+#endif  // MOZC_RENDERER_WINDOW_EFFECT_UTIL_H_

--- a/src/renderer/window_effect_util_test.cc
+++ b/src/renderer/window_effect_util_test.cc
@@ -1,0 +1,154 @@
+// Copyright 2010-2021, Google Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "renderer/window_effect_util.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <vector>
+
+#include "testing/gunit.h"
+
+namespace mozc {
+namespace renderer {
+namespace {
+
+TEST(WindowEffectUtilTest, ComputesScreenSpaceShadowDirections) {
+  const WindowShadowGeometry right =
+      ComputeWindowShadowGeometry(100, 50, 12, 6, 0, 6);
+  EXPECT_EQ(6, right.shadow_dx);
+  EXPECT_EQ(0, right.shadow_dy);
+  EXPECT_EQ(12, right.left_margin);
+  EXPECT_EQ(18, right.right_margin);
+  EXPECT_EQ(12, right.top_margin);
+  EXPECT_EQ(12, right.bottom_margin);
+
+  const WindowShadowGeometry down =
+      ComputeWindowShadowGeometry(100, 50, 12, 6, 90, 6);
+  EXPECT_EQ(0, down.shadow_dx);
+  EXPECT_EQ(6, down.shadow_dy);
+  EXPECT_EQ(12, down.left_margin);
+  EXPECT_EQ(12, down.right_margin);
+  EXPECT_EQ(12, down.top_margin);
+  EXPECT_EQ(18, down.bottom_margin);
+
+  const WindowShadowGeometry up_left =
+      ComputeWindowShadowGeometry(100, 50, 12, 6, 225, 6);
+  EXPECT_EQ(-4, up_left.shadow_dx);
+  EXPECT_EQ(-4, up_left.shadow_dy);
+  EXPECT_EQ(16, up_left.left_margin);
+  EXPECT_EQ(12, up_left.right_margin);
+  EXPECT_EQ(16, up_left.top_margin);
+  EXPECT_EQ(12, up_left.bottom_margin);
+}
+
+TEST(WindowEffectUtilTest, GeometryEqualityCoversRenderingInputs) {
+  const WindowShadowGeometry first =
+      ComputeWindowShadowGeometry(100, 50, 12, 6, 45, 8);
+  WindowShadowGeometry same = first;
+  EXPECT_EQ(first, same);
+
+  same.shadow_dx += 1;
+  EXPECT_NE(first, same);
+}
+
+TEST(WindowEffectUtilTest, ZeroDistanceKeepsEvenMargins) {
+  const WindowShadowGeometry geometry =
+      ComputeWindowShadowGeometry(80, 40, 10, 0, 271, 100);
+  EXPECT_TRUE(geometry.enabled());
+  EXPECT_EQ(10, geometry.left_margin);
+  EXPECT_EQ(10, geometry.right_margin);
+  EXPECT_EQ(10, geometry.top_margin);
+  EXPECT_EQ(10, geometry.bottom_margin);
+  EXPECT_EQ(20, geometry.corner_radius);
+}
+
+TEST(WindowEffectUtilTest, DisabledShadowHasNoBitmapExtent) {
+  const WindowShadowGeometry geometry =
+      ComputeWindowShadowGeometry(80, 40, 0, 20, 45, 8);
+  EXPECT_FALSE(geometry.enabled());
+  EXPECT_EQ(0, geometry.width);
+  EXPECT_EQ(0, geometry.height);
+}
+
+TEST(WindowEffectUtilTest, ShadowMaskNeverCoversOwnerBody) {
+  const WindowShadowGeometry geometry =
+      ComputeWindowShadowGeometry(30, 20, 8, 4, 45, 5);
+  ASSERT_TRUE(geometry.enabled());
+
+  std::vector<uint8_t> alpha(
+      static_cast<size_t>(geometry.width) * geometry.height);
+  ASSERT_TRUE(RenderWindowShadowAlphaMask(
+      geometry, 60, alpha.data(), alpha.size()));
+
+  for (int y = geometry.owner_top;
+       y < geometry.owner_top + geometry.owner_height; ++y) {
+    for (int x = geometry.owner_left;
+         x < geometry.owner_left + geometry.owner_width; ++x) {
+      const double owner_x =
+          static_cast<double>(x - geometry.owner_left) + 0.5;
+      const double owner_y =
+          static_cast<double>(y - geometry.owner_top) + 0.5;
+      if (SignedDistanceFromRoundedRect(
+              owner_x, owner_y, geometry.owner_width, geometry.owner_height,
+              geometry.corner_radius) <= 0.0) {
+        EXPECT_EQ(0, alpha[static_cast<size_t>(y) * geometry.width + x]);
+      }
+    }
+  }
+  EXPECT_GT(*std::max_element(alpha.begin(), alpha.end()), 0);
+}
+
+TEST(WindowEffectUtilTest, OpacityScalesShadowAlpha) {
+  const WindowShadowGeometry geometry =
+      ComputeWindowShadowGeometry(40, 24, 10, 0, 0, 4);
+  ASSERT_TRUE(geometry.enabled());
+
+  uint8_t max_100 = 0;
+  uint8_t max_50 = 0;
+  for (int y = 0; y < geometry.height; ++y) {
+    for (int x = 0; x < geometry.width; ++x) {
+      max_100 = std::max(
+          max_100, ComputeWindowShadowAlpha(geometry, x, y, 100));
+      max_50 = std::max(
+          max_50, ComputeWindowShadowAlpha(geometry, x, y, 50));
+    }
+  }
+  EXPECT_GE(max_100, 254);
+  EXPECT_NEAR(127, max_50, 1);
+}
+
+TEST(WindowEffectUtilTest, RoundedRectCoverageIsClamped) {
+  EXPECT_DOUBLE_EQ(1.0, RoundedRectCoverage(10.5, 10.5, 20, 20, 4));
+  EXPECT_DOUBLE_EQ(0.0, RoundedRectCoverage(-10.0, -10.0, 20, 20, 4));
+}
+
+}  // namespace
+}  // namespace renderer
+}  // namespace mozc


### PR DESCRIPTION
## 概要

macOS の候補ウィンドウ・サジェストウィンドウ・ルビウィンドウ・情報リストに、
角丸・透明度・カスタムシャドウのウィンドウ効果を追加します。

あわせて、Windows で使用していた影のジオメトリ／アルファ生成処理を
プラットフォーム共通のユーティリティへ切り出し、
macOS / Windows で同じ影計算を利用できる構成に整理しました。

## 主な変更

### macOS

- 候補ウィンドウに角丸・透明度・カスタムシャドウを追加
- サジェスト／予測ウィンドウに独立したウィンドウ効果設定を追加
- ルビウィンドウにカスタムシャドウを追加
- 情報リストに候補ウィンドウ系のウィンドウ効果を適用
- `RendererShadowWindow` を追加
  - 透明な非アクティブ `NSPanel` として影を描画
  - Retina / backing scale に対応
  - ウィンドウ移動時の不要な再生成を回避
  - 本体ウィンドウの論理座標・サイズには影響しない構成
- `RendererBaseWindow` のウィンドウ初期化と影ライフサイクルを整理

### 共通処理

`renderer/window_effect_util.{h,cc}` を追加し、以下を共通化しました。

- 角丸矩形の signed distance
- アンチエイリアス coverage
- 影領域のジオメトリ計算
- 影 alpha の計算
- alpha mask の生成

Windows 側の既存実装もこの共通処理を利用するよう変更しています。

### RendererStyleHandler

候補ウィンドウの種別判定を共通化しました。

- SUGGESTION / PREDICTION → Suggestion 設定
- Conversion / Transliteration / Usage → Candidate 設定

### 設定

既存の Candidate / Suggestion / Ruby のウィンドウ効果設定を、
macOS レンダラーでも反映するようにしました。

影については、それぞれ以下を設定できます。

- サイズ
- 不透明度
- 角度
- 距離

あわせて、影のデフォルト値を以下に調整しました。

| Window     | Size | Opacity | Angle | Distance |
| ---------- | ---: | ------: | ----: | -------: |
| Candidate  | 5    |     10% |   45° |        6 |
| Suggestion | 5    |     10% |   45° |        6 |
| Ruby       | 5    |      8% |   45° |        3 |

Size / Distance は論理ピクセルとして扱い、
各レンダラー側で表示スケールに応じて変換します。

設定ダイアログの初期値および「デフォルトに戻す」の値も同期しています。

## ジオメトリ上の仕様

影の size / distance / angle を変更しても、
候補ウィンドウ本体の論理位置やサイズは変更しません。

そのため、キャレットや入力文字列に対する
既存の候補ウィンドウ配置ロジックには影響しません。

影の角度は画面座標上で以下の向きです。

- 0°: 右
- 45°: 右下
- 90°: 下
