### PR TITLE
feat(mac): add Zenz surrounding context acquisition

### DIFF
--- a/src/mac/BUILD.bazel
+++ b/src/mac/BUILD.bazel
@@ -30,6 +30,8 @@
 load(
     "//:build_defs.bzl",
     "MOZC_TAGS",
+    "mozc_cc_library",
+    "mozc_cc_test",
     "mozc_macos_application",
     "mozc_macos_bundle",
     "mozc_objc_library",
@@ -160,6 +162,23 @@ mozc_objc_library(
     ],
 )
 
+mozc_cc_library(
+    name = "zenz_context_acquisition",
+    srcs = ["zenz_context_acquisition.cc"],
+    hdrs = ["zenz_context_acquisition.h"],
+    deps = ["//base:util"],
+)
+
+mozc_cc_test(
+    name = "zenz_context_acquisition_test",
+    size = "small",
+    srcs = ["zenz_context_acquisition_test.cc"],
+    deps = [
+        ":zenz_context_acquisition",
+        "//testing:gunit_main",
+    ],
+)
+
 mozc_objc_library(
     name = "mozc_imk_input_controller",
     srcs = ["mozc_imk_input_controller.mm"],
@@ -178,6 +197,7 @@ mozc_objc_library(
         ":common",
         ":keycode_map",
         ":renderer_receiver",
+        ":zenz_context_acquisition",
         "//base:const",
         "//base:process",
         "//base:util",

--- a/src/mac/mozc_imk_input_controller.h
+++ b/src/mac/mozc_imk_input_controller.h
@@ -103,6 +103,10 @@
 
   /** True when the current config enables live conversion. */
   bool useLiveConversion_;
+  /** True when a Zenz context-length preflight is useful for this config. */
+  bool useZenzContextAcquisition_;
+  /** -1 uses Carbon; 0/1 are deterministic test overrides. */
+  int secureEventInputStateForTest_;
 
   /** Latest delayed callback requested by Output::Callback. */
   std::unique_ptr<mozc::commands::SessionCommand> delayedSessionCommand_;
@@ -129,6 +133,8 @@
 @property(readwrite, assign) NSRange replacementRange;
 @property(readwrite, retain) id imkClientForTest;
 @property(readwrite, assign) bool useLiveConversionForTest;
+@property(readwrite, assign) bool useZenzContextAcquisitionForTest;
+@property(readwrite, assign) int secureEventInputStateForTest;
 
 /** Sets the RendererReceiver used by all instances of the controller.
  * the RendererReceiver is a singleton object used as a proxy to receive messages from
@@ -272,6 +278,12 @@
  * @return YES if context was filled; NO otherwise.
  */
 - (BOOL)fillSurroundingContext:(mozc::commands::Context *)context client:(id<IMKTextInput>)client;
+
+/** Fills bounded Zenz-specific context requested by TEST_SEND_KEY. */
+- (BOOL)fillZenzSurroundingContext:(mozc::commands::Context *)context
+                            client:(id<IMKTextInput>)client
+                   precedingLength:(uint32_t)precedingLength
+                   followingLength:(uint32_t)followingLength;
 
 @end
 

--- a/src/mac/mozc_imk_input_controller.mm
+++ b/src/mac/mozc_imk_input_controller.mm
@@ -43,12 +43,14 @@
 #include <map>
 #include <memory>
 #include <new>
+#include <optional>
 #include <set>
 #include <string>
 #include <utility>
 
 #import "mac/KeyCodeMap.h"
 #import "mac/renderer_receiver.h"
+#include "mac/zenz_context_acquisition.h"
 
 #include "absl/log/log.h"
 #include "absl/strings/string_view.h"
@@ -93,9 +95,11 @@ RendererReceiver *gRendererReceiver = nil;
 constexpr NSTimeInterval kDoubleTapInterval = 0.5;
 
 constexpr int kMaxSurroundingLength = 20;
-// In some apllications when the client's text length is large, getting the
-// surrounding text takes too much time. So we set this limitation.
-constexpr int kGetSurroundingTextClientLengthLimit = 1000;
+// Legacy generic surrounding-context acquisition keeps the historical client
+// length cap because some applications make attributedSubstringFromRange:
+// expensive on large documents. Zenz-specific acquisition is independently
+// bounded to a small native range and does not inherit this document-size cap.
+constexpr int kGenericSurroundingTextClientLengthLimit = 1000;
 
 constexpr absl::string_view kRomanModeId = "com.apple.inputmethod.Roman";
 constexpr absl::string_view kKatakanaModeId = "com.apple.inputmethod.Japanese.Katakana";
@@ -256,6 +260,35 @@ NSUInteger CodePointOffsetToUtf16Offset(NSString *text, uint32_t code_point_offs
   }
   return utf16_offset;
 }
+bool IsHighSurrogate(unichar value) {
+  return value >= 0xD800 && value <= 0xDBFF;
+}
+
+bool IsLowSurrogate(unichar value) {
+  return value >= 0xDC00 && value <= 0xDFFF;
+}
+
+NSString *TrimIncompleteZenzSurrogateEdges(NSString *text) {
+  if (text == nil) {
+    return nil;
+  }
+
+  NSUInteger begin = 0;
+  NSUInteger end = [text length];
+
+  if (begin < end && IsLowSurrogate([text characterAtIndex:begin])) {
+    ++begin;
+  }
+  if (begin < end && IsHighSurrogate([text characterAtIndex:end - 1])) {
+    --end;
+  }
+
+  if (begin == 0 && end == [text length]) {
+    return text;
+  }
+  return [text substringWithRange:NSMakeRange(begin, end - begin)];
+}
+
 }  // namespace
 
 @implementation MozcImkInputController
@@ -267,6 +300,8 @@ NSUInteger CodePointOffsetToUtf16Offset(NSString *text, uint32_t code_point_offs
 @synthesize replacementRange = replacementRange_;
 @synthesize imkClientForTest = imkClientForTest_;
 @synthesize useLiveConversionForTest = useLiveConversion_;
+@synthesize useZenzContextAcquisitionForTest = useZenzContextAcquisition_;
+@synthesize secureEventInputStateForTest = secureEventInputStateForTest_;
 - (mozc::client::ClientInterface *)mozcClient {
   return mozcClient_.get();
 }
@@ -308,24 +343,35 @@ NSUInteger CodePointOffsetToUtf16Offset(NSString *text, uint32_t code_point_offs
   liveConversionAnchorLeft_ = 0;
   hasLiveConversionAnchorLeft_ = false;
   useLiveConversion_ = false;
-  mozcRenderer_ = mozc::renderer::RendererClient::Create();
-  mozcClient_ = mozc::client::ClientFactory::NewClient();
+  useZenzContextAcquisition_ = false;
+  secureEventInputStateForTest_ = (server == nil) ? 0 : -1;
+  // Unit tests inject mock renderer/client objects immediately after
+  // construction. Avoid creating production process/IPC dependencies in the
+  // server == nil test environment.
+  if (server != nil) {
+    mozcRenderer_ = mozc::renderer::RendererClient::Create();
+    mozcClient_ = mozc::client::ClientFactory::NewClient();
+  }
   lastKeyDownTime_ = 0;
   lastKeyCode_ = 0;
 
   // We don't check the return value of NSBundle because it fails during tests.
   [[NSBundle mainBundle] loadNibNamed:@"Config" owner:self topLevelObjects:nil];
-  if (!originalString_ || !composedString_ || !mozcRenderer_ || !mozcClient_) {
+  const bool hasRuntimeDependencies =
+      server == nil || (mozcRenderer_ != nullptr && mozcClient_ != nullptr);
+  if (!originalString_ || !composedString_ || !hasRuntimeDependencies) {
     self = nil;
   } else {
     DLOG(INFO) << [[NSString
         stringWithFormat:@"initWithServer: %@ %@ %@", server, delegate, inputClient] UTF8String];
-    if (!mozcRenderer_->Activate()) {
+    if (mozcRenderer_ && !mozcRenderer_->Activate()) {
       LOG(ERROR) << "Cannot activate renderer";
       mozcRenderer_.reset();
     }
     [self setupClientBundle:inputClient];
-    [self setupCapability];
+    if (mozcClient_) {
+      [self setupCapability];
+    }
     RendererCommand::ApplicationInfo *applicationInfo = rendererCommand_.mutable_application_info();
     applicationInfo->set_process_id(::getpid());
     // thread_id and receiver_handle are not used currently in Mac but
@@ -450,6 +496,9 @@ NSUInteger CodePointOffsetToUtf16Offset(NSString *text, uint32_t code_point_offs
   [keyCodeMap_ setInputMode:input_mode];
   yenSignCharacter_ = config.yen_sign_character();
   useLiveConversion_ = config.use_live_conversion();
+  // Avoid an extra TEST_SEND_KEY round trip for ordinary Mozc input.
+  useZenzContextAcquisition_ =
+      useLiveConversion_ && config.use_zenz_live_correction();
 
   if (config.use_japanese_layout()) {
     // Apple does not have "Japanese" layout actually -- here sets
@@ -1013,7 +1062,7 @@ NSUInteger CodePointOffsetToUtf16Offset(NSString *text, uint32_t code_point_offs
 - (BOOL)fillSurroundingContext:(mozc::commands::Context *)context client:(id<IMKTextInput>)client {
   NSInteger totalLength = [client length];
   if (totalLength == 0 || totalLength == NSNotFound ||
-      totalLength > kGetSurroundingTextClientLengthLimit) {
+      totalLength > kGenericSurroundingTextClientLengthLimit) {
     return false;
   }
   NSRange selectedRange = [client selectedRange];
@@ -1031,6 +1080,117 @@ NSUInteger CodePointOffsetToUtf16Offset(NSString *text, uint32_t code_point_offs
     DLOG(INFO) << "preceding_text: \"" << context->preceding_text() << "\"";
   }
   return true;
+}
+
+- (BOOL)fillZenzSurroundingContext:(mozc::commands::Context *)context
+                            client:(id<IMKTextInput>)client
+                   precedingLength:(uint32_t)precedingLength
+                   followingLength:(uint32_t)followingLength {
+  if (context == nullptr || client == nil) {
+    return false;
+  }
+  if (precedingLength == 0 && followingLength == 0) {
+    return true;
+  }
+
+  const NSUInteger totalLength = [client length];
+  if (totalLength == NSNotFound) {
+    return false;
+  }
+
+  const NSRange selectedRange = [client selectedRange];
+  if (selectedRange.location == NSNotFound ||
+      selectedRange.length == NSNotFound) {
+    return false;
+  }
+
+  const std::optional<mozc::mac::ZenzContextNativeRanges> ranges =
+      mozc::mac::GetZenzContextNativeRanges(
+          static_cast<size_t>(totalLength),
+          static_cast<size_t>(selectedRange.location),
+          static_cast<size_t>(selectedRange.length), precedingLength,
+          followingLength);
+  if (!ranges.has_value()) {
+    return false;
+  }
+
+  bool succeeded = true;
+
+  if (precedingLength > 0 && ranges->preceding.has_value()) {
+    if (context->has_preceding_text() &&
+        mozc::Util::CharsLen(context->preceding_text()) >= precedingLength) {
+      context->set_zenz_preceding_text(
+          mozc::mac::TakeTrailingZenzContextCharacters(
+              context->preceding_text(), precedingLength));
+    } else {
+      const mozc::mac::ZenzContextNativeRange range = *ranges->preceding;
+      if (range.length == 0) {
+        context->set_zenz_preceding_text("");
+      } else {
+        @try {
+          NSString *nativeText =
+              [[client attributedSubstringFromRange:NSMakeRange(
+                           static_cast<NSUInteger>(range.location),
+                           static_cast<NSUInteger>(range.length))]
+                  string];
+          nativeText = TrimIncompleteZenzSurrogateEdges(nativeText);
+          const char *utf8 =
+              nativeText == nil ? nullptr : [nativeText UTF8String];
+          if (utf8 == nullptr) {
+            succeeded = false;
+          } else {
+            context->set_zenz_preceding_text(
+                mozc::mac::TakeTrailingZenzContextCharacters(
+                    utf8, precedingLength));
+          }
+        } @catch (NSException *exception) {
+          LOG(ERROR)
+              << "Exception while acquiring Zenz preceding context from ["
+              << clientBundle_ << "]: " << [[exception reason] UTF8String];
+          succeeded = false;
+        }
+      }
+    }
+  }
+
+  if (followingLength > 0 && ranges->following.has_value()) {
+    const mozc::mac::ZenzContextNativeRange range = *ranges->following;
+    if (range.length == 0) {
+      context->set_zenz_following_text("");
+    } else {
+      @try {
+        NSString *nativeText =
+            [[client attributedSubstringFromRange:NSMakeRange(
+                         static_cast<NSUInteger>(range.location),
+                         static_cast<NSUInteger>(range.length))]
+                string];
+        nativeText = TrimIncompleteZenzSurrogateEdges(nativeText);
+        const char *utf8 =
+            nativeText == nil ? nullptr : [nativeText UTF8String];
+        if (utf8 == nullptr) {
+          succeeded = false;
+        } else {
+          context->set_zenz_following_text(
+              mozc::mac::TakeLeadingZenzContextCharacters(
+                  utf8, followingLength));
+        }
+      } @catch (NSException *exception) {
+        LOG(ERROR)
+            << "Exception while acquiring Zenz following context from ["
+            << clientBundle_ << "]: " << [[exception reason] UTF8String];
+        succeeded = false;
+      }
+    }
+  }
+
+  return succeeded;
+}
+
+- (BOOL)isSecureEventInputEnabledForContext {
+  if (secureEventInputStateForTest_ >= 0) {
+    return secureEventInputStateForTest_ != 0;
+  }
+  return IsSecureEventInputEnabled();
 }
 
 - (BOOL)handleEvent:(NSEvent *)event client:(id)sender {
@@ -1129,10 +1289,43 @@ NSUInteger CodePointOffsetToUtf16Offset(NSString *text, uint32_t code_point_offs
   }
   keyEvent.set_mode(mode_);
 
-  if ([composedString_ length] == 0 && CanSelectedRange(clientBundle_) &&
-      CanSurroundingText(clientBundle_)) {
+  const bool secureEventInput =
+      [self isSecureEventInputEnabledForContext];
+
+  const bool canAcquireSurroundingContext =
+      [composedString_ length] == 0 &&
+      CanSelectedRange(clientBundle_) &&
+      CanSurroundingText(clientBundle_);
+
+  if (secureEventInput) {
+    // Match the Windows password-scope privacy boundary. Do not inspect
+    // application surrounding text while macOS Secure Event Input is active.
+    context.set_input_field_type(mozc::commands::Context::PASSWORD);
+  } else if (canAcquireSurroundingContext) {
+    // Preserve the historical generic-context behavior as a best-effort path.
     [self fillSurroundingContext:&context client:sender];
   }
+
+  // Zenz-specific acquisition is independently bounded, so a legacy generic
+  // context failure (for example, a document longer than 1000 UTF-16 units)
+  // must not suppress the TEST_SEND_KEY preflight.
+  if (!secureEventInput && useZenzContextAcquisition_ &&
+      canAcquireSurroundingContext) {
+    Output testOutput;
+    if (mozcClient_->TestSendKeyWithContext(keyEvent, context, &testOutput)) {
+      const uint32_t precedingLength =
+          testOutput.zenz_preceding_text_request_length();
+      const uint32_t followingLength =
+          testOutput.zenz_following_text_request_length();
+      if (precedingLength > 0 || followingLength > 0) {
+        [self fillZenzSurroundingContext:&context
+                                  client:sender
+                         precedingLength:precedingLength
+                         followingLength:followingLength];
+      }
+    }
+  }
+
   if (!mozcClient_->SendKeyWithContext(keyEvent, context, &output)) {
     return NO;
   }

--- a/src/mac/mozc_imk_input_controller_test.mm
+++ b/src/mac/mozc_imk_input_controller_test.mm
@@ -170,6 +170,10 @@
 }
 
 - (NSAttributedString *)attributedSubstringFromRange:(NSRange)range {
+  counters_["attributedSubstringFromRange:"]++;
+  counters_[std::string("attributedSubstringFromRange:") +
+            std::to_string(range.location) + ":" +
+            std::to_string(range.length)]++;
   return [attributedString_ attributedSubstringFromRange:range];
 }
 
@@ -197,6 +201,7 @@ namespace {
 
 using ::testing::_;
 using ::testing::DoAll;
+using ::testing::InSequence;
 using ::testing::Mock;
 using ::testing::NotNull;
 using ::testing::Return;
@@ -1006,12 +1011,16 @@ TEST_F(MozcImkInputControllerTest, handleConfig) {
   config.set_preedit_method(config::Config::KANA);
   config.set_yen_sign_character(config::Config::BACKSLASH);
   config.set_use_japanese_layout(true);
+  config.set_use_live_conversion(true);
+  config.set_use_zenz_live_correction(true);
   EXPECT_CALL(*mock_mozc_client_, GetConfig(NotNull()))
       .WillOnce(DoAll(SetArgPointee<0>(config), Return(true)));
 
   [controller_ handleConfig];
   EXPECT_EQ(controller_.keyCodeMap.inputMode, KANA);
   EXPECT_EQ(controller_.yenSignCharacter, config::Config::BACKSLASH);
+  EXPECT_TRUE(controller_.useLiveConversionForTest);
+  EXPECT_TRUE(controller_.useZenzContextAcquisitionForTest);
   EXPECT_EQ([mock_client_ getCounter:"overrideKeyboardWithKeyboardNamed:"], 1);
   EXPECT_TRUE([@"com.apple.keylayout.US" isEqualToString:mock_client_.overriddenLayout])
       << [mock_client_.overriddenLayout UTF8String];
@@ -1193,6 +1202,312 @@ TEST_F(MozcImkInputControllerTest, DoubleTapEisuCommitRawText) {
               SendCommandWithContext(Type(commands::SessionCommand::COMMIT_RAW_TEXT), _, NotNull()))
       .WillOnce(Return(true));
   EXPECT_EQ(SendKeyEvent(kVK_JIS_Eisu, controller_, mock_client_), YES);
+}
+
+TEST_F(MozcImkInputControllerTest,
+       ZenzContextPreflightAttachesRequestedDirectionalContext) {
+  controller_.mode = commands::HIRAGANA;
+  controller_.useZenzContextAcquisitionForTest = true;
+  [mock_client_ setAttributedString:[[NSAttributedString alloc]
+      initWithString:@"0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"]];
+  mock_client_.expectedRange = NSMakeRange(30, 0);
+
+  commands::Output testOutput;
+  testOutput.set_zenz_preceding_text_request_length(24);
+  testOutput.set_zenz_following_text_request_length(3);
+  commands::Output sendOutput;
+  sendOutput.set_consumed(true);
+  commands::Context testContext;
+  commands::Context sendContext;
+
+  {
+    InSequence sequence;
+    EXPECT_CALL(*mock_mozc_client_,
+                TestSendKeyWithContext(
+                    HasSpecialKey(commands::KeyEvent::TAB), _, NotNull()))
+        .WillOnce(DoAll(SaveArg<1>(&testContext),
+                        SetArgPointee<2>(testOutput), Return(true)));
+    EXPECT_CALL(*mock_mozc_client_,
+                SendKeyWithContext(
+                    HasSpecialKey(commands::KeyEvent::TAB), _, NotNull()))
+        .WillOnce(DoAll(SaveArg<1>(&sendContext),
+                        SetArgPointee<2>(sendOutput), Return(true)));
+  }
+
+  EXPECT_TRUE(SendKeyEvent(kVK_Tab, controller_, mock_client_));
+  EXPECT_EQ(testContext.preceding_text(), "ABCDEFGHIJKLMNOPQRST");
+  EXPECT_FALSE(testContext.has_zenz_preceding_text());
+  EXPECT_FALSE(testContext.has_zenz_following_text());
+
+  EXPECT_EQ(sendContext.preceding_text(), "ABCDEFGHIJKLMNOPQRST");
+  EXPECT_EQ(sendContext.zenz_preceding_text(),
+            "6789ABCDEFGHIJKLMNOPQRST");
+  EXPECT_EQ(sendContext.zenz_following_text(), "UVW");
+  EXPECT_EQ([mock_client_ getCounter:"attributedSubstringFromRange:"], 3);
+  EXPECT_EQ([mock_client_ getCounter:"attributedSubstringFromRange:10:20"], 1);
+  EXPECT_EQ([mock_client_ getCounter:"attributedSubstringFromRange:0:30"], 1);
+  EXPECT_EQ([mock_client_ getCounter:"attributedSubstringFromRange:30:7"], 1);
+}
+
+TEST_F(MozcImkInputControllerTest,
+       ZenzContextPreflightDoesNotReadZeroRequestDirection) {
+  controller_.mode = commands::HIRAGANA;
+  controller_.useZenzContextAcquisitionForTest = true;
+  [mock_client_ setAttributedString:[[NSAttributedString alloc]
+      initWithString:@"0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"]];
+  mock_client_.expectedRange = NSMakeRange(20, 0);
+
+  commands::Output testOutput;
+  testOutput.set_zenz_following_text_request_length(3);
+  commands::Output sendOutput;
+  sendOutput.set_consumed(true);
+  commands::Context sendContext;
+
+  EXPECT_CALL(*mock_mozc_client_,
+              TestSendKeyWithContext(
+                  HasSpecialKey(commands::KeyEvent::TAB), _, NotNull()))
+      .WillOnce(DoAll(SetArgPointee<2>(testOutput), Return(true)));
+  EXPECT_CALL(*mock_mozc_client_,
+              SendKeyWithContext(
+                  HasSpecialKey(commands::KeyEvent::TAB), _, NotNull()))
+      .WillOnce(DoAll(SaveArg<1>(&sendContext),
+                      SetArgPointee<2>(sendOutput), Return(true)));
+
+  EXPECT_TRUE(SendKeyEvent(kVK_Tab, controller_, mock_client_));
+  EXPECT_FALSE(sendContext.has_zenz_preceding_text());
+  EXPECT_EQ(sendContext.zenz_following_text(), "KLM");
+  EXPECT_EQ([mock_client_ getCounter:"attributedSubstringFromRange:"], 2);
+  EXPECT_EQ([mock_client_ getCounter:"attributedSubstringFromRange:0:20"], 1);
+  EXPECT_EQ([mock_client_ getCounter:"attributedSubstringFromRange:20:7"], 1);
+}
+
+TEST_F(MozcImkInputControllerTest,
+       ZenzContextPreflightFailureFallsBackToGenericSend) {
+  controller_.mode = commands::HIRAGANA;
+  controller_.useZenzContextAcquisitionForTest = true;
+  [mock_client_ setAttributedString:[[NSAttributedString alloc]
+      initWithString:@"abcdefghij"]];
+  mock_client_.expectedRange = NSMakeRange(5, 0);
+
+  commands::Output sendOutput;
+  sendOutput.set_consumed(true);
+  commands::Context sendContext;
+
+  EXPECT_CALL(*mock_mozc_client_,
+              TestSendKeyWithContext(
+                  HasSpecialKey(commands::KeyEvent::TAB), _, NotNull()))
+      .WillOnce(Return(false));
+  EXPECT_CALL(*mock_mozc_client_,
+              SendKeyWithContext(
+                  HasSpecialKey(commands::KeyEvent::TAB), _, NotNull()))
+      .WillOnce(DoAll(SaveArg<1>(&sendContext),
+                      SetArgPointee<2>(sendOutput), Return(true)));
+
+  EXPECT_TRUE(SendKeyEvent(kVK_Tab, controller_, mock_client_));
+  EXPECT_EQ(sendContext.preceding_text(), "abcde");
+  EXPECT_FALSE(sendContext.has_zenz_preceding_text());
+  EXPECT_FALSE(sendContext.has_zenz_following_text());
+  EXPECT_EQ([mock_client_ getCounter:"attributedSubstringFromRange:"], 1);
+}
+
+TEST_F(MozcImkInputControllerTest,
+       LongDocumentStillAcquiresBoundedZenzContext) {
+  controller_.mode = commands::HIRAGANA;
+  controller_.useZenzContextAcquisitionForTest = true;
+  controller_.secureEventInputStateForTest = 0;
+
+  NSMutableString *document =
+      [NSMutableString stringWithCapacity:1200];
+  for (int i = 0; i < 1100; ++i) {
+    [document appendString:@"L"];
+  }
+  for (int i = 0; i < 100; ++i) {
+    [document appendString:@"R"];
+  }
+
+  [mock_client_ setAttributedString:[[NSAttributedString alloc]
+      initWithString:document]];
+  mock_client_.expectedRange = NSMakeRange(1100, 0);
+
+  commands::Output testOutput;
+  testOutput.set_zenz_preceding_text_request_length(4);
+  testOutput.set_zenz_following_text_request_length(5);
+
+  commands::Output sendOutput;
+  sendOutput.set_consumed(true);
+  commands::Context testContext;
+  commands::Context sendContext;
+
+  EXPECT_CALL(*mock_mozc_client_,
+              TestSendKeyWithContext(
+                  HasSpecialKey(commands::KeyEvent::TAB), _, NotNull()))
+      .WillOnce(DoAll(SaveArg<1>(&testContext),
+                      SetArgPointee<2>(testOutput), Return(true)));
+  EXPECT_CALL(*mock_mozc_client_,
+              SendKeyWithContext(
+                  HasSpecialKey(commands::KeyEvent::TAB), _, NotNull()))
+      .WillOnce(DoAll(SaveArg<1>(&sendContext),
+                      SetArgPointee<2>(sendOutput), Return(true)));
+
+  EXPECT_TRUE(SendKeyEvent(kVK_Tab, controller_, mock_client_));
+
+  EXPECT_FALSE(testContext.has_preceding_text());
+  EXPECT_FALSE(sendContext.has_preceding_text());
+
+  EXPECT_EQ(sendContext.zenz_preceding_text(), "LLLL");
+  EXPECT_EQ(sendContext.zenz_following_text(), "RRRRR");
+
+  EXPECT_EQ([mock_client_ getCounter:"attributedSubstringFromRange:"], 2);
+  EXPECT_EQ([mock_client_ getCounter:"attributedSubstringFromRange:1091:9"], 1);
+  EXPECT_EQ([mock_client_ getCounter:"attributedSubstringFromRange:1100:11"], 1);
+}
+
+TEST_F(MozcImkInputControllerTest,
+       SecureEventInputSuppressesAllSurroundingContext) {
+  controller_.mode = commands::HIRAGANA;
+  controller_.useZenzContextAcquisitionForTest = true;
+  controller_.secureEventInputStateForTest = 1;
+
+  [mock_client_ setAttributedString:[[NSAttributedString alloc]
+      initWithString:@"secret-neighboring-application-text"]];
+  mock_client_.expectedRange = NSMakeRange(10, 0);
+
+  commands::Output sendOutput;
+  sendOutput.set_consumed(true);
+  commands::Context sendContext;
+
+  EXPECT_CALL(*mock_mozc_client_, TestSendKeyWithContext(_, _, _)).Times(0);
+  EXPECT_CALL(*mock_mozc_client_,
+              SendKeyWithContext(
+                  HasSpecialKey(commands::KeyEvent::TAB), _, NotNull()))
+      .WillOnce(DoAll(SaveArg<1>(&sendContext),
+                      SetArgPointee<2>(sendOutput), Return(true)));
+
+  EXPECT_TRUE(SendKeyEvent(kVK_Tab, controller_, mock_client_));
+
+  ASSERT_TRUE(sendContext.has_input_field_type());
+  EXPECT_EQ(sendContext.input_field_type(), commands::Context::PASSWORD);
+  EXPECT_FALSE(sendContext.has_preceding_text());
+  EXPECT_FALSE(sendContext.has_following_text());
+  EXPECT_FALSE(sendContext.has_zenz_preceding_text());
+  EXPECT_FALSE(sendContext.has_zenz_following_text());
+
+  EXPECT_EQ([mock_client_ getCounter:"selectedRange"], 0);
+  EXPECT_EQ([mock_client_ getCounter:"attributedSubstringFromRange:"], 0);
+}
+
+TEST_F(MozcImkInputControllerTest,
+       NonSecureOverridePreservesZenzContextPreflight) {
+  controller_.mode = commands::HIRAGANA;
+  controller_.useZenzContextAcquisitionForTest = true;
+  controller_.secureEventInputStateForTest = 0;
+
+  [mock_client_ setAttributedString:[[NSAttributedString alloc]
+      initWithString:@"0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"]];
+  mock_client_.expectedRange = NSMakeRange(20, 0);
+
+  commands::Output testOutput;
+  testOutput.set_zenz_following_text_request_length(3);
+  commands::Output sendOutput;
+  sendOutput.set_consumed(true);
+  commands::Context sendContext;
+
+  EXPECT_CALL(*mock_mozc_client_,
+              TestSendKeyWithContext(
+                  HasSpecialKey(commands::KeyEvent::TAB), _, NotNull()))
+      .WillOnce(DoAll(SetArgPointee<2>(testOutput), Return(true)));
+  EXPECT_CALL(*mock_mozc_client_,
+              SendKeyWithContext(
+                  HasSpecialKey(commands::KeyEvent::TAB), _, NotNull()))
+      .WillOnce(DoAll(SaveArg<1>(&sendContext),
+                      SetArgPointee<2>(sendOutput), Return(true)));
+
+  EXPECT_TRUE(SendKeyEvent(kVK_Tab, controller_, mock_client_));
+
+  EXPECT_FALSE(sendContext.has_input_field_type());
+  EXPECT_EQ(sendContext.preceding_text(), "0123456789ABCDEFGHIJ");
+  EXPECT_EQ(sendContext.zenz_following_text(), "KLM");
+}
+
+TEST_F(MozcImkInputControllerTest,
+       ZenzContextPreflightIsSkippedWhenFeatureGateIsDisabled) {
+  controller_.mode = commands::HIRAGANA;
+  controller_.useZenzContextAcquisitionForTest = false;
+  [mock_client_ setAttributedString:[[NSAttributedString alloc]
+      initWithString:@"abcdefghij"]];
+  mock_client_.expectedRange = NSMakeRange(5, 0);
+
+  commands::Output sendOutput;
+  sendOutput.set_consumed(true);
+  commands::Context sendContext;
+
+  EXPECT_CALL(*mock_mozc_client_, TestSendKeyWithContext(_, _, _)).Times(0);
+  EXPECT_CALL(*mock_mozc_client_,
+              SendKeyWithContext(
+                  HasSpecialKey(commands::KeyEvent::TAB), _, NotNull()))
+      .WillOnce(DoAll(SaveArg<1>(&sendContext),
+                      SetArgPointee<2>(sendOutput), Return(true)));
+
+  EXPECT_TRUE(SendKeyEvent(kVK_Tab, controller_, mock_client_));
+  EXPECT_EQ(sendContext.preceding_text(), "abcde");
+  EXPECT_FALSE(sendContext.has_zenz_preceding_text());
+  EXPECT_FALSE(sendContext.has_zenz_following_text());
+  EXPECT_EQ([mock_client_ getCounter:"attributedSubstringFromRange:"], 1);
+}
+
+TEST_F(MozcImkInputControllerTest,
+       ZenzContextPrecedingReadDropsLeadingLowSurrogate) {
+  const unichar characters[] = {'A', 0xD83D, 0xDE00, 'B', 'C'};
+  NSString *nativeText = [NSString stringWithCharacters:characters length:5];
+  [mock_client_ setAttributedString:[[NSAttributedString alloc]
+      initWithString:nativeText]];
+  mock_client_.expectedRange = NSMakeRange(5, 0);
+
+  commands::Context context;
+  EXPECT_TRUE([controller_ fillZenzSurroundingContext:&context
+                                               client:(id)mock_client_
+                                      precedingLength:1
+                                      followingLength:0]);
+
+  ASSERT_TRUE(context.has_zenz_preceding_text());
+  EXPECT_EQ(context.zenz_preceding_text(), "C");
+  EXPECT_EQ([mock_client_ getCounter:"attributedSubstringFromRange:2:3"], 1);
+}
+
+TEST_F(MozcImkInputControllerTest,
+       ZenzContextFollowingReadDropsTrailingHighSurrogate) {
+  const unichar characters[] = {'A', 'B', 0xD83D, 0xDE00, 'C'};
+  NSString *nativeText = [NSString stringWithCharacters:characters length:5];
+  [mock_client_ setAttributedString:[[NSAttributedString alloc]
+      initWithString:nativeText]];
+  mock_client_.expectedRange = NSMakeRange(0, 0);
+
+  commands::Context context;
+  EXPECT_TRUE([controller_ fillZenzSurroundingContext:&context
+                                               client:(id)mock_client_
+                                      precedingLength:0
+                                      followingLength:1]);
+
+  ASSERT_TRUE(context.has_zenz_following_text());
+  EXPECT_EQ(context.zenz_following_text(), "A");
+  EXPECT_EQ([mock_client_ getCounter:"attributedSubstringFromRange:0:3"], 1);
+}
+
+TEST_F(MozcImkInputControllerTest,
+       ZenzContextBoundarySetsExplicitEmptyWithoutNativeRead) {
+  [mock_client_ setAttributedString:[[NSAttributedString alloc]
+      initWithString:@"abcde"]];
+  mock_client_.expectedRange = NSMakeRange(0, 0);
+
+  commands::Context context;
+  EXPECT_TRUE([controller_ fillZenzSurroundingContext:&context
+                                               client:(id)mock_client_
+                                      precedingLength:4
+                                      followingLength:0]);
+  EXPECT_TRUE(context.has_zenz_preceding_text());
+  EXPECT_TRUE(context.zenz_preceding_text().empty());
+  EXPECT_FALSE(context.has_zenz_following_text());
+  EXPECT_EQ([mock_client_ getCounter:"attributedSubstringFromRange:"], 0);
 }
 
 TEST_F(MozcImkInputControllerTest, fillSurroundingContext) {

--- a/src/mac/zenz_context_acquisition.cc
+++ b/src/mac/zenz_context_acquisition.cc
@@ -1,0 +1,94 @@
+// Copyright 2026
+// Licensed under the same terms as Mozc.
+
+#include "mac/zenz_context_acquisition.h"
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <string_view>
+
+#include "base/util.h"
+
+namespace mozc::mac {
+namespace {
+
+constexpr uint32_t kMaxZenzContextRequestLength = 128;
+constexpr size_t kMaxUtf16CodeUnitsPerUnicodeCharacter = 2;
+constexpr size_t kNativeAcquisitionPadding = 1;
+
+size_t GetNativeUtf16Budget(uint32_t requested_characters) {
+  const uint32_t clamped =
+      std::min(requested_characters, kMaxZenzContextRequestLength);
+  return static_cast<size_t>(clamped) *
+             kMaxUtf16CodeUnitsPerUnicodeCharacter +
+         kNativeAcquisitionPadding;
+}
+
+}  // namespace
+
+std::optional<ZenzContextNativeRanges> GetZenzContextNativeRanges(
+    size_t document_length, size_t selection_location, size_t selection_length,
+    uint32_t preceding_length, uint32_t following_length) {
+  if (selection_location > document_length ||
+      selection_length > document_length - selection_location) {
+    return std::nullopt;
+  }
+
+  ZenzContextNativeRanges ranges;
+
+  if (preceding_length > 0) {
+    const size_t native_budget = GetNativeUtf16Budget(preceding_length);
+    const size_t native_length = std::min(selection_location, native_budget);
+    ranges.preceding = ZenzContextNativeRange{
+        .location = selection_location - native_length,
+        .length = native_length,
+    };
+  }
+
+  if (following_length > 0) {
+    const size_t following_start = selection_location + selection_length;
+    const size_t native_budget = GetNativeUtf16Budget(following_length);
+    const size_t native_length =
+        std::min(document_length - following_start, native_budget);
+    ranges.following = ZenzContextNativeRange{
+        .location = following_start,
+        .length = native_length,
+    };
+  }
+
+  return ranges;
+}
+
+std::string TakeLeadingZenzContextCharacters(
+    const std::string_view text, const size_t max_characters) {
+  if (max_characters == 0 || text.empty()) {
+    return std::string();
+  }
+
+  const size_t length = Util::CharsLen(text);
+  if (length <= max_characters) {
+    return std::string(text);
+  }
+
+  return std::string(Util::Utf8SubString(text, 0, max_characters));
+}
+
+std::string TakeTrailingZenzContextCharacters(
+    const std::string_view text, const size_t max_characters) {
+  if (max_characters == 0 || text.empty()) {
+    return std::string();
+  }
+
+  const size_t length = Util::CharsLen(text);
+  if (length <= max_characters) {
+    return std::string(text);
+  }
+
+  return std::string(
+      Util::Utf8SubString(text, length - max_characters, max_characters));
+}
+
+}  // namespace mozc::mac

--- a/src/mac/zenz_context_acquisition.h
+++ b/src/mac/zenz_context_acquisition.h
@@ -1,0 +1,47 @@
+// Copyright 2026
+// Licensed under the same terms as Mozc.
+
+#ifndef MOZC_MAC_ZENZ_CONTEXT_ACQUISITION_H_
+#define MOZC_MAC_ZENZ_CONTEXT_ACQUISITION_H_
+
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <string_view>
+
+namespace mozc::mac {
+
+// A range expressed in the native UTF-16 code-unit coordinate system used by
+// NSString and IMKTextInput.
+struct ZenzContextNativeRange {
+  size_t location = 0;
+  size_t length = 0;
+};
+
+struct ZenzContextNativeRanges {
+  // Presence means the corresponding direction was requested. A present
+  // zero-length range is valid at a document boundary.
+  std::optional<ZenzContextNativeRange> preceding;
+  std::optional<ZenzContextNativeRange> following;
+};
+
+// Converts semantic Unicode-character budgets from the server into bounded
+// UTF-16 native ranges around the current selection.
+//
+// The selected text itself is intentionally excluded. The preceding range ends
+// at selection_location, and the following range starts after selection_length.
+// Invalid selection coordinates return std::nullopt.
+std::optional<ZenzContextNativeRanges> GetZenzContextNativeRanges(
+    size_t document_length, size_t selection_location, size_t selection_length,
+    uint32_t preceding_length, uint32_t following_length);
+
+// Trims UTF-8 text by Unicode character count without splitting a character.
+std::string TakeLeadingZenzContextCharacters(std::string_view text,
+                                             size_t max_characters);
+std::string TakeTrailingZenzContextCharacters(std::string_view text,
+                                              size_t max_characters);
+
+}  // namespace mozc::mac
+
+#endif  // MOZC_MAC_ZENZ_CONTEXT_ACQUISITION_H_

--- a/src/mac/zenz_context_acquisition_test.cc
+++ b/src/mac/zenz_context_acquisition_test.cc
@@ -1,0 +1,129 @@
+// Copyright 2026
+// Licensed under the same terms as Mozc.
+
+#include "mac/zenz_context_acquisition.h"
+
+#include <optional>
+
+#include "testing/gunit.h"
+
+namespace mozc::mac {
+namespace {
+
+TEST(ZenzContextAcquisitionTest, ZeroRequestsDoNotProduceNativeRanges) {
+  const std::optional<ZenzContextNativeRanges> ranges =
+      GetZenzContextNativeRanges(100, 50, 0, 0, 0);
+
+  ASSERT_TRUE(ranges.has_value());
+  EXPECT_FALSE(ranges->preceding.has_value());
+  EXPECT_FALSE(ranges->following.has_value());
+}
+
+TEST(ZenzContextAcquisitionTest, UsesIndependentDirectionalUtf16Budgets) {
+  const std::optional<ZenzContextNativeRanges> ranges =
+      GetZenzContextNativeRanges(100, 50, 0, 24, 10);
+
+  ASSERT_TRUE(ranges.has_value());
+  ASSERT_TRUE(ranges->preceding.has_value());
+  ASSERT_TRUE(ranges->following.has_value());
+  EXPECT_EQ(ranges->preceding->location, 1);
+  EXPECT_EQ(ranges->preceding->length, 49);
+  EXPECT_EQ(ranges->following->location, 50);
+  EXPECT_EQ(ranges->following->length, 21);
+}
+
+TEST(ZenzContextAcquisitionTest, ExcludesSelectedText) {
+  const std::optional<ZenzContextNativeRanges> ranges =
+      GetZenzContextNativeRanges(30, 10, 4, 3, 4);
+
+  ASSERT_TRUE(ranges.has_value());
+  ASSERT_TRUE(ranges->preceding.has_value());
+  ASSERT_TRUE(ranges->following.has_value());
+  EXPECT_EQ(ranges->preceding->location, 3);
+  EXPECT_EQ(ranges->preceding->length, 7);
+  EXPECT_EQ(ranges->following->location, 14);
+  EXPECT_EQ(ranges->following->length, 9);
+}
+
+TEST(ZenzContextAcquisitionTest, ClampsNativeRangesAtDocumentBoundaries) {
+  const std::optional<ZenzContextNativeRanges> ranges =
+      GetZenzContextNativeRanges(10, 3, 2, 24, 24);
+
+  ASSERT_TRUE(ranges.has_value());
+  ASSERT_TRUE(ranges->preceding.has_value());
+  ASSERT_TRUE(ranges->following.has_value());
+  EXPECT_EQ(ranges->preceding->location, 0);
+  EXPECT_EQ(ranges->preceding->length, 3);
+  EXPECT_EQ(ranges->following->location, 5);
+  EXPECT_EQ(ranges->following->length, 5);
+}
+
+TEST(ZenzContextAcquisitionTest, RequestedBoundaryProducesEmptyNativeRange) {
+  const std::optional<ZenzContextNativeRanges> ranges =
+      GetZenzContextNativeRanges(5, 0, 5, 1, 1);
+
+  ASSERT_TRUE(ranges.has_value());
+  ASSERT_TRUE(ranges->preceding.has_value());
+  ASSERT_TRUE(ranges->following.has_value());
+  EXPECT_EQ(ranges->preceding->location, 0);
+  EXPECT_EQ(ranges->preceding->length, 0);
+  EXPECT_EQ(ranges->following->location, 5);
+  EXPECT_EQ(ranges->following->length, 0);
+}
+
+TEST(ZenzContextAcquisitionTest, RejectsInvalidSelectionLocation) {
+  EXPECT_FALSE(GetZenzContextNativeRanges(10, 11, 0, 1, 1).has_value());
+}
+
+TEST(ZenzContextAcquisitionTest, RejectsSelectionPastDocumentEnd) {
+  EXPECT_FALSE(GetZenzContextNativeRanges(10, 8, 3, 1, 1).has_value());
+}
+
+TEST(ZenzContextAcquisitionTest, DefensivelyClampsServerRequestLengths) {
+  const std::optional<ZenzContextNativeRanges> ranges =
+      GetZenzContextNativeRanges(1000, 500, 0, 4096, 4096);
+
+  ASSERT_TRUE(ranges.has_value());
+  ASSERT_TRUE(ranges->preceding.has_value());
+  ASSERT_TRUE(ranges->following.has_value());
+  EXPECT_EQ(ranges->preceding->location, 243);
+  EXPECT_EQ(ranges->preceding->length, 257);
+  EXPECT_EQ(ranges->following->location, 500);
+  EXPECT_EQ(ranges->following->length, 257);
+}
+
+TEST(ZenzContextAcquisitionTest, AddsOneUtf16UnitOfEdgePadding) {
+  const std::optional<ZenzContextNativeRanges> ranges =
+      GetZenzContextNativeRanges(100, 50, 0, 1, 1);
+
+  ASSERT_TRUE(ranges.has_value());
+  ASSERT_TRUE(ranges->preceding.has_value());
+  ASSERT_TRUE(ranges->following.has_value());
+  EXPECT_EQ(ranges->preceding->location, 47);
+  EXPECT_EQ(ranges->preceding->length, 3);
+  EXPECT_EQ(ranges->following->location, 50);
+  EXPECT_EQ(ranges->following->length, 3);
+}
+
+TEST(ZenzContextAcquisitionTest, TakesLeadingUnicodeCharacters) {
+  constexpr char kText[] =
+      "\xE7\x94\xB2\xF0\xA0\xAE\x9F\xE4\xB9\x99\xE4\xB8\x99";
+  constexpr char kFirstTwo[] = "\xE7\x94\xB2\xF0\xA0\xAE\x9F";
+
+  EXPECT_EQ(TakeLeadingZenzContextCharacters(kText, 2), kFirstTwo);
+  EXPECT_EQ(TakeLeadingZenzContextCharacters(kText, 99), kText);
+  EXPECT_EQ(TakeLeadingZenzContextCharacters(kText, 0), "");
+}
+
+TEST(ZenzContextAcquisitionTest, TakesTrailingUnicodeCharacters) {
+  constexpr char kText[] =
+      "\xE7\x94\xB2\xF0\xA0\xAE\x9F\xE4\xB9\x99\xE4\xB8\x99";
+  constexpr char kLastTwo[] = "\xE4\xB9\x99\xE4\xB8\x99";
+
+  EXPECT_EQ(TakeTrailingZenzContextCharacters(kText, 2), kLastTwo);
+  EXPECT_EQ(TakeTrailingZenzContextCharacters(kText, 99), kText);
+  EXPECT_EQ(TakeTrailingZenzContextCharacters(kText, 0), "");
+}
+
+}  // namespace
+}  // namespace mozc::mac


### PR DESCRIPTION
## 概要

macOS の Zenz ライブ補正で、Mozc Server が必要とする前後文脈の長さに応じて、カーソル周辺のテキストを取得できるようにします。

従来の macOS の surrounding context は主に直前の短い文脈を対象としており、Zenz が必要とする長い preceding context や following context を取得できませんでした。

今回、既存の generic surrounding context とは独立した Zenz 専用の取得経路を追加し、

```text
Mozc Server
↓
TEST_SEND_KEY
↓
必要な preceding / following length
↓
macOS IMK client
↓
必要範囲の surrounding text を取得
↓
zenz_preceding_text / zenz_following_text
↓
SEND_KEY
```

という server-driven の extended surrounding context acquisition を macOS に接続しました。

## 主な変更

### Zenz 専用 surrounding context acquisition

* `TEST_SEND_KEY` で Server が要求する

  * `zenz_preceding_text_request_length`
  * `zenz_following_text_request_length`
    を取得
* 要求された方向・長さだけ macOS の `IMKTextInput` から取得
* 取得結果を

  * `zenz_preceding_text`
  * `zenz_following_text`
    に設定して `SEND_KEY`
* preceding / following を独立して取得
* 要求長が 0 の方向は追加の native text read を行わない

### generic context との分離

従来の generic surrounding context の挙動は維持します。

generic context には、大きな文書で `attributedSubstringFromRange:` が高コストになるアプリへの対策として既存の文書長制限があります。

Zenz 用 context はこの制限とは分離し、カーソル付近の必要な小範囲だけを取得するため、長い文書でも bounded read で前後文脈を取得できます。

### UTF-16 / Unicode 境界

macOS の `NSString` / `IMKTextInput` は UTF-16 code-unit 座標を使用する一方、Server の要求長は Unicode character 数として扱います。

そのため、

* Unicode character 数から bounded UTF-16 range を計算
* surrogate pair を取得範囲の端で切断した場合に不完全な surrogate を除去
* UTF-8 変換後に要求された文字数へ最終的に trim

する処理を追加しました。

異常に大きな Server request に対しても native read の上限を設けています。

### privacy

macOS の Secure Event Input が有効な場合は、

* context を `PASSWORD` として扱う
* `selectedRange` を取得しない
* application surrounding text を取得しない
* Zenz の `TEST_SEND_KEY` preflight も実行しない

ようにしました。

パスワード入力中にアプリケーションの前後テキストを読み取らない privacy boundary を維持します。

### feature gate

Zenz 専用 preflight は、

```text
live conversion enabled
AND
Zenz live correction enabled
```

の場合だけ実行します。

通常の Mozc 入力では追加の `TEST_SEND_KEY` round trip は発生しません。

## 新規ファイル

* `src/mac/zenz_context_acquisition.cc`
* `src/mac/zenz_context_acquisition.h`
* `src/mac/zenz_context_acquisition_test.cc`

macOS native の UTF-16 range 計算と、取得後の Unicode character trimming を controller から分離しています。

## テスト

以下の targeted tests を実行しました。

```text
//mac:zenz_context_acquisition_test
//mac:mozc_imk_input_controller_test
```

結果:

```text
Executed 2 out of 2 tests: 2 tests pass.
```

主に以下を検証しています。

* preceding / following の独立した request
* requested direction のみ取得
* `TEST_SEND_KEY` failure 時の従来経路への fallback
* 1000 UTF-16 units を超える長文書での bounded Zenz context acquisition
* Secure Event Input 時に surrounding text を一切取得しないこと
* feature disabled 時に Zenz preflight を実行しないこと
* selection 内の文字列を surrounding context に含めないこと
* document boundary
* invalid selection range
* 過大な Server request の clamp
* UTF-16 surrogate pair 境界
* Unicode character 数による leading / trailing trim

`git diff --check` も通過しています。

## 実機検証

Zenz runtime を含む macOS PKG を clean build してインストールし、実機でも確認しました。

```text
Mozc startup            PASS
mozc_zenz_scorer        RUNNING
llama-server            RUNNING
new crash               NONE
preceding context       PASS
following context       PASS
combined context        PASS
```

実際の日本語入力でも、カーソル前後の文脈によって変換判断が変わることを確認しています。

## Zenz 対応 macOS PKG

Zenz runtime 入りの macOS package は通常の package build と異なり、`llama-server` と GGUF model を staging したうえで次の条件が必要です。

```bash
bazelisk build \
  --config=oss_macos \
  --config=release_build \
  --define=macos_zenz_runtime=1 \
  //mac:package \
  --verbose_failures
```

今回の検証用 clean package:

```text
SHA256:
3e89d3ce5007fa04d642f27fee126a352011e52bf11fb0ec7ca68c143173111a
```

payload 内で以下を確認しています。

```text
ZenzRuntime/mozc_zenz_scorer
ZenzRuntime/llama-server
ZenzRuntime/models/zenz-v3.2-small-Q5_K_M.gguf
```

## 補足

従来の generic surrounding context の仕様は変更していません。

今回の変更は Zenz 専用 extended context acquisition を追加するもので、Server / Session 側にある文脈選択や request-length のロジックを macOS 側で再実装せず、macOS は要求された周辺テキストを安全かつ bounded に取得する platform adapter として扱います。
