### PR TITLE
Fix mode indicator for native IME on/off keys

### DIFF
--- a/src/win32/tip/BUILD.bazel
+++ b/src/win32/tip/BUILD.bazel
@@ -341,6 +341,17 @@ mozc_cc_library(
 )
 
 mozc_cc_library(
+    name = "tip_mode_indicator_key",
+    hdrs = ["tip_mode_indicator_key.h"],
+    tags = MOZC_TAGS.WIN_ONLY,
+    target_compatible_with = ["@platforms//os:windows"],
+    deps = [
+        "//win32/base:input_state",
+        "//win32/base:keyboard",
+    ],
+)
+
+mozc_cc_library(
     name = "tip_keyevent_handler",
     srcs = ["tip_keyevent_handler.cc"],
     hdrs = ["tip_keyevent_handler.h"],
@@ -348,6 +359,7 @@ mozc_cc_library(
     target_compatible_with = ["@platforms//os:windows"],
     deps = [
         ":tip_edit_session",
+        ":tip_mode_indicator_key",
         ":tip_input_mode_manager",
         ":tip_private_context_h",
         ":tip_status",
@@ -868,6 +880,18 @@ mozc_cc_test(
     target_compatible_with = ["@platforms//os:windows"],
     deps = [
         ":tip_input_mode_manager",
+        "//testing:gunit_main",
+    ],
+)
+
+mozc_cc_test(
+    name = "tip_mode_indicator_key_test",
+    size = "small",
+    srcs = ["tip_mode_indicator_key_test.cc"],
+    tags = MOZC_TAGS.WIN_ONLY,
+    target_compatible_with = ["@platforms//os:windows"],
+    deps = [
+        ":tip_mode_indicator_key",
         "//testing:gunit_main",
     ],
 )

--- a/src/win32/tip/BUILD.bazel
+++ b/src/win32/tip/BUILD.bazel
@@ -359,8 +359,8 @@ mozc_cc_library(
     target_compatible_with = ["@platforms//os:windows"],
     deps = [
         ":tip_edit_session",
-        ":tip_mode_indicator_key",
         ":tip_input_mode_manager",
+        ":tip_mode_indicator_key",
         ":tip_private_context_h",
         ":tip_status",
         ":tip_surrounding_text",

--- a/src/win32/tip/tip_keyevent_handler.cc
+++ b/src/win32/tip/tip_keyevent_handler.cc
@@ -42,7 +42,6 @@
 #include "base/win32/wide_char.h"
 #include "client/client_interface.h"
 #include "protocol/commands.pb.h"
-#include "session/key_info_util.h"
 #include "win32/base/conversion_mode_util.h"
 #include "win32/base/deleter.h"
 #include "win32/base/input_state.h"
@@ -51,6 +50,7 @@
 #include "win32/base/surrogate_pair_observer.h"
 #include "win32/tip/tip_edit_session.h"
 #include "win32/tip/tip_input_mode_manager.h"
+#include "win32/tip/tip_mode_indicator_key.h"
 #include "win32/tip/tip_private_context.h"
 #include "win32/tip/tip_status.h"
 #include "win32/tip/tip_surrounding_text.h"
@@ -115,27 +115,12 @@ void ShowModeIndicatorAndUpdateUI(TipTextService* text_service,
   }
 }
 
-bool IsNoOpModeIndicatorKey(const InputBehavior& behavior,
-                            const InputState& current_state,
-                            const KeyEventHandlerResult& result) {
-  if (!result.has_key_information) {
-    return false;
-  }
-
-  if (current_state.open) {
-    return KeyInfoUtil::ContainsKeyInformation(
-        behavior.active_mode_ime_on_keys, result.key_information);
-  }
-
-  return KeyInfoUtil::ContainsKeyInformation(
-      behavior.direct_mode_ime_off_keys, result.key_information);
-}
-
 bool UpdateNoOpModeIndicatorKeyState(
     TipTextService* text_service, TipPrivateContext* private_context,
-    TipInputModeManager* input_mode_manager, bool is_key_down,
-    const InputBehavior& behavior, const InputState& current_state,
-    const KeyEventHandlerResult& result, bool is_on_key) {
+    TipInputModeManager* input_mode_manager, const VirtualKey& key,
+    bool is_key_down, const InputBehavior& behavior,
+    const InputState& current_state, const KeyEventHandlerResult& result,
+    bool is_on_key) {
   if (!result.has_key_information) {
     if (is_key_down) {
       private_context->ClearPendingModeIndicatorKey();
@@ -144,7 +129,9 @@ bool UpdateNoOpModeIndicatorKeyState(
   }
 
   if (is_key_down) {
-    if (IsNoOpModeIndicatorKey(behavior, current_state, result)) {
+    if (IsNoOpModeIndicatorKey(
+            key, behavior, current_state, result.has_key_information,
+            result.key_information)) {
       private_context->SetPendingModeIndicatorKey(result.key_information);
     } else {
       private_context->ClearPendingModeIndicatorKey();
@@ -353,7 +340,7 @@ HRESULT OnTestKey(TipTextService* text_service, ITfContext* context,
   }
 
   if (UpdateNoOpModeIndicatorKeyState(
-          text_service, private_context, input_mode_manager, is_key_down,
+          text_service, private_context, input_mode_manager, vk, is_key_down,
           behavior, input_state, result,
           /*is_on_key=*/false)) {
     *eaten = TRUE;
@@ -666,7 +653,7 @@ HRESULT OnKey(TipTextService* text_service, ITfContext* context,
 
     const bool handled_noop_mode_indicator_key =
         UpdateNoOpModeIndicatorKeyState(
-            text_service, private_context, input_mode_manager, is_key_down,
+            text_service, private_context, input_mode_manager, vk, is_key_down,
             behavior, ime_state, result,
             /*is_on_key=*/true);
 

--- a/src/win32/tip/tip_mode_indicator_key.h
+++ b/src/win32/tip/tip_mode_indicator_key.h
@@ -1,0 +1,84 @@
+// Copyright 2010-2021, Google Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#ifndef MOZC_WIN32_TIP_TIP_MODE_INDICATOR_KEY_H_
+#define MOZC_WIN32_TIP_TIP_MODE_INDICATOR_KEY_H_
+
+#include <windows.h>
+
+#include <algorithm>
+
+#include "win32/base/input_state.h"
+#include "win32/base/keyboard.h"
+
+namespace mozc {
+namespace win32 {
+namespace tsf {
+
+inline bool HasNoModifiers(KeyInformation key_information) {
+  // KeyInformation is |Modifiers(16)|SpecialKey(16)|Unicode(32)|.
+  return (key_information >> 48) == 0;
+}
+
+// Returns true when |key| explicitly requests the IME state that is already
+// active. User-configured IMEOn/IMEOff bindings and the dedicated Windows
+// VK_IME_ON/VK_IME_OFF state-selection keys share the same semantics here.
+inline bool IsNoOpModeIndicatorKey(const VirtualKey& key,
+                                   const InputBehavior& behavior,
+                                   const InputState& current_state,
+                                   bool has_key_information,
+                                   KeyInformation key_information) {
+  if (!has_key_information) {
+    return false;
+  }
+
+  if (current_state.open) {
+    if (key.virtual_key() == VK_IME_ON &&
+        HasNoModifiers(key_information)) {
+      return true;
+    }
+    return std::binary_search(behavior.active_mode_ime_on_keys.begin(),
+                              behavior.active_mode_ime_on_keys.end(),
+                              key_information);
+  }
+
+  if (key.virtual_key() == VK_IME_OFF &&
+      HasNoModifiers(key_information)) {
+    return true;
+  }
+  return std::binary_search(behavior.direct_mode_ime_off_keys.begin(),
+                            behavior.direct_mode_ime_off_keys.end(),
+                            key_information);
+}
+
+}  // namespace tsf
+}  // namespace win32
+}  // namespace mozc
+
+#endif  // MOZC_WIN32_TIP_TIP_MODE_INDICATOR_KEY_H_

--- a/src/win32/tip/tip_mode_indicator_key_test.cc
+++ b/src/win32/tip/tip_mode_indicator_key_test.cc
@@ -1,0 +1,127 @@
+// Copyright 2010-2021, Google Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "win32/tip/tip_mode_indicator_key.h"
+
+#include <windows.h>
+
+#include "testing/gunit.h"
+
+namespace mozc {
+namespace win32 {
+namespace tsf {
+namespace {
+
+TEST(TipModeIndicatorKeyTest, NativeImeStateSelectionKeys) {
+  const InputBehavior behavior;
+  constexpr bool kHasKeyInformation = true;
+  constexpr KeyInformation kKeyInformation = 1;
+
+  InputState state;
+  state.open = true;
+  EXPECT_TRUE(IsNoOpModeIndicatorKey(
+      VirtualKey::FromVirtualKey(VK_IME_ON), behavior, state,
+      kHasKeyInformation, kKeyInformation));
+  EXPECT_FALSE(IsNoOpModeIndicatorKey(
+      VirtualKey::FromVirtualKey(VK_IME_OFF), behavior, state,
+      kHasKeyInformation, kKeyInformation));
+
+  state.open = false;
+  EXPECT_TRUE(IsNoOpModeIndicatorKey(
+      VirtualKey::FromVirtualKey(VK_IME_OFF), behavior, state,
+      kHasKeyInformation, kKeyInformation));
+  EXPECT_FALSE(IsNoOpModeIndicatorKey(
+      VirtualKey::FromVirtualKey(VK_IME_ON), behavior, state,
+      kHasKeyInformation, kKeyInformation));
+}
+
+TEST(TipModeIndicatorKeyTest, NativeImeStateSelectionKeysRequireNoModifiers) {
+  const InputBehavior behavior;
+  constexpr KeyInformation kModifiedKeyInformation =
+      (static_cast<KeyInformation>(1) << 48) | 1;
+
+  InputState state;
+  state.open = true;
+  EXPECT_FALSE(IsNoOpModeIndicatorKey(
+      VirtualKey::FromVirtualKey(VK_IME_ON), behavior, state, true,
+      kModifiedKeyInformation));
+
+  state.open = false;
+  EXPECT_FALSE(IsNoOpModeIndicatorKey(
+      VirtualKey::FromVirtualKey(VK_IME_OFF), behavior, state, true,
+      kModifiedKeyInformation));
+}
+
+TEST(TipModeIndicatorKeyTest, ConfiguredImeStateSelectionKeysRemainSupported) {
+  InputBehavior behavior;
+  behavior.active_mode_ime_on_keys.push_back(10);
+  behavior.direct_mode_ime_off_keys.push_back(20);
+
+  InputState state;
+  state.open = true;
+  EXPECT_TRUE(IsNoOpModeIndicatorKey(
+      VirtualKey::FromVirtualKey(VK_F1), behavior, state, true, 10));
+  EXPECT_FALSE(IsNoOpModeIndicatorKey(
+      VirtualKey::FromVirtualKey(VK_F1), behavior, state, true, 20));
+
+  state.open = false;
+  EXPECT_TRUE(IsNoOpModeIndicatorKey(
+      VirtualKey::FromVirtualKey(VK_F1), behavior, state, true, 20));
+  EXPECT_FALSE(IsNoOpModeIndicatorKey(
+      VirtualKey::FromVirtualKey(VK_F1), behavior, state, true, 10));
+}
+
+TEST(TipModeIndicatorKeyTest,
+     ConfiguredImeStateSelectionKeysMayContainModifiers) {
+  constexpr KeyInformation kModifiedKeyInformation =
+      (static_cast<KeyInformation>(1) << 48) | 30;
+
+  InputBehavior behavior;
+  behavior.active_mode_ime_on_keys.push_back(kModifiedKeyInformation);
+
+  InputState state;
+  state.open = true;
+  EXPECT_TRUE(IsNoOpModeIndicatorKey(
+      VirtualKey::FromVirtualKey(VK_F1), behavior, state, true,
+      kModifiedKeyInformation));
+}
+
+TEST(TipModeIndicatorKeyTest, RequiresKeyInformation) {
+  const InputBehavior behavior;
+  InputState state;
+  state.open = false;
+
+  EXPECT_FALSE(IsNoOpModeIndicatorKey(
+      VirtualKey::FromVirtualKey(VK_IME_OFF), behavior, state, false, 0));
+}
+
+}  // namespace
+}  // namespace tsf
+}  // namespace win32
+}  // namespace mozc


### PR DESCRIPTION
## 概要

Windows でネイティブの IME ON / IME OFF キーを押した際、
すでに目的の IME 状態になっている場合でもモードインジケータを表示するように修正します。

対象となるのは Windows の `VK_IME_ON` / `VK_IME_OFF` です。

たとえば IME がすでに OFF の状態で `VK_IME_OFF` を押した場合、
従来は状態変化が発生しないため OFF インジケータが表示されませんでした。

この修正により、明示的な IME ON / OFF 操作に対する確認表示が、
状態変化の有無にかかわらず行われます。

## 背景

既存実装では、ユーザー設定された `IMEOn` / `IMEOff` キーについては、
すでに同じ IME 状態の場合でも no-op mode indicator key として扱い、
キー操作後にモードインジケータを表示する仕組みがあります。

一方、Windows のネイティブな

- `VK_IME_ON`
- `VK_IME_OFF`

はこの判定対象に含まれていませんでした。

そのため、たとえば以下のような差がありました。

- IME OFF + ユーザー設定された `IMEOff` キー
  - OFF インジケータが表示される
- IME OFF + `VK_IME_OFF`
  - OFF のままだが、インジケータは表示されない

## 原因

TSF の実機イベントを確認したところ、状態が変化する場合は
`GUID_COMPARTMENT_KEYBOARD_OPENCLOSE` の変更通知が発生します。

一方、すでに目的の状態になっている場合は compartment の状態変化が発生しません。

ただし、no-op の場合でもネイティブ IME ON / OFF キー自体は
`OnTestKeyDown` / `OnTestKeyUp` に届いていました。

そのため、状態同期側を変更するのではなく、
既存の no-op mode indicator key の判定に
ネイティブ `VK_IME_ON` / `VK_IME_OFF` を統合する方針としました。

## 修正内容

- no-op mode indicator key の判定を独立したヘルパーへ切り出し
- IME が ON のときの単独 `VK_IME_ON` を no-op mode indicator key として扱う
- IME が OFF のときの単独 `VK_IME_OFF` を no-op mode indicator key として扱う
- 既存のユーザー設定による `IMEOn` / `IMEOff` キーの挙動を維持
- 修飾キー付き `VK_IME_ON` / `VK_IME_OFF` は単独キーの特例対象にしない

既存の pending / key-up ベースのインジケータ表示処理は変更せず、
判定部分だけを拡張しています。

また、TSF の open/close 状態同期処理には変更を加えていません。

## 修飾キーの扱い

Windows では修飾キー付き IME ON / OFF キーが
単独の IME ON / OFF キーとは異なる意味を持つ場合があります。

そのため、

- 単独 `VK_IME_ON`
- 単独 `VK_IME_OFF`

のみをネイティブ state-selection key の特例として扱います。

一方、ユーザー設定によって修飾キーを含むキーへ
`IMEOn` / `IMEOff` が割り当てられている場合は、
従来どおりその設定を尊重します。

## テスト

以下のテストを追加・実行しました。

- native `VK_IME_ON`
  - IME ON → no-op indicator 対象
  - IME OFF → 対象外
- native `VK_IME_OFF`
  - IME OFF → no-op indicator 対象
  - IME ON → 対象外
- 修飾キー付き native `VK_IME_ON/OFF`
  - native no-op indicator の特例対象外
- ユーザー設定された `IMEOn` / `IMEOff`
  - 既存動作を維持
- 修飾キーを含むユーザー設定キー
  - 既存動作を維持
- key information がない場合
  - 対象外

実行したテスト:

- `//win32/tip:tip_mode_indicator_key_test`
- `//win32/tip:tip_input_mode_manager_test`
- `//win32/base:keyevent_handler_test`

すべて PASS しています。

`//win32/tip:mozc_tip64` および Windows package build も成功しています。

## 実機確認

Windows の TSF 環境で以下を確認しました。

- IME ON → LANG2
  - OFF になり、OFF インジケータが表示される
- IME OFF → LANG2
  - OFF のまま、OFF インジケータが表示される
- IME OFF → LANG1
  - ON になり、ON インジケータが表示される
- IME ON → LANG1
  - ON のまま、ON インジケータが表示される
- IME OFF → ユーザー設定の `IMEOff` キー
  - 既存の OFF インジケータ表示を維持
- IME ON → ユーザー設定の `IMEOn` キー
  - 既存の ON インジケータ表示を維持

修飾キー付き LANG1 / LANG2 についても、
単独 LANG1 / LANG2 の no-op confirmation として誤処理されないことを確認しています。
