### PR TITLE
Change default Down key binding to PredictAndConvert

### DIFF
--- a/src/data/keymap/kotoeri.tsv
+++ b/src/data/keymap/kotoeri.tsv
@@ -77,7 +77,7 @@ Conversion	Ctrl Right	SegmentFocusLast
 Conversion	Ctrl s	SegmentFocusLeft
 Conversion	Ctrl w	SegmentWidthExpand
 Conversion	Ctrl x	ConvertNext
-Conversion	Down	ConvertNext
+Conversion	Down	PredictAndConvert
 Conversion	End	SegmentFocusLast
 Conversion	Enter	Commit
 Conversion	ESC	Cancel

--- a/src/data/keymap/ms-ime.tsv
+++ b/src/data/keymap/ms-ime.tsv
@@ -89,7 +89,7 @@ Conversion	Ctrl Up	ConvertPrev
 Conversion	Ctrl x	ConvertNext
 Conversion	Ctrl z	Cancel
 Conversion	Delete	Cancel
-Conversion	Down	ConvertNext
+Conversion	Down	PredictAndConvert
 Conversion	Eisu	ToggleAlphanumericMode
 Conversion	End	SegmentFocusLast
 Conversion	Enter	Commit

--- a/src/session/keymap_test.cc
+++ b/src/session/keymap_test.cc
@@ -1020,6 +1020,31 @@ TEST_F(KeyMapTest, ParseCompositionModeLegacyCommandStringsForConversionState) {
             command);
 }
 
+TEST_F(KeyMapTest, ConversionDownBindings) {
+  commands::KeyEvent key_event;
+  ASSERT_TRUE(KeyParser::ParseKey("Down", &key_event));
+
+  ConversionState::Commands command;
+
+  {  // MSIME
+    KeyMapManager manager(GetDefaultConfig(config::Config::MSIME));
+    EXPECT_TRUE(manager.GetCommandConversion(key_event, &command));
+    EXPECT_EQ(command, ConversionState::PREDICT_AND_CONVERT);
+  }
+
+  {  // Kotoeri
+    KeyMapManager manager(GetDefaultConfig(config::Config::KOTOERI));
+    EXPECT_TRUE(manager.GetCommandConversion(key_event, &command));
+    EXPECT_EQ(command, ConversionState::PREDICT_AND_CONVERT);
+  }
+
+  {  // ATOK keeps its native Down behavior.
+    KeyMapManager manager(GetDefaultConfig(config::Config::ATOK));
+    EXPECT_TRUE(manager.GetCommandConversion(key_event, &command));
+    EXPECT_EQ(command, ConversionState::COMMIT_SEGMENT);
+  }
+}
+
 TEST_F(KeyMapTest, ShiftTabToConvertPrev) {
   // http://b/2973471
   // Shift+TAB does not work on a suggestion window

--- a/src/session/session_test.cc
+++ b/src/session/session_test.cc
@@ -2824,7 +2824,7 @@ TEST_F(SessionTest, SpaceDuringLiveConversionKeepsNormalCandidateNavigation) {
   EXPECT_PREEDIT("阿", command);
 }
 
-TEST_F(SessionTest, DownDuringLiveConversionKeepsNormalCandidateNavigation) {
+TEST_F(SessionTest, DownDuringLiveConversionFocusesPredictionCandidates) {
   MockEngine engine;
   std::shared_ptr<MockConverter> converter = CreateEngineConverterMock(&engine);
 
@@ -2859,8 +2859,15 @@ TEST_F(SessionTest, DownDuringLiveConversionKeepsNormalCandidateNavigation) {
   ASSERT_TRUE(EnsurePreedit("亜", command));
   Mock::VerifyAndClearExpectations(converter.get());
 
+  Segments prediction_segments;
+  Segment* prediction_segment = prediction_segments.add_segment();
+  prediction_segment->set_key("あ");
+  AddCandidate("あ", "ありがとう", prediction_segment);
+  AddCandidate("あ", "ありがたい", prediction_segment);
+
   EXPECT_CALL(*converter, StartPredictionWithPreviousSuggestion(_, _, _))
-      .Times(0);
+      .Times(1)
+      .WillOnce(DoAll(SetArgPointee<2>(prediction_segments), Return(true)));
 
   command.Clear();
   EXPECT_TRUE(SendSpecialKey(commands::KeyEvent::DOWN, &session, &command));
@@ -2870,7 +2877,20 @@ TEST_F(SessionTest, DownDuringLiveConversionKeepsNormalCandidateNavigation) {
   EXPECT_FALSE(session_peer.live_conversion_active_());
   EXPECT_FALSE(command.output().live_conversion());
   ASSERT_TRUE(command.output().has_candidate_window());
-  EXPECT_PREEDIT("阿", command);
+  ASSERT_TRUE(command.output().candidate_window().has_focused_index());
+  EXPECT_EQ(command.output().candidate_window().focused_index(), 0);
+  EXPECT_PREEDIT("ありがとう", command);
+  Mock::VerifyAndClearExpectations(converter.get());
+
+  command.Clear();
+  EXPECT_TRUE(SendSpecialKey(commands::KeyEvent::DOWN, &session, &command));
+
+  EXPECT_TRUE(command.output().consumed());
+  EXPECT_EQ(session.context().state(), ImeContext::CONVERSION);
+  ASSERT_TRUE(command.output().has_candidate_window());
+  ASSERT_TRUE(command.output().candidate_window().has_focused_index());
+  EXPECT_EQ(command.output().candidate_window().focused_index(), 1);
+  EXPECT_PREEDIT("ありがたい", command);
 }
 
 TEST_F(SessionTest,


### PR DESCRIPTION
## 概要

MS-IME / Kotoeri の既定キー設定を変更し、
`Conversion + Down` に `PredictAndConvert` を割り当てます。

これにより、ライブ変換中は Down キーで予測・サジェスト候補へ移動でき、
通常変換中は既存の `PredictAndConvert` のフォールバックにより、
従来どおり次の通常変換候補へ進みます。

既存の `PredictAndConvert` コマンドやライブ変換時の処理ロジックは変更せず、
デフォルトキーマップとその回帰テストのみを変更します。

## 変更内容

- MS-IME
  - `Conversion + Down`: `ConvertNext` → `PredictAndConvert`
- Kotoeri
  - `Conversion + Down`: `ConvertNext` → `PredictAndConvert`
- ATOK
  - 既存の Down キー動作を変更しない
- キーマップの回帰テストを追加
- ライブ変換中の Down キー動作テストを更新
  - 1回目の Down で予測候補へ移動
  - 2回目の Down で予測候補内の次候補へ移動

## 動作

ライブ変換中:

- Down → 予測・サジェスト候補へ移動
- Space → 従来どおり通常変換候補へ移動
- Tab → 従来どおり予測候補へ移動

予測候補選択中:

- Down → 次の予測候補

通常変換候補選択中:

- Down → 従来どおり次の通常変換候補

## テスト

以下を実行し、PASS を確認しました。

```text
//session:keymap_test
//session:session_test
```

結果:

```text
//session:keymap_test   PASSED
//session:session_test  PASSED
```

`git diff --check` も PASS しています。

## Windows 実機確認

修正済みソースから release MSI をビルドし、

1. 既存 Mozkey をアンインストール
2. Windows を再起動
3. 修正済み MSI を通常インストール
4. TIP 登録を確認

まで実施しました。

MS-IME のキー設定画面でも、

```text
変換中 + Down
→ 予測変換（候補内では次候補）
```

と表示されることを確認しています。

実入力でも、

```text
ライブ変換 + Down
→ 予測・サジェスト候補へ移動

そのまま Down
→ 次の予測候補へ移動

ライブ変換 + Space
→ 通常変換候補へ移動

ライブ変換 + Tab
→ 予測候補へ移動

通常変換中 + Down
→ 次の通常変換候補へ移動
```

となることを確認しました。

## 変更ファイル

```text
src/data/keymap/ms-ime.tsv
src/data/keymap/kotoeri.tsv
src/session/keymap_test.cc
src/session/session_test.cc
```
