### PR TITLE
Fix Mozkey default settings consistency

### DIFF
--- a/src/config/config_handler.cc
+++ b/src/config/config_handler.cc
@@ -66,6 +66,46 @@ namespace {
 
 constexpr absl::string_view kFileNamePrefix = "user://config";
 
+constexpr uint32_t kMozkeyDefaultDirectCommitKey =
+    Config::DIRECT_COMMIT_KUTEN |
+    Config::DIRECT_COMMIT_TOUTEN |
+    Config::DIRECT_COMMIT_QUESTION_MARK |
+    Config::DIRECT_COMMIT_EXCLAMATION_MARK |
+    Config::DIRECT_COMMIT_OPEN_BRACKET |
+    Config::DIRECT_COMMIT_CLOSE_BRACKET;
+
+// Applies Mozkey-specific product defaults only to fields that have not been
+// explicitly stored.  Keep this shared by normalization and the user-facing
+// product-default accessor so that a fresh profile, an older profile missing
+// newer fields, and "Reset to defaults" all resolve to the same values without
+// overwriting explicit user choices.
+void ApplyMozkeyProductDefaults(Config* config) {
+  if (!config->has_use_live_conversion()) {
+    config->set_use_live_conversion(true);
+  }
+  if (!config->has_show_candidate_window_on_initial_conversion()) {
+    config->set_show_candidate_window_on_initial_conversion(true);
+  }
+  if (!config->has_use_direct_commit()) {
+    config->set_use_direct_commit(true);
+  }
+  if (!config->has_direct_commit_key()) {
+    config->set_direct_commit_key(kMozkeyDefaultDirectCommitKey);
+  }
+  if (!config->has_use_zenz_live_correction()) {
+    config->set_use_zenz_live_correction(true);
+  }
+  if (!config->has_use_zenz_feedback_learning()) {
+    config->set_use_zenz_feedback_learning(true);
+  }
+  if (!config->has_use_zenz_live_correction_right_context()) {
+    config->set_use_zenz_live_correction_right_context(true);
+  }
+  if (!config->has_use_realtime_conversion()) {
+    config->set_use_realtime_conversion(false);
+  }
+}
+
 void AddCharacterFormRule(const absl::string_view group,
                           const Config::CharacterForm preedit_form,
                           const Config::CharacterForm conversion_form,
@@ -146,27 +186,7 @@ void NormalizeConfig(Config* config) {
     config->set_use_emoji_conversion(true);
   }
 
-  if (!config->has_use_live_conversion()) {
-    config->set_use_live_conversion(true);
-  }
-
-  if (!config->has_show_candidate_window_on_initial_conversion()) {
-    config->set_show_candidate_window_on_initial_conversion(true);
-  }
-
-  if (!config->has_use_direct_commit()) {
-    config->set_use_direct_commit(true);
-  }
-
-  if (!config->has_direct_commit_key()) {
-    config->set_direct_commit_key(
-        Config::DIRECT_COMMIT_KUTEN |
-        Config::DIRECT_COMMIT_TOUTEN |
-        Config::DIRECT_COMMIT_QUESTION_MARK |
-        Config::DIRECT_COMMIT_EXCLAMATION_MARK |
-        Config::DIRECT_COMMIT_OPEN_BRACKET |
-        Config::DIRECT_COMMIT_CLOSE_BRACKET);
-  }
+  ApplyMozkeyProductDefaults(config);
 }
 
 class ConfigHandlerImpl final {
@@ -317,6 +337,12 @@ void ConfigHandler::SetConfig(Config config) {
 // static
 void ConfigHandler::GetDefaultConfig(Config* config) {
   *config = DefaultConfig();
+}
+
+Config ConfigHandler::GetProductDefaultConfig() {
+  Config config = DefaultConfig();
+  ApplyMozkeyProductDefaults(&config);
+  return config;
 }
 
 std::shared_ptr<const Config> ConfigHandler::GetSharedDefaultConfig() {

--- a/src/config/config_handler.h
+++ b/src/config/config_handler.h
@@ -75,6 +75,11 @@ class ConfigHandler {
   // These functions are also thread-safe.
   static void GetDefaultConfig(Config* config);
 
+  // Returns user-facing Mozkey product defaults.  Unlike DefaultConfig(), this
+  // includes Mozkey-specific settings used for a fresh profile and
+  // "Reset to defaults".
+  static Config GetProductDefaultConfig();
+
   static const Config& DefaultConfig();
   static std::shared_ptr<const config::Config> GetSharedDefaultConfig();
 

--- a/src/config/config_handler_test.cc
+++ b/src/config/config_handler_test.cc
@@ -70,17 +70,51 @@ class ConfigHandlerTest : public testing::TestWithTempUserProfile {
   std::string default_config_filename_;
 };
 
-void SetMozkeyInputDefaultsForTesting(Config* config) {
+constexpr uint32_t kExpectedMozkeyDirectCommitKey =
+    Config::DIRECT_COMMIT_KUTEN |
+    Config::DIRECT_COMMIT_TOUTEN |
+    Config::DIRECT_COMMIT_QUESTION_MARK |
+    Config::DIRECT_COMMIT_EXCLAMATION_MARK |
+    Config::DIRECT_COMMIT_OPEN_BRACKET |
+    Config::DIRECT_COMMIT_CLOSE_BRACKET;
+
+void SetMozkeyProductDefaultsForTesting(Config* config) {
   config->set_use_live_conversion(true);
   config->set_show_candidate_window_on_initial_conversion(true);
   config->set_use_direct_commit(true);
-  config->set_direct_commit_key(
-      Config::DIRECT_COMMIT_KUTEN |
-      Config::DIRECT_COMMIT_TOUTEN |
-      Config::DIRECT_COMMIT_QUESTION_MARK |
-      Config::DIRECT_COMMIT_EXCLAMATION_MARK |
-      Config::DIRECT_COMMIT_OPEN_BRACKET |
-      Config::DIRECT_COMMIT_CLOSE_BRACKET);
+  config->set_direct_commit_key(kExpectedMozkeyDirectCommitKey);
+  config->set_use_zenz_live_correction(true);
+  config->set_use_zenz_feedback_learning(true);
+  config->set_use_zenz_live_correction_right_context(true);
+  config->set_use_realtime_conversion(false);
+}
+
+void ExpectMozkeyProductDefaults(const Config& config) {
+  EXPECT_TRUE(config.use_live_conversion());
+  EXPECT_EQ(config.live_conversion_delay_msec(), 228);
+  EXPECT_EQ(config.live_conversion_min_key_length(), 2);
+  EXPECT_TRUE(config.show_candidate_window_on_initial_conversion());
+
+  EXPECT_TRUE(config.use_direct_commit());
+  EXPECT_EQ(config.direct_commit_key(), kExpectedMozkeyDirectCommitKey);
+
+  EXPECT_TRUE(config.use_zenz_live_correction());
+  EXPECT_EQ(config.zenz_live_correction_delay_msec(), 1000);
+  EXPECT_EQ(config.zenz_live_correction_timeout_msec(), 180);
+  EXPECT_EQ(config.zenz_live_correction_min_key_length(), 2);
+  EXPECT_EQ(config.zenz_live_correction_left_context_length(), 24);
+  EXPECT_TRUE(config.use_zenz_synthetic_candidate());
+  EXPECT_TRUE(config.use_zenz_feedback_learning());
+  EXPECT_FALSE(config.use_zenz_auto_block_rejected_correction());
+  EXPECT_EQ(config.zenz_auto_block_reject_threshold(), 3);
+  EXPECT_TRUE(config.use_zenz_live_correction_right_context());
+  EXPECT_EQ(config.zenz_live_correction_right_context_length(), 24);
+
+  EXPECT_EQ(config.history_learning_level(), Config::DEFAULT_HISTORY);
+  EXPECT_TRUE(config.use_history_suggest());
+  EXPECT_TRUE(config.use_dictionary_suggest());
+  EXPECT_FALSE(config.use_realtime_conversion());
+  EXPECT_EQ(config.suggestions_size(), 3);
 }
 
 TEST_F(ConfigHandlerTest, SetConfig) {
@@ -101,7 +135,7 @@ TEST_F(ConfigHandlerTest, SetConfig) {
   input.set_verbose_level(2);
 #endif  // NDEBUG
   Config expected = input;
-  SetMozkeyInputDefaultsForTesting(&expected);
+  SetMozkeyProductDefaultsForTesting(&expected);
 
   ConfigHandler::SetConfig(input);
   output = ConfigHandler::GetCopiedConfig();
@@ -118,7 +152,7 @@ TEST_F(ConfigHandlerTest, SetConfig) {
   input.set_verbose_level(0);
 #endif  // NDEBUG
   expected = input;
-  SetMozkeyInputDefaultsForTesting(&expected);
+  SetMozkeyProductDefaultsForTesting(&expected);
 
   ConfigHandler::SetConfig(input);
   output = ConfigHandler::GetCopiedConfig();
@@ -131,7 +165,7 @@ TEST_F(ConfigHandlerTest, SetConfig) {
   EXPECT_EQ(absl::StrCat(output2), absl::StrCat(expected));
 }
 
-TEST_F(ConfigHandlerTest, NormalizeMozkeyInputDefaults) {
+TEST_F(ConfigHandlerTest, MissingConfigUsesMozkeyProductDefaults) {
   TempDirectory temp_dir = testing::MakeTempDirectoryOrDie();
   const std::string config_file =
       FileUtil::JoinPath(temp_dir.path(), "mozc_config_test_tmp");
@@ -139,23 +173,10 @@ TEST_F(ConfigHandlerTest, NormalizeMozkeyInputDefaults) {
   ConfigHandler::SetConfigFileNameForTesting(config_file);
   ConfigHandler::Reload();
 
-  const Config output = ConfigHandler::GetCopiedConfig();
-
-  EXPECT_TRUE(output.use_live_conversion());
-  EXPECT_EQ(output.live_conversion_min_key_length(), 2);
-  EXPECT_TRUE(output.show_candidate_window_on_initial_conversion());
-  EXPECT_TRUE(output.use_direct_commit());
-  EXPECT_EQ(
-      output.direct_commit_key(),
-      Config::DIRECT_COMMIT_KUTEN |
-          Config::DIRECT_COMMIT_TOUTEN |
-          Config::DIRECT_COMMIT_QUESTION_MARK |
-          Config::DIRECT_COMMIT_EXCLAMATION_MARK |
-          Config::DIRECT_COMMIT_OPEN_BRACKET |
-          Config::DIRECT_COMMIT_CLOSE_BRACKET);
+  ExpectMozkeyProductDefaults(ConfigHandler::GetCopiedConfig());
 }
 
-TEST_F(ConfigHandlerTest, NormalizeMozkeyInputDefaultsPreservesExplicitFalse) {
+TEST_F(ConfigHandlerTest, MozkeyProductDefaultsPreserveExplicitSettings) {
   TempDirectory temp_dir = testing::MakeTempDirectoryOrDie();
   const std::string config_file =
       FileUtil::JoinPath(temp_dir.path(), "mozc_config_test_tmp");
@@ -164,10 +185,14 @@ TEST_F(ConfigHandlerTest, NormalizeMozkeyInputDefaultsPreservesExplicitFalse) {
   ConfigHandler::Reload();
 
   Config input;
-  ConfigHandler::GetDefaultConfig(&input);
   input.set_use_live_conversion(false);
   input.set_show_candidate_window_on_initial_conversion(false);
   input.set_use_direct_commit(false);
+  input.set_direct_commit_key(0);
+  input.set_use_zenz_live_correction(false);
+  input.set_use_zenz_feedback_learning(false);
+  input.set_use_zenz_live_correction_right_context(false);
+  input.set_use_realtime_conversion(true);
 
   ConfigHandler::SetConfig(input);
   const Config output = ConfigHandler::GetCopiedConfig();
@@ -175,6 +200,11 @@ TEST_F(ConfigHandlerTest, NormalizeMozkeyInputDefaultsPreservesExplicitFalse) {
   EXPECT_FALSE(output.use_live_conversion());
   EXPECT_FALSE(output.show_candidate_window_on_initial_conversion());
   EXPECT_FALSE(output.use_direct_commit());
+  EXPECT_EQ(output.direct_commit_key(), 0);
+  EXPECT_FALSE(output.use_zenz_live_correction());
+  EXPECT_FALSE(output.use_zenz_feedback_learning());
+  EXPECT_FALSE(output.use_zenz_live_correction_right_context());
+  EXPECT_TRUE(output.use_realtime_conversion());
 }
 
 TEST_F(ConfigHandlerTest, SetMetadata) {
@@ -309,6 +339,14 @@ TEST_F(ConfigHandlerTest, GetDefaultConfig) {
   EXPECT_EQ(output.session_keymap(), Config::MSIME);
 #endif  // __APPLE__ || OS_CHROMEOS
 
+  EXPECT_FALSE(output.has_use_live_conversion());
+  EXPECT_FALSE(output.has_show_candidate_window_on_initial_conversion());
+  EXPECT_FALSE(output.has_use_direct_commit());
+  EXPECT_FALSE(output.has_direct_commit_key());
+  EXPECT_FALSE(output.has_use_zenz_live_correction());
+  EXPECT_FALSE(output.has_use_zenz_feedback_learning());
+  EXPECT_FALSE(output.has_use_zenz_live_correction_right_context());
+  EXPECT_FALSE(output.has_use_realtime_conversion());
   EXPECT_EQ(output.live_conversion_min_key_length(), 2);
   EXPECT_EQ(output.character_form_rules_size(), 13);
 
@@ -344,6 +382,10 @@ TEST_F(ConfigHandlerTest, GetDefaultConfig) {
     EXPECT_EQ(output.character_form_rules(i).conversion_character_form(),
               kTestCases[i].conversion_character_form);
   }
+}
+
+TEST_F(ConfigHandlerTest, ProductDefaultConfig) {
+  ExpectMozkeyProductDefaults(ConfigHandler::GetProductDefaultConfig());
 }
 
 TEST_F(ConfigHandlerTest, DefaultConfig) {

--- a/src/gui/config_dialog/config_dialog.cc
+++ b/src/gui/config_dialog/config_dialog.cc
@@ -4148,7 +4148,7 @@ void ConfigDialog::ResetToDefaults() {
     // nice to have GET_DEFAULT_CONFIG command
     const bool was_suppressed = suppress_apply_button_update_;
     suppress_apply_button_update_ = true;
-    ConvertFromProto(config::ConfigHandler::DefaultConfig());
+    ConvertFromProto(config::ConfigHandler::GetProductDefaultConfig());
     UpdateDependentControls();
     suppress_apply_button_update_ = was_suppressed;
     EnableApplyButton();

--- a/src/protocol/config.proto
+++ b/src/protocol/config.proto
@@ -266,6 +266,8 @@ message Config {
     DIRECT_COMMIT_CLOSE_BRACKET = 128;
     DIRECT_COMMIT_MIDDLE_DOT = 256;
   }
+  // Mozkey enables direct commit by default in ConfigHandler and initially
+  // selects `、。？！「」`.
   optional bool use_direct_commit = 1001 [default = false];
 
   // can't use DirectCommitKey as a type since
@@ -318,6 +320,7 @@ message Config {
   // Use live conversion.
   // If this is true, the current composition is converted on every character
   // input without committing the previous live conversion result.
+  // Mozkey enables this by default in ConfigHandler.
   optional bool use_live_conversion = 69 [default = false];
 
   // Delay in milliseconds before applying live conversion after character input.
@@ -331,12 +334,12 @@ message Config {
 
   // When live conversion is disabled, the initial Convert command in
   // composition mode opens the conversion candidate window without advancing
-  // the focused candidate.
+  // the focused candidate. Mozkey enables this by default in ConfigHandler.
   optional bool show_candidate_window_on_initial_conversion = 72
       [default = false];
 
-  // Experimental: use asynchronous zenz live correction after normal live
-  // conversion. This is intentionally default-off until the feature is verified.
+  // Use asynchronous zenz live correction after normal live conversion.
+  // Mozkey enables this by default in ConfigHandler.
   optional bool use_zenz_live_correction = 1003 [default = false];
 
   // Debounce in milliseconds before submitting a zenz live correction request
@@ -365,9 +368,10 @@ message Config {
   // Debug logging for zenz live correction.
   optional bool zenz_live_correction_debug = 1010 [default = false];
 
-  // Experimental: record and reuse local feedback for zenz live correction.
+  // Record and reuse local feedback for zenz live correction.
   // This stores only local TSV data and never sends feedback outside the machine.
-  // Raw left context is not stored.
+  // Raw left context is not stored. Mozkey enables this by default in
+  // ConfigHandler.
   optional bool use_zenz_feedback_learning = 1011 [default = false];
 
   // When enabled, repeated divergent commits of the same full-sequence Zenz
@@ -390,7 +394,8 @@ message Config {
   optional string zenz_live_correction_settings = 1015 [default = ""];
 
   // Zenzai v3.2 right-context support. The actual text is taken from
-  // commands::Context::following_text when the client supplies it.
+  // commands::Context::following_text when the client supplies it. Mozkey keeps
+  // this enabled in its product defaults.
   optional bool use_zenz_live_correction_right_context = 1016
       [default = true];
   optional uint32 zenz_live_correction_right_context_length = 1017
@@ -446,7 +451,9 @@ message Config {
   // you haven't typed before.
   optional bool use_dictionary_suggest = 101 [default = true];
 
-  // Use realtime conversion feature.
+  // Use realtime conversion feature. Mozkey disables this by default in
+  // ConfigHandler because normal live conversion already provides inline
+  // conversion results.
   optional bool use_realtime_conversion = 102 [default = true];
 
   // Size of suggestions.

--- a/src/session/session_handler_scenario_test.cc
+++ b/src/session/session_handler_scenario_test.cc
@@ -69,6 +69,9 @@ void SetLegacyInputDefaultsForScenarioTest() {
   config.set_use_live_conversion(false);
   config.set_use_direct_commit(false);
   config.set_direct_commit_key(0);
+  config.set_use_zenz_live_correction(false);
+  config.set_use_zenz_feedback_learning(false);
+  config.set_use_realtime_conversion(true);
 
   config::ConfigHandler::SetConfig(config);
 }


### PR DESCRIPTION
## 概要

Mozkey の製品既定値を整理し、
新規環境・未設定項目・設定画面の「初期値に戻す」で
同じ既定値が使用されるようにします。

これまで一部の設定では、

- 新規環境で実際に使用される初期値
- protobuf 上の既定値
- `ConfigHandler` が補完する値
- 設定画面の「初期値に戻す」で復元される値

の間に不整合があり、
「初期値に戻す」を実行しても Mozkey が意図している初期状態に
戻らない項目がありました。#107

今回、内部処理で広く使用される `ConfigHandler::DefaultConfig()` と、
ユーザー向けの Mozkey 製品既定値を明確に分離し、
製品としての初期状態を一貫して扱えるようにします。

## ユーザー体験としての意図

Mozkey では、単に Mozc に追加機能を載せるのではなく、

- Mozc の通常変換・学習
- ライブ変換
- Zenz による文脈を考慮した補正
- 履歴・辞書サジェスト

を互いに邪魔しない形で共存させることを重視しています。

今回の既定値も、この入力体験を基準に設定しています。

### Zenz を既定で有効化

Zenz ライブ補正を既定で有効にします。

Mozkey の大きな特徴の一つは、
Mozc の通常変換と Zenz を単純に置き換えるのではなく、
両者を共存させながら利用できる点にあります。

通常の Mozc 変換による候補選択や学習を維持しつつ、
入力中には Zenz が前後の文脈を考慮して補正することで、
従来のかな漢字変換だけでは扱いにくい文脈依存の変換も
自然に利用できます。

この Mozc と Zenz の組み合わせは Mozkey の大きな特徴であるため、
文脈を考慮したかな漢字変換の利点を、
特別な設定を行わなくても利用できる状態を既定とします。

あわせて、

- Zenz feedback / ローカル学習
- Zenz 右文脈

も既定で有効にし、
Mozkey が想定する Zenz 統合を初期状態から利用できるようにします。

### リアルタイム変換サジェストは既定で OFF

一方、`use_realtime_conversion` による
リアルタイム変換サジェストは既定で OFF にします。

Mozkey ではライブ変換中にルビウィンドウが表示されるため、
さらに長い入力に対してリアルタイム変換のサジェストウィンドウまで
常時表示されると、入力文字の周囲に複数の情報ウィンドウが
上下に並びやすくなります。

これは候補情報としては有用でも、

- 表示される情報量が過剰になる
- 入力位置周辺の視覚的ノイズが増える
- 長い文章を書く際に本文へ集中しづらくなる

といった問題につながる可能性があります。

そのため、

- 入力履歴サジェスト: ON
- 辞書サジェスト: ON
- リアルタイム変換サジェスト: OFF

を既定とします。

短い入力に対する履歴・辞書サジェストの利便性は維持しつつ、
長文でも継続的に表示されやすいリアルタイム変換サジェストは抑え、
ライブ変換・Zenz を中心とした本文入力を邪魔しない構成を意図しています。

なお、ここで OFF にする「リアルタイム変換サジェスト」と、
本文中で動作する「ライブ変換」は別機能です。

`use_realtime_conversion = false` でも、
Mozkey のライブ変換自体は引き続き有効です。

## Mozkey の製品既定値

### ライブ変換

- ライブ変換: ON
- ライブ変換遅延: 228 ms
- ライブ変換の最小読み長: 2
- 初回変換で候補ウィンドウを表示: ON

### 単打確定

- 単打確定: ON
- 単打確定キー: `、。？！「」`

### Zenz

- Zenz ライブ補正: ON
- Zenz ライブ補正遅延: 1000 ms
- Zenz timeout: 180 ms
- Zenz 最小読み長: 2
- Zenz 左文脈長: 24
- Zenz synthetic candidate: ON
- Zenz feedback / ローカル学習: ON
- rejected correction 自動 block: OFF
- auto-block threshold: 3
- Zenz 右文脈: ON
- Zenz 右文脈長: 24

### サジェスト

- 入力履歴サジェスト: ON
- 辞書サジェスト: ON
- リアルタイム変換サジェスト: OFF
- サジェスト候補数: 3

### 学習

- Mozc 履歴学習: `DEFAULT_HISTORY`

## 設定管理の変更

内部処理で広く使われる `ConfigHandler::DefaultConfig()` は、
従来どおり中立な設定として維持します。

Mozkey 固有の製品既定値は新たに
`ConfigHandler::GetProductDefaultConfig()` として分離します。

これにより、

### 新規環境・未設定項目

`NormalizeConfig()` で、
まだ保存されていない項目だけ Mozkey 製品既定値を補完します。

既にユーザーが明示的に設定している項目については、
`has_*()` を確認して値を上書きしません。

そのため、アップデート後に既存ユーザーの設定を
強制的に Mozkey の既定値へ戻すことはありません。

### 「初期値に戻す」

設定画面の「初期値に戻す」も
`GetProductDefaultConfig()` を使用するよう変更します。

これまで存在していた、

> 実際の Mozkey の初期状態と、
> 「初期値に戻す」で復元される状態が一致しない

という不整合を解消し、

- 新規環境
- 未設定項目の補完
- 「初期値に戻す」

で同じ Mozkey 製品既定値を使用します。

## protobuf defaults について

`config.proto` の `[default=...]` 自体は変更していません。

protobuf の schema default は、
Mozc 内部のさまざまな処理や bare `Config` の生成にも影響します。

Mozkey 固有の製品ポリシーを schema default に持ち込むと、
ユーザー向け設定とは無関係な内部処理まで挙動が変化する可能性があります。

そのため、

- protobuf / 内部既定値
- Mozkey のユーザー向け製品既定値

を分離し、
製品既定値は `ConfigHandler` 側で管理します。

## テスト

以下を追加・更新しました。

- Mozkey 製品既定値の全項目を検証
- `DefaultConfig()` が Mozkey 製品既定値で汚染されないことを検証
- 新規 / 未設定 config に製品既定値が補完されることを検証
- 明示的に保存されたユーザー設定が保持されることを検証
- 設定画面の「初期値に戻す」が product defaults を使用することを確認

## 検証

Windows `release_build` で以下を確認しました。

- `//config:config_handler_test`
- `//prediction:dictionary_prediction_aggregator_test`
- `//rewriter:command_rewriter_test`
- `//rewriter:zenz_feedback_candidate_rewriter_test`
- `//session:session_test`
- `//session:zenz_context_request_test`

上記はすべて PASS しています。

`//session:ime_context_test` の
`ImeContextTest.CopyContext` については、
変更を完全に退避した clean HEAD に対して、
同一 workspace / 同一 build environment でも同じ failure が再現することを
A/B 検証しており、本変更による回帰ではないことを確認しています。

また、

- `//gui/config_dialog:config_dialog_main` の release build
- Windows package build
- MSI payload の展開・確認
- clean uninstall
- reboot
- normal install
- インストール済み `mozc_tool.exe` の payload hash 一致
- TIP 登録
- `Get-WinUserLanguageList` の Mozkey profile 登録
- 「初期値に戻す」で製品既定値が反映されること

まで確認しています。

session_handler_scenario_test では、Mozkey の製品既定値が従来の golden scenario の前提に影響しないよう、scenario fixture で従来値を明示的に固定しました。変更前に CI と同じ failure をローカルで再現し、修正後は debug / release_build の両方で全 shard PASS を確認しています。
