### PR TITLE
Make config dialog layout responsive

### DIFF
--- a/src/gui/config_dialog/character_form_editor.cc
+++ b/src/gui/config_dialog/character_form_editor.cc
@@ -165,6 +165,19 @@ void CharacterFormEditor::Load(const config::Config &config) {
   }
 
   horizontalHeader()->setSectionResizeMode(QHeaderView::Stretch);
+
+  // The Advanced tab itself scrolls vertically.  Size this nested table to
+  // its normal contents so users do not have to operate two vertical scroll
+  // areas for the usual character-form rule set.  Cap unusually large custom
+  // configurations so the table can still scroll internally when necessary.
+  constexpr int kMaxVisibleRows = 16;
+  const int visible_rows =
+      rowCount() < kMaxVisibleRows ? rowCount() : kMaxVisibleRows;
+  int content_height = horizontalHeader()->height() + 2 * frameWidth();
+  for (int row = 0; row < visible_rows; ++row) {
+    content_height += rowHeight(row);
+  }
+  setFixedHeight(content_height);
 }
 
 void CharacterFormEditor::Save(config::Config *config) {

--- a/src/gui/config_dialog/config_dialog.cc
+++ b/src/gui/config_dialog/config_dialog.cc
@@ -49,6 +49,7 @@
 #include <QPushButton>
 #include <QSizePolicy>
 #include <QSpinBox>
+#include <QStyle>
 #include <QStringList>
 #include <QTableWidget>
 #include <QTableWidgetItem>
@@ -289,7 +290,9 @@ ConfigDialog::ConfigDialog()
   inputSupportScrollArea->viewport()->setStyleSheet(QString());
   inputSupportScrollAreaWidgetContents->setStyleSheet(QString());
 
-  setWindowFlags(Qt::WindowSystemMenuHint | Qt::WindowCloseButtonHint);
+  Qt::WindowFlags flags = windowFlags();
+  flags &= ~Qt::WindowContextHelpButtonHint;
+  setWindowFlags(flags);
   setWindowModality(Qt::NonModal);
 
 #ifdef _WIN32
@@ -576,6 +579,24 @@ ConfigDialog::ConfigDialog()
 #else   // _WIN32
   IMEHotKeyDisabledCheckBox->setVisible(false);
 #endif  // _WIN32
+
+  // QScrollArea breaks the minimum-width chain from its scroll widget to the
+  // surrounding dialog.  Synchronize the Advanced tab's minimum width only
+  // after translated labels, config-backed table contents, and all
+  // platform-specific visibility have reached their final initial state.
+  // Keep an as-needed horizontal scrollbar as a safety valve for unusual font,
+  // translation, or accessibility configurations.
+  inputSupportContentLayout->invalidate();
+  inputSupportContentLayout->activate();
+  const int input_support_minimum_width =
+      inputSupportScrollAreaWidgetContents->minimumSizeHint().width();
+  if (input_support_minimum_width > 0) {
+    const int scrollbar_extent = inputSupportScrollArea->style()->pixelMetric(
+        QStyle::PM_ScrollBarExtent, nullptr, inputSupportScrollArea);
+    inputSupportScrollArea->setMinimumWidth(
+        input_support_minimum_width + scrollbar_extent +
+        2 * inputSupportScrollArea->frameWidth());
+  }
 
   RecordCurrentStateAsApplied();
   suppress_apply_button_update_ = false;
@@ -2318,15 +2339,15 @@ void ConfigDialog::InitializeWindowsImeIconStyleControls() {
   group->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
 
   QVBoxLayout* group_layout = new QVBoxLayout(group);
-  group_layout->setSpacing(10);
-  group_layout->setContentsMargins(0, 0, 5, 0);
+  group_layout->setSpacing(0);
+  group_layout->setContentsMargins(0, 0, 0, 0);
 
   QWidget* header = new QWidget(group);
   header->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
 
   QHBoxLayout* header_layout = new QHBoxLayout(header);
   header_layout->setSpacing(6);
-  header_layout->setContentsMargins(0, 0, 0, 0);
+  header_layout->setContentsMargins(9, 9, 9, 9);
 
   QLabel* title = new QLabel(TrConfigDialog("IME icon"), header);
   title->setObjectName(QStringLiteral("windowsImeIconStyleTitle"));
@@ -2345,7 +2366,7 @@ void ConfigDialog::InitializeWindowsImeIconStyleControls() {
   body->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
 
   QGridLayout* body_layout = new QGridLayout(body);
-  body_layout->setContentsMargins(12, 0, 0, 0);
+  body_layout->setContentsMargins(24, 9, 24, 9);
 
   QLabel* label = new QLabel(TrConfigDialog("IME icon style"), body);
   label->setObjectName(QStringLiteral("windowsImeIconStyleLabel"));
@@ -2381,7 +2402,7 @@ void ConfigDialog::InitializeWindowsImeIconStyleControls() {
       group);
   note->setObjectName(QStringLiteral("windowsImeIconStyleNote"));
   note->setWordWrap(true);
-  note->setContentsMargins(12, 0, 5, 0);
+  note->setContentsMargins(24, 0, 24, 9);
   group_layout->addWidget(note);
 
   const int insert_index = verticalLayout->indexOf(miscAdministrationWidget);
@@ -2402,27 +2423,20 @@ void ConfigDialog::InitializeRendererAppearanceControls() {
   candidateRubyFontLabel->hide();
   candidateRubyFontComboBox->hide();
 
-  constexpr int kRendererAppearanceGroupX = 30;
-  constexpr int kRendererAppearanceGroupY = 1146;
-  constexpr int kRendererAppearanceGroupWidth = 441;
-#ifdef _WIN32
-  constexpr int kRendererAppearanceToPreeditMargin = 18;
-#endif  // _WIN32
-  constexpr int kInputSupportBottomMargin = 30;
-
   QWidget* group = new QWidget(inputSupportScrollAreaWidgetContents);
   group->setObjectName(QStringLiteral("rendererAppearanceGroupBox"));
-  group->setGeometry(kRendererAppearanceGroupX, kRendererAppearanceGroupY,
-                     kRendererAppearanceGroupWidth, 1);
+  group->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
 
   QVBoxLayout* root_layout = new QVBoxLayout(group);
+  // Keep the renderer section in the same layout system as the static
+  // Advanced-tab groups.  Use layout margins instead of a dialog-wide
+  // stylesheet so native checkbox and frame rendering stays untouched.
   root_layout->setContentsMargins(0, 0, 0, 0);
-  root_layout->setSpacing(6);
+  root_layout->setSpacing(0);
 
   QWidget* section = new QWidget(group);
-  section->setFixedHeight(60);
   QHBoxLayout* section_layout = new QHBoxLayout(section);
-  section_layout->setContentsMargins(0, 20, 0, 16);
+  section_layout->setContentsMargins(9, 9, 9, 9);
   QLabel* section_label =
       new QLabel(tr("Candidate, suggestion, and ruby window appearance"),
                  section);
@@ -2442,6 +2456,13 @@ void ConfigDialog::InitializeRendererAppearanceControls() {
                    SLOT(ResetRendererAppearanceControls()));
   root_layout->addWidget(section);
 
+  QWidget* body = new QWidget(group);
+  body->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
+  QVBoxLayout* body_layout = new QVBoxLayout(body);
+  body_layout->setContentsMargins(24, 9, 24, 9);
+  body_layout->setSpacing(6);
+  root_layout->addWidget(body);
+
   QGridLayout* font_layout = new QGridLayout();
   font_layout->setContentsMargins(0, 0, 0, 0);
   font_layout->setHorizontalSpacing(8);
@@ -2456,7 +2477,7 @@ void ConfigDialog::InitializeRendererAppearanceControls() {
   font_layout->addWidget(font_label, 0, 0);
   font_layout->addWidget(candidateRubyFontComboBox, 0, 1);
   font_layout->setColumnStretch(1, 1);
-  root_layout->addLayout(font_layout);
+  body_layout->addLayout(font_layout);
 
   QGroupBox* font_weight_box = new QGroupBox(tr("Font weight"), group);
   font_weight_box->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
@@ -2488,7 +2509,7 @@ void ConfigDialog::InitializeRendererAppearanceControls() {
                       "suggestWindowFontWeightComboBox");
   add_font_weight_row(2, tr("Ruby window"),
                       "rubyWindowFontWeightComboBox");
-  root_layout->addWidget(font_weight_box);
+  body_layout->addWidget(font_weight_box);
 
   QWidget* color_grid_widget = new QWidget(group);
   color_grid_widget->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
@@ -2496,7 +2517,7 @@ void ConfigDialog::InitializeRendererAppearanceControls() {
   grid->setContentsMargins(0, 0, 0, 0);
   grid->setHorizontalSpacing(8);
   grid->setVerticalSpacing(2);
-  root_layout->addWidget(color_grid_widget);
+  body_layout->addWidget(color_grid_widget);
 
   auto add_color_theme_combo = [](QComboBox* combo, bool allow_follow) {
     if (allow_follow) {
@@ -2588,7 +2609,7 @@ void ConfigDialog::InitializeRendererAppearanceControls() {
     grid->setRowStretch(row, 0);
   }
 
-  root_layout->addSpacing(12);
+  body_layout->addSpacing(12);
 
   QGroupBox* ruby_spacing_box =
       new QGroupBox(tr("Ruby window spacing and gap"), group);
@@ -2631,9 +2652,9 @@ void ConfigDialog::InitializeRendererAppearanceControls() {
       tr("Distance between the ruby window and the text being composed."),
       "rubyWindowCompositionGapSpinBox", 32, 4);
   ruby_spacing_layout->setColumnStretch(0, 1);
-  root_layout->addWidget(ruby_spacing_box);
+  body_layout->addWidget(ruby_spacing_box);
 
-  root_layout->addSpacing(12);
+  body_layout->addSpacing(12);
 
   QWidget* shadow_grid_widget = new QWidget(group);
   shadow_grid_widget->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
@@ -2641,7 +2662,7 @@ void ConfigDialog::InitializeRendererAppearanceControls() {
   shadow_grid->setContentsMargins(0, 0, 0, 0);
   shadow_grid->setHorizontalSpacing(8);
   shadow_grid->setVerticalSpacing(6);
-  root_layout->addWidget(shadow_grid_widget);
+  body_layout->addWidget(shadow_grid_widget);
 
   auto add_shadow_spin = [&](int row, int column, const char* name, int min,
                              int max, const QString& suffix, int value) {
@@ -2816,7 +2837,7 @@ void ConfigDialog::InitializeRendererAppearanceControls() {
     }
     load_layout->addStretch();
     box_layout->addLayout(load_layout);
-    root_layout->addWidget(box);
+    body_layout->addWidget(box);
   };
 
   auto add_ruby_palette_group = [&]() {
@@ -2846,7 +2867,7 @@ void ConfigDialog::InitializeRendererAppearanceControls() {
                     SLOT(LoadRendererCandidateAppearance()));
     load_layout->addStretch();
     box_layout->addLayout(load_layout);
-    root_layout->addWidget(box);
+    body_layout->addWidget(box);
   };
 
   add_candidate_palette_group(tr("Candidate window custom colors"),
@@ -2855,25 +2876,11 @@ void ConfigDialog::InitializeRendererAppearanceControls() {
                               QStringLiteral("suggestWindow"), true);
   add_ruby_palette_group();
 
-  root_layout->activate();
-  const int appearance_height = root_layout->sizeHint().height();
-  group->setGeometry(kRendererAppearanceGroupX, kRendererAppearanceGroupY,
-                     kRendererAppearanceGroupWidth, appearance_height);
-#ifdef _WIN32
-  preeditDisplayColorGroupBox->move(
-      kRendererAppearanceGroupX,
-      group->y() + group->height() + kRendererAppearanceToPreeditMargin);
-  inputSupportScrollAreaWidgetContents->resize(
-      485, preeditDisplayColorGroupBox->y() +
-               preeditDisplayColorGroupBox->height() +
-               kInputSupportBottomMargin);
-#else
-  // The preedit color section is Windows TSF-specific.  On macOS, terminate
-  // the scrollable content immediately after the renderer appearance section
-  // so that hiding the preedit section does not leave a large blank area.
-  inputSupportScrollAreaWidgetContents->resize(
-      485, group->y() + group->height() + kInputSupportBottomMargin);
-#endif  // _WIN32
+  const int insert_index =
+      inputSupportContentLayout->indexOf(preeditDisplayColorGroupBox);
+  inputSupportContentLayout->insertWidget(
+      insert_index >= 0 ? insert_index : inputSupportContentLayout->count(),
+      group);
 }
 
 void ConfigDialog::ConvertFromProto(const config::Config &config) {

--- a/src/gui/config_dialog/config_dialog.ui
+++ b/src/gui/config_dialog/config_dialog.ui
@@ -29,7 +29,6 @@
  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 -->
-
 <ui version="4.0">
  <class>ConfigDialog</class>
  <widget class="QDialog" name="ConfigDialog">
@@ -38,1095 +37,320 @@
     <x>0</x>
     <y>0</y>
     <width>525</width>
-    <height>440</height>
+    <height>575</height>
    </rect>
-  </property>
-  <property name="sizePolicy">
-   <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-    <horstretch>0</horstretch>
-    <verstretch>0</verstretch>
-   </sizepolicy>
-  </property>
-  <property name="minimumSize">
-   <size>
-    <width>525</width>
-    <height>440</height>
-   </size>
-  </property>
-  <property name="maximumSize">
-   <size>
-    <width>525</width>
-    <height>440</height>
-   </size>
   </property>
   <property name="windowTitle">
    <string>[ProductName] Settings</string>
   </property>
-  <widget class="QWidget" name="centralwidget" native="true">
-   <property name="geometry">
-    <rect>
-     <x>0</x>
-     <y>0</y>
-     <width>525</width>
-     <height>440</height>
-    </rect>
+  <layout class="QVBoxLayout" name="centralLayout">
+   <property name="spacing">
+    <number>6</number>
    </property>
-   <widget class="QTabWidget" name="configDialogTabWidget">
-    <property name="geometry">
-     <rect>
-      <x>10</x>
-      <y>10</y>
-      <width>506</width>
-      <height>381</height>
-     </rect>
-    </property>
-    <property name="currentIndex">
-     <number>0</number>
-    </property>
-    <widget class="QWidget" name="basicTab">
-     <attribute name="title">
-      <string>General</string>
-     </attribute>
-     <widget class="QWidget" name="gridLayoutWidget">
-      <property name="geometry">
-       <rect>
-        <x>30</x>
-        <y>30</y>
-        <width>441</width>
-        <height>234</height>
-       </rect>
-      </property>
-      <layout class="QGridLayout" name="gridLayout">
-       <item row="0" column="1">
-        <widget class="QComboBox" name="inputModeComboBox"/>
-       </item>
-       <item row="1" column="1">
-        <widget class="QComboBox" name="punctuationsSettingComboBox"/>
-       </item>
-       <item row="2" column="1">
-        <widget class="QComboBox" name="symbolsSettingComboBox">
-         <property name="enabled">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-       <item row="4" column="1">
-        <widget class="QComboBox" name="spaceCharacterFormComboBox">
-         <property name="enabled">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="0">
-        <widget class="QLabel" name="inputModeLabel">
-         <property name="text">
-          <string>Input mode</string>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="0">
-        <widget class="QLabel" name="PunctuationsSettingLabel">
-         <property name="text">
-          <string>Punctuation style</string>
-         </property>
-        </widget>
-       </item>
-       <item row="2" column="0">
-        <widget class="QLabel" name="symbolsSettingLabel">
-         <property name="text">
-          <string>Symbol style</string>
-         </property>
-        </widget>
-       </item>
-       <item row="4" column="0">
-        <widget class="QLabel" name="spaceInputSettingLabel">
-         <property name="text">
-          <string>Space input style</string>
-         </property>
-        </widget>
-       </item>
-       <item row="5" column="1">
-        <widget class="QComboBox" name="selectionShortcutModeComboBox"/>
-       </item>
-       <item row="5" column="0">
-        <widget class="QLabel" name="selectionShortcutModeLabel">
-         <property name="text">
-          <string>Candidate selection shortcut</string>
-         </property>
-        </widget>
-       </item>
-       <item row="6" column="0">
-        <widget class="QLabel" name="numpadCharacterFormLabel">
-         <property name="text">
-          <string>Input from numpad keys</string>
-         </property>
-        </widget>
-       </item>
-       <item row="6" column="1">
-        <widget class="QComboBox" name="numpadCharacterFormComboBox">
-         <property name="minimumSize">
-          <size>
-           <width>150</width>
-           <height>0</height>
-          </size>
-         </property>
-        </widget>
-       </item>
-       <item row="3" column="0">
-        <widget class="QLabel" name="yenSignLabel">
-         <property name="text">
-          <string>Input from ¥ or backslash key</string>
-         </property>
-        </widget>
-       </item>
-       <item row="3" column="1">
-        <widget class="QComboBox" name="yenSignComboBox"/>
-       </item>
-      </layout>
-     </widget>
-     <widget class="QWidget" name="gridLayoutWidget_2">
-      <property name="geometry">
-       <rect>
-        <x>30</x>
-        <y>280</y>
-        <width>441</width>
-        <height>66</height>
-       </rect>
-      </property>
-      <layout class="QGridLayout" name="gridLayout_2">
-       <item row="0" column="1">
-        <widget class="QComboBox" name="keymapSettingComboBox"/>
-       </item>
-       <item row="0" column="0">
-        <widget class="QLabel" name="keymapSettingLabel">
-         <property name="text">
-          <string>Keymap style</string>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="2">
-        <widget class="QPushButton" name="editKeymapButton">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="text">
-          <string>Customize...</string>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="2">
-        <widget class="QPushButton" name="editRomanTableButton">
-         <property name="text">
-          <string>Customize...</string>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="0">
-        <widget class="QLabel" name="label_11">
-         <property name="text">
-          <string>Romaji table</string>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </widget>
-     <widget class="QWidget" name="horizontalLayoutWidget">
-      <property name="geometry">
-       <rect>
-        <x>20</x>
-        <y>10</y>
-        <width>461</width>
-        <height>21</height>
-       </rect>
-      </property>
-      <layout class="QHBoxLayout" name="horizontalLayout">
-       <item>
-        <widget class="QLabel" name="basicsLabel">
-         <property name="text">
-          <string>Basics</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="Line" name="basicsLine">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="orientation">
-          <enum>Qt::Orientation::Horizontal</enum>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </widget>
-     <widget class="QWidget" name="horizontalLayoutWidget_8">
-      <property name="geometry">
-       <rect>
-        <x>20</x>
-        <y>260</y>
-        <width>461</width>
-        <height>20</height>
-       </rect>
-      </property>
-      <layout class="QHBoxLayout" name="horizontalLayout_11">
-       <item>
-        <widget class="QLabel" name="label_4">
-         <property name="text">
-          <string>Keymap</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="Line" name="line_3">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="orientation">
-          <enum>Qt::Orientation::Horizontal</enum>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </widget>
-    </widget>
-    <widget class="QWidget" name="dictionaryTab">
-     <attribute name="title">
-      <string>Dictionary</string>
-     </attribute>
-     <widget class="QWidget" name="gridLayoutWidget_5">
-      <property name="geometry">
-       <rect>
-        <x>30</x>
-        <y>30</y>
-        <width>441</width>
-        <height>71</height>
-       </rect>
-      </property>
-      <layout class="QGridLayout" name="gridLayout_5">
-       <item row="1" column="1">
-        <widget class="QPushButton" name="clearUserHistoryButton">
-         <property name="text">
-          <string>Clear personalization data</string>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="0">
-        <widget class="QLabel" name="label_7">
-         <property name="text">
-          <string>Adjust conversion based on previous input</string>
-         </property>
-         <property name="wordWrap">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="1">
-        <widget class="QComboBox" name="historyLearningLevelComboBox">
-         <property name="minimumSize">
-          <size>
-           <width>150</width>
-           <height>0</height>
-          </size>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="0">
-        <spacer name="horizontalSpacer_2">
-         <property name="orientation">
-          <enum>Qt::Orientation::Horizontal</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>40</width>
-           <height>20</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-      </layout>
-     </widget>
-     <widget class="QWidget" name="gridLayoutWidget_6">
-      <property name="geometry">
-       <rect>
-        <x>30</x>
-        <y>120</y>
-        <width>441</width>
-        <height>32</height>
-       </rect>
-      </property>
-      <layout class="QGridLayout" name="gridLayout_6">
-       <item row="0" column="1">
-        <spacer name="horizontalSpacer">
-         <property name="orientation">
-          <enum>Qt::Orientation::Horizontal</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>40</width>
-           <height>20</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item row="0" column="2">
-        <widget class="QPushButton" name="editUserDictionaryButton">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="minimumSize">
-          <size>
-           <width>150</width>
-           <height>0</height>
-          </size>
-         </property>
-         <property name="text">
-          <string>Edit user dictionary...</string>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </widget>
-     <widget class="QWidget" name="gridLayoutWidget_3">
-      <property name="geometry">
-       <rect>
-        <x>30</x>
-        <y>220</y>
-        <width>456</width>
-        <height>121</height>
-       </rect>
-      </property>
-      <layout class="QGridLayout" name="gridLayout_3">
-       <item row="0" column="0">
-        <widget class="QCheckBox" name="singleKanjiConversionCheckBox">
-         <property name="text">
-          <string>Single kanji conversion</string>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="0">
-        <widget class="QCheckBox" name="symbolConversionCheckBox">
-         <property name="text">
-          <string>Symbol conversion</string>
-         </property>
-        </widget>
-       </item>
-       <item row="2" column="0">
-        <widget class="QCheckBox" name="emoticonConversionCheckBox">
-         <property name="text">
-          <string>Emoticon conversion</string>
-         </property>
-        </widget>
-       </item>
-       <item row="3" column="0">
-        <widget class="QCheckBox" name="t13nConversionCheckBox">
-         <property name="text">
-          <string>Katakana to English conversion</string>
-         </property>
-        </widget>
-       </item>
-       <item row="4" column="0">
-        <widget class="QCheckBox" name="zipcodeConversionCheckBox">
-         <property name="text">
-          <string>Postal code conversion</string>
-         </property>
-        </widget>
-       </item>
-       <item row="4" column="1">
-        <widget class="QCheckBox" name="spellingCorrectionCheckBox">
-         <property name="text">
-          <string>Spelling correction</string>
-         </property>
-        </widget>
-       </item>
-       <item row="3" column="1">
-        <widget class="QCheckBox" name="calculatorCheckBox">
-         <property name="text">
-          <string>Calculator</string>
-         </property>
-        </widget>
-       </item>
-       <item row="2" column="1">
-        <widget class="QCheckBox" name="numberConversionCheckBox">
-         <property name="text">
-          <string>Special number conversion</string>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="1">
-        <widget class="QCheckBox" name="dateConversionCheckBox">
-         <property name="text">
-          <string>Date/time conversion</string>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="1">
-        <widget class="QCheckBox" name="emojiConversionCheckBox">
-         <property name="text">
-          <string>Emoji conversion</string>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </widget>
-     <widget class="QWidget" name="horizontalLayoutWidget_5">
-      <property name="geometry">
-       <rect>
-        <x>20</x>
-        <y>10</y>
-        <width>461</width>
-        <height>21</height>
-       </rect>
-      </property>
-      <layout class="QHBoxLayout" name="horizontalLayout_8">
-       <item>
-        <widget class="QLabel" name="label">
-         <property name="text">
-          <string>Personalization</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="Line" name="line">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="orientation">
-          <enum>Qt::Orientation::Horizontal</enum>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </widget>
-     <widget class="QWidget" name="horizontalLayoutWidget_11">
-      <property name="geometry">
-       <rect>
-        <x>20</x>
-        <y>100</y>
-        <width>461</width>
-        <height>20</height>
-       </rect>
-      </property>
-      <layout class="QHBoxLayout" name="horizontalLayout_14">
-       <item>
-        <widget class="QLabel" name="label_6">
-         <property name="text">
-          <string>User dictionary</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="Line" name="line_6">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="orientation">
-          <enum>Qt::Orientation::Horizontal</enum>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </widget>
-     <widget class="QWidget" name="horizontalLayoutWidget_7">
-      <property name="geometry">
-       <rect>
-        <x>20</x>
-        <y>200</y>
-        <width>461</width>
-        <height>21</height>
-       </rect>
-      </property>
-      <layout class="QHBoxLayout" name="horizontalLayout_22">
-       <item>
-        <widget class="QLabel" name="specialConversionLabel">
-         <property name="text">
-          <string>Special conversions</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="Line" name="specialConversionLine">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="orientation">
-          <enum>Qt::Orientation::Horizontal</enum>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </widget>
-     <widget class="QWidget" name="horizontalLayoutWidget_21">
-      <property name="geometry">
-       <rect>
-        <x>20</x>
-        <y>150</y>
-        <width>461</width>
-        <height>20</height>
-       </rect>
-      </property>
-      <layout class="QHBoxLayout" name="horizontalLayout_24">
-       <item>
-        <widget class="QLabel" name="label_9">
-         <property name="text">
-          <string>Usage dictionary</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="Line" name="line_9">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="orientation">
-          <enum>Qt::Orientation::Horizontal</enum>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </widget>
-     <widget class="QWidget" name="gridLayoutWidget_8">
-      <property name="geometry">
-       <rect>
-        <x>30</x>
-        <y>170</y>
-        <width>441</width>
-        <height>32</height>
-       </rect>
-      </property>
-      <layout class="QGridLayout" name="gridLayout_12">
-       <item row="0" column="0">
-        <widget class="QCheckBox" name="localUsageDictionaryCheckBox">
-         <property name="text">
-          <string>Homonym dictionary</string>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="1">
-        <spacer name="horizontalSpacer_5">
-         <property name="orientation">
-          <enum>Qt::Orientation::Horizontal</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>20</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-      </layout>
-     </widget>
-    </widget>
-    <widget class="QWidget" name="inputsupport_tab">
-     <attribute name="title">
-      <string>Advanced</string>
-     </attribute>
-     <widget class="QScrollArea" name="inputSupportScrollArea">
-      <property name="geometry">
-       <rect>
-        <x>0</x>
-        <y>0</y>
-        <width>501</width>
-        <height>351</height>
-       </rect>
-      </property>
-      <property name="frameShape">
-       <enum>QFrame::NoFrame</enum>
-      </property>
-      <property name="horizontalScrollBarPolicy">
-       <enum>Qt::ScrollBarAlwaysOff</enum>
-      </property>
-      <property name="widgetResizable">
-       <bool>false</bool>
-      </property>
-      <widget class="QWidget" name="inputSupportScrollAreaWidgetContents">
-       <property name="geometry">
-        <rect>
-         <x>0</x>
-         <y>0</y>
-         <width>485</width>
-         <height>1452</height>
-        </rect>
+   <item>
+    <layout class="QVBoxLayout" name="configDialogTabLayout">
+     <property name="spacing">
+      <number>0</number>
+     </property>
+     <property name="leftMargin">
+      <number>0</number>
+     </property>
+     <property name="topMargin">
+      <number>5</number>
+     </property>
+     <property name="rightMargin">
+      <number>0</number>
+     </property>
+     <property name="bottomMargin">
+      <number>0</number>
+     </property>
+     <item>
+      <widget class="QTabWidget" name="configDialogTabWidget">
+       <property name="currentIndex">
+        <number>0</number>
        </property>
-       <widget class="QWidget" name="horizontalLayoutWidget_2">
-        <property name="geometry">
-         <rect>
-          <x>20</x>
-          <y>10</y>
-          <width>461</width>
-          <height>21</height>
-         </rect>
-        </property>
-        <layout class="QHBoxLayout" name="horizontalLayout_4">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+         <horstretch>10</horstretch>
+         <verstretch>10</verstretch>
+        </sizepolicy>
+       </property>
+       <widget class="QWidget" name="basicTab">
+        <attribute name="title">
+         <string>General</string>
+        </attribute>
+        <layout class="QVBoxLayout" name="basicTabLayout">
+         <property name="spacing">
+          <number>0</number>
+         </property>
          <item>
-          <widget class="QLabel" name="autoCorrectionLable">
-           <property name="text">
-            <string>Input Assistance</string>
+          <widget class="QFrame" name="basicsHeader">
+           <property name="frameShape">
+            <enum>QFrame::Shape::NoFrame</enum>
            </property>
+           <layout class="QHBoxLayout" name="horizontalLayout">
+            <property name="leftMargin">
+             <number>9</number>
+            </property>
+            <property name="topMargin">
+             <number>9</number>
+            </property>
+            <property name="rightMargin">
+             <number>9</number>
+            </property>
+            <property name="bottomMargin">
+             <number>9</number>
+            </property>
+            <property name="spacing">
+             <number>6</number>
+            </property>
+            <item>
+             <widget class="QLabel" name="basicsLabel">
+              <property name="text">
+               <string>Basics</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="Line" name="basicsLine">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="orientation">
+               <enum>Qt::Orientation::Horizontal</enum>
+              </property>
+             </widget>
+            </item>
+           </layout>
           </widget>
          </item>
          <item>
-          <widget class="Line" name="autoCorrectionLine_2">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
+          <widget class="QFrame" name="basicsGroup">
+           <property name="frameShape">
+            <enum>QFrame::Shape::NoFrame</enum>
            </property>
+           <layout class="QGridLayout" name="gridLayout">
+            <property name="verticalSpacing">
+             <number>6</number>
+            </property>
+            <property name="horizontalSpacing">
+             <number>8</number>
+            </property>
+            <property name="leftMargin">
+             <number>24</number>
+            </property>
+            <property name="topMargin">
+             <number>9</number>
+            </property>
+            <property name="rightMargin">
+             <number>24</number>
+            </property>
+            <property name="bottomMargin">
+             <number>9</number>
+            </property>
+            <item row="0" column="1">
+             <widget class="QComboBox" name="inputModeComboBox"/>
+            </item>
+            <item row="1" column="1">
+             <widget class="QComboBox" name="punctuationsSettingComboBox"/>
+            </item>
+            <item row="2" column="1">
+             <widget class="QComboBox" name="symbolsSettingComboBox">
+              <property name="enabled">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item row="4" column="1">
+             <widget class="QComboBox" name="spaceCharacterFormComboBox">
+              <property name="enabled">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="0">
+             <widget class="QLabel" name="inputModeLabel">
+              <property name="text">
+               <string>Input mode</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="0">
+             <widget class="QLabel" name="PunctuationsSettingLabel">
+              <property name="text">
+               <string>Punctuation style</string>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="0">
+             <widget class="QLabel" name="symbolsSettingLabel">
+              <property name="text">
+               <string>Symbol style</string>
+              </property>
+             </widget>
+            </item>
+            <item row="4" column="0">
+             <widget class="QLabel" name="spaceInputSettingLabel">
+              <property name="text">
+               <string>Space input style</string>
+              </property>
+             </widget>
+            </item>
+            <item row="5" column="1">
+             <widget class="QComboBox" name="selectionShortcutModeComboBox"/>
+            </item>
+            <item row="5" column="0">
+             <widget class="QLabel" name="selectionShortcutModeLabel">
+              <property name="text">
+               <string>Candidate selection shortcut</string>
+              </property>
+             </widget>
+            </item>
+            <item row="6" column="0">
+             <widget class="QLabel" name="numpadCharacterFormLabel">
+              <property name="text">
+               <string>Input from numpad keys</string>
+              </property>
+             </widget>
+            </item>
+            <item row="6" column="1">
+             <widget class="QComboBox" name="numpadCharacterFormComboBox">
+              <property name="minimumSize">
+               <size>
+                <width>150</width>
+                <height>0</height>
+               </size>
+              </property>
+             </widget>
+            </item>
+            <item row="3" column="0">
+             <widget class="QLabel" name="yenSignLabel">
+              <property name="text">
+               <string>Input from ¥ or backslash key</string>
+              </property>
+             </widget>
+            </item>
+            <item row="3" column="1">
+             <widget class="QComboBox" name="yenSignComboBox"/>
+            </item>
+           </layout>
+          </widget>
+         </item>
+         <item>
+          <widget class="QFrame" name="keymapHeader">
+           <property name="frameShape">
+            <enum>QFrame::Shape::NoFrame</enum>
+           </property>
+           <layout class="QHBoxLayout" name="horizontalLayout_11">
+            <property name="leftMargin">
+             <number>9</number>
+            </property>
+            <property name="topMargin">
+             <number>9</number>
+            </property>
+            <property name="rightMargin">
+             <number>9</number>
+            </property>
+            <property name="bottomMargin">
+             <number>9</number>
+            </property>
+            <property name="spacing">
+             <number>6</number>
+            </property>
+            <item>
+             <widget class="QLabel" name="label_4">
+              <property name="text">
+               <string>Keymap</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="Line" name="line_3">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="orientation">
+               <enum>Qt::Orientation::Horizontal</enum>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+         </item>
+         <item>
+          <widget class="QFrame" name="keymapGroup">
+           <property name="frameShape">
+            <enum>QFrame::Shape::NoFrame</enum>
+           </property>
+           <layout class="QGridLayout" name="gridLayout_2">
+            <property name="verticalSpacing">
+             <number>6</number>
+            </property>
+            <property name="horizontalSpacing">
+             <number>8</number>
+            </property>
+            <property name="leftMargin">
+             <number>24</number>
+            </property>
+            <property name="topMargin">
+             <number>9</number>
+            </property>
+            <property name="rightMargin">
+             <number>24</number>
+            </property>
+            <property name="bottomMargin">
+             <number>9</number>
+            </property>
+            <item row="0" column="1">
+             <widget class="QComboBox" name="keymapSettingComboBox"/>
+            </item>
+            <item row="0" column="0">
+             <widget class="QLabel" name="keymapSettingLabel">
+              <property name="text">
+               <string>Keymap style</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="2">
+             <widget class="QPushButton" name="editKeymapButton">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string>Customize...</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="2">
+             <widget class="QPushButton" name="editRomanTableButton">
+              <property name="text">
+               <string>Customize...</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="0">
+             <widget class="QLabel" name="label_11">
+              <property name="text">
+               <string>Romaji table</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+         </item>
+         <item>
+          <spacer name="basicTabBottomSpacer">
            <property name="orientation">
-            <enum>Qt::Orientation::Horizontal</enum>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </widget>
-       <widget class="QWidget" name="gridLayoutWidget_9">
-        <property name="geometry">
-         <rect>
-          <x>30</x>
-          <y>40</y>
-          <width>441</width>
-          <height>892</height>
-         </rect>
-        </property>
-        <layout class="QGridLayout" name="gridLayout_9">
-         <item row="10" column="0" colspan="8">
-          <widget class="QWidget" name="liveConversionSectionWidget">
-           <property name="minimumSize">
-            <size>
-             <width>0</width>
-             <height>60</height>
-            </size>
-           </property>
-           <layout class="QHBoxLayout" name="horizontalLayout_liveConversionSection">
-            <property name="leftMargin">
-             <number>0</number>
-            </property>
-            <property name="topMargin">
-             <number>20</number>
-            </property>
-            <property name="rightMargin">
-             <number>0</number>
-            </property>
-            <property name="bottomMargin">
-             <number>16</number>
-            </property>
-            <item>
-             <widget class="QLabel" name="liveConversionSectionLabel">
-              <property name="text">
-               <string>ライブ変換</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="Line" name="liveConversionSectionLine">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="orientation">
-               <enum>Qt::Orientation::Horizontal</enum>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </widget>
-         </item>
-
-         <item row="15" column="0" colspan="8">
-          <widget class="QWidget" name="zenzLiveCorrectionSectionWidget">
-           <property name="minimumSize">
-            <size>
-             <width>0</width>
-             <height>60</height>
-            </size>
-           </property>
-           <layout class="QHBoxLayout" name="horizontalLayout_zenzLiveCorrectionSection">
-            <property name="leftMargin">
-             <number>0</number>
-            </property>
-            <property name="topMargin">
-             <number>20</number>
-            </property>
-            <property name="rightMargin">
-             <number>0</number>
-            </property>
-            <property name="bottomMargin">
-             <number>16</number>
-            </property>
-            <item>
-             <widget class="QLabel" name="zenzLiveCorrectionSectionLabel">
-              <property name="text">
-               <string>Zenz ライブ補正</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="Line" name="zenzLiveCorrectionSectionLine">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="orientation">
-               <enum>Qt::Orientation::Horizontal</enum>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </widget>
-         </item>
-
-         <item row="19" column="0" colspan="8">
-          <widget class="QWidget" name="zenzConditionFieldsSectionWidget">
-           <property name="minimumSize">
-            <size>
-             <width>0</width>
-             <height>60</height>
-            </size>
-           </property>
-           <layout class="QHBoxLayout" name="horizontalLayout_zenzConditionFieldsSection">
-            <property name="leftMargin">
-             <number>0</number>
-            </property>
-            <property name="topMargin">
-             <number>20</number>
-            </property>
-            <property name="rightMargin">
-             <number>0</number>
-            </property>
-            <property name="bottomMargin">
-             <number>16</number>
-            </property>
-            <item>
-             <widget class="QLabel" name="zenzConditionFieldsSectionLabel">
-              <property name="text">
-               <string>Zenz 条件フィールド</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="Line" name="zenzConditionFieldsSectionLine">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="orientation">
-               <enum>Qt::Orientation::Horizontal</enum>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </widget>
-         </item>
-
-         <item row="26" column="0" colspan="8">
-          <widget class="QWidget" name="zenzFeedbackLearningSectionWidget">
-           <property name="minimumSize">
-            <size>
-             <width>0</width>
-             <height>60</height>
-            </size>
-           </property>
-           <layout class="QHBoxLayout" name="horizontalLayout_zenzFeedbackLearningSection">
-            <property name="leftMargin">
-             <number>0</number>
-            </property>
-            <property name="topMargin">
-             <number>20</number>
-            </property>
-            <property name="rightMargin">
-             <number>0</number>
-            </property>
-            <property name="bottomMargin">
-             <number>16</number>
-            </property>
-            <item>
-             <widget class="QLabel" name="zenzFeedbackLearningSectionLabel">
-              <property name="text">
-               <string>Zenz 学習</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="Line" name="zenzFeedbackLearningSectionLine">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="orientation">
-               <enum>Qt::Orientation::Horizontal</enum>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </widget>
-         </item>
-         <item row="8" column="0" colspan="8">
-          <widget class="QCheckBox" name="autoSwitchCompositionMode">
-           <property name="text">
-            <string>Automatically switch to halfwidth</string>
-           </property>
-          </widget>
-         </item>
-
-         <item row="9" column="0" colspan="8">
-          <widget class="QCheckBox" name="showCandidateWindowOnInitialConversionCheckBox">
-           <property name="toolTip">
-            <string>When live conversion is off, the first conversion action opens the candidate window without advancing to the second candidate.</string>
-           </property>
-           <property name="text">
-            <string>Open candidate window on first conversion action (live conversion off)</string>
-           </property>
-          </widget>
-         </item>
-
-         <item row="11" column="0" colspan="8">
-          <widget class="QCheckBox" name="liveConversionCheckBox">
-           <property name="toolTip">
-            <string>入力中の未確定文字列を、文字が入力されるたびに自動で変換します。</string>
-           </property>
-           <property name="text">
-            <string>ライブ変換を有効にする</string>
-           </property>
-          </widget>
-         </item>
-
-         <item row="12" column="0" colspan="3">
-          <widget class="QLabel" name="liveConversionDelayLabel">
-           <property name="toolTip">
-            <string>文字入力後、ライブ変換を開始するまでの待ち時間です。0 ms にすると即時変換します。</string>
-           </property>
-           <property name="text">
-            <string>ライブ変換の遅延</string>
-           </property>
-          </widget>
-         </item>
-         <item row="12" column="3" colspan="5">
-          <widget class="QSpinBox" name="liveConversionDelaySpinBox">
-           <property name="toolTip">
-            <string>文字入力後、ライブ変換を開始するまでの待ち時間です。0 ms にすると即時変換します。</string>
-           </property>
-           <property name="minimum">
-            <number>0</number>
-           </property>
-           <property name="maximum">
-            <number>1000</number>
-           </property>
-           <property name="singleStep">
-            <number>5</number>
-           </property>
-           <property name="value">
-            <number>228</number>
-           </property>
-           <property name="suffix">
-            <string> ms</string>
-           </property>
-           <property name="specialValueText">
-            <string>即時</string>
-           </property>
-          </widget>
-         </item>
-
-         <item row="13" column="0" colspan="3">
-          <widget class="QLabel" name="liveConversionMinKeyLengthLabel">
-           <property name="toolTip">
-            <string>ライブ変換を開始する最小文字数です。1 にすると 1 文字目からライブ変換します。</string>
-           </property>
-           <property name="text">
-            <string>ライブ変換開始の最小文字数</string>
-           </property>
-          </widget>
-         </item>
-         <item row="13" column="3" colspan="5">
-          <widget class="QSpinBox" name="liveConversionMinKeyLengthSpinBox">
-           <property name="toolTip">
-            <string>ライブ変換を開始する最小文字数です。短くすると変換開始は早くなりますが、1 文字の助詞などが漢字化されやすくなります。</string>
-           </property>
-           <property name="minimum">
-            <number>1</number>
-           </property>
-           <property name="maximum">
-            <number>20</number>
-           </property>
-           <property name="singleStep">
-            <number>1</number>
-           </property>
-           <property name="value">
-            <number>2</number>
-           </property>
-           <property name="suffix">
-            <string> 文字</string>
-           </property>
-          </widget>
-         </item>
-
-         <item row="14" column="0" colspan="8">
-          <widget class="QCheckBox" name="showLiveConversionRubyWindow">
-           <property name="toolTip">
-            <string>Shows the typed reading near the candidate window during live conversion.</string>
-           </property>
-           <property name="text">
-            <string>Show ruby window during live conversion</string>
-           </property>
-          </widget>
-         </item>
-
-         <item row="0" column="0" colspan="3">
-          <widget class="QCheckBox" name="useAutoConversion">
-           <property name="text">
-            <string>Convert at punctuations</string>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="3">
-          <widget class="QCheckBox" name="kutenCheckBox">
-           <property name="maximumSize">
-            <size>
-             <width>45</width>
-             <height>16777215</height>
-            </size>
-           </property>
-           <property name="text">
-            <string>。</string>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="4">
-          <widget class="QCheckBox" name="toutenCheckBox">
-           <property name="maximumSize">
-            <size>
-             <width>45</width>
-             <height>16777215</height>
-            </size>
-           </property>
-           <property name="text">
-            <string>、</string>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="5">
-          <widget class="QCheckBox" name="questionMarkCheckBox">
-           <property name="maximumSize">
-            <size>
-             <width>45</width>
-             <height>16777215</height>
-            </size>
-           </property>
-           <property name="text">
-            <string>?</string>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="6">
-          <widget class="QCheckBox" name="exclamationMarkCheckBox">
-           <property name="maximumSize">
-            <size>
-             <width>45</width>
-             <height>16777215</height>
-            </size>
-           </property>
-           <property name="text">
-            <string>!</string>
-           </property>
-          </widget>
-         </item>
-
-         <item row="1" column="0" colspan="3">
-          <widget class="QCheckBox" name="useDirectCommit">
-           <property name="text">
-            <string>句読点・記号の単打確定を有効にする</string>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="3">
-          <widget class="QCheckBox" name="directCommitKutenCheckBox">
-           <property name="maximumSize">
-            <size>
-             <width>45</width>
-             <height>16777215</height>
-            </size>
-           </property>
-           <property name="text">
-            <string>。</string>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="4">
-          <widget class="QCheckBox" name="directCommitToutenCheckBox">
-           <property name="maximumSize">
-            <size>
-             <width>45</width>
-             <height>16777215</height>
-            </size>
-           </property>
-           <property name="text">
-            <string>、</string>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="5">
-          <widget class="QCheckBox" name="directCommitQuestionMarkCheckBox">
-           <property name="maximumSize">
-            <size>
-             <width>45</width>
-             <height>16777215</height>
-            </size>
-           </property>
-           <property name="text">
-            <string>?</string>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="6">
-          <widget class="QCheckBox" name="directCommitExclamationMarkCheckBox">
-           <property name="maximumSize">
-            <size>
-             <width>45</width>
-             <height>16777215</height>
-            </size>
-           </property>
-           <property name="text">
-            <string>!</string>
-           </property>
-          </widget>
-         </item>
-
-         <item row="2" column="0" colspan="3">
-          <spacer name="horizontalSpacer_directCommit">
-           <property name="orientation">
-            <enum>Qt::Orientation::Horizontal</enum>
+            <enum>Qt::Orientation::Vertical</enum>
            </property>
            <property name="sizeHint" stdset="0">
             <size>
@@ -1136,1191 +360,1509 @@
            </property>
           </spacer>
          </item>
-         <item row="2" column="3">
-          <widget class="QCheckBox" name="directCommitOpenParenthesisCheckBox">
-           <property name="maximumSize">
+        </layout>
+       </widget>
+       <widget class="QWidget" name="dictionaryTab">
+        <attribute name="title">
+         <string>Dictionary</string>
+        </attribute>
+        <layout class="QVBoxLayout" name="dictionaryTabLayout">
+         <property name="spacing">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QFrame" name="personalizationHeader">
+           <property name="frameShape">
+            <enum>QFrame::Shape::NoFrame</enum>
+           </property>
+           <layout class="QHBoxLayout" name="horizontalLayout_8">
+            <property name="leftMargin">
+             <number>9</number>
+            </property>
+            <property name="topMargin">
+             <number>9</number>
+            </property>
+            <property name="rightMargin">
+             <number>9</number>
+            </property>
+            <property name="bottomMargin">
+             <number>9</number>
+            </property>
+            <property name="spacing">
+             <number>6</number>
+            </property>
+            <item>
+             <widget class="QLabel" name="label">
+              <property name="text">
+               <string>Personalization</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="Line" name="line">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="orientation">
+               <enum>Qt::Orientation::Horizontal</enum>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+         </item>
+         <item>
+          <widget class="QFrame" name="personalizationGroup">
+           <property name="frameShape">
+            <enum>QFrame::Shape::NoFrame</enum>
+           </property>
+           <layout class="QGridLayout" name="gridLayout_5">
+            <property name="verticalSpacing">
+             <number>6</number>
+            </property>
+            <property name="horizontalSpacing">
+             <number>8</number>
+            </property>
+            <property name="leftMargin">
+             <number>24</number>
+            </property>
+            <property name="topMargin">
+             <number>9</number>
+            </property>
+            <property name="rightMargin">
+             <number>24</number>
+            </property>
+            <property name="bottomMargin">
+             <number>9</number>
+            </property>
+            <item row="1" column="1">
+             <widget class="QPushButton" name="clearUserHistoryButton">
+              <property name="text">
+               <string>Clear personalization data</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="0">
+             <widget class="QLabel" name="label_7">
+              <property name="text">
+               <string>Adjust conversion based on previous input</string>
+              </property>
+              <property name="wordWrap">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="1">
+             <widget class="QComboBox" name="historyLearningLevelComboBox">
+              <property name="minimumSize">
+               <size>
+                <width>150</width>
+                <height>0</height>
+               </size>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="0">
+             <spacer name="horizontalSpacer_2">
+              <property name="orientation">
+               <enum>Qt::Orientation::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
+          </widget>
+         </item>
+         <item>
+          <widget class="QFrame" name="userDictionaryHeader">
+           <property name="frameShape">
+            <enum>QFrame::Shape::NoFrame</enum>
+           </property>
+           <layout class="QHBoxLayout" name="horizontalLayout_14">
+            <property name="leftMargin">
+             <number>9</number>
+            </property>
+            <property name="topMargin">
+             <number>9</number>
+            </property>
+            <property name="rightMargin">
+             <number>9</number>
+            </property>
+            <property name="bottomMargin">
+             <number>9</number>
+            </property>
+            <property name="spacing">
+             <number>6</number>
+            </property>
+            <item>
+             <widget class="QLabel" name="label_6">
+              <property name="text">
+               <string>User dictionary</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="Line" name="line_6">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="orientation">
+               <enum>Qt::Orientation::Horizontal</enum>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+         </item>
+         <item>
+          <widget class="QFrame" name="userDictionaryGroup">
+           <property name="frameShape">
+            <enum>QFrame::Shape::NoFrame</enum>
+           </property>
+           <layout class="QGridLayout" name="gridLayout_6">
+            <property name="verticalSpacing">
+             <number>6</number>
+            </property>
+            <property name="horizontalSpacing">
+             <number>8</number>
+            </property>
+            <property name="leftMargin">
+             <number>24</number>
+            </property>
+            <property name="topMargin">
+             <number>9</number>
+            </property>
+            <property name="rightMargin">
+             <number>24</number>
+            </property>
+            <property name="bottomMargin">
+             <number>9</number>
+            </property>
+            <item row="0" column="1">
+             <spacer name="horizontalSpacer">
+              <property name="orientation">
+               <enum>Qt::Orientation::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item row="0" column="2">
+             <widget class="QPushButton" name="editUserDictionaryButton">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="minimumSize">
+               <size>
+                <width>150</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="text">
+               <string>Edit user dictionary...</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+         </item>
+         <item>
+          <widget class="QFrame" name="usageDictionaryHeader">
+           <property name="frameShape">
+            <enum>QFrame::Shape::NoFrame</enum>
+           </property>
+           <layout class="QHBoxLayout" name="horizontalLayout_24">
+            <property name="leftMargin">
+             <number>9</number>
+            </property>
+            <property name="topMargin">
+             <number>9</number>
+            </property>
+            <property name="rightMargin">
+             <number>9</number>
+            </property>
+            <property name="bottomMargin">
+             <number>9</number>
+            </property>
+            <property name="spacing">
+             <number>6</number>
+            </property>
+            <item>
+             <widget class="QLabel" name="label_9">
+              <property name="text">
+               <string>Usage dictionary</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="Line" name="line_9">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="orientation">
+               <enum>Qt::Orientation::Horizontal</enum>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+         </item>
+         <item>
+          <widget class="QFrame" name="usageDictionaryGroup">
+           <property name="frameShape">
+            <enum>QFrame::Shape::NoFrame</enum>
+           </property>
+           <layout class="QGridLayout" name="gridLayout_12">
+            <property name="verticalSpacing">
+             <number>6</number>
+            </property>
+            <property name="horizontalSpacing">
+             <number>8</number>
+            </property>
+            <property name="leftMargin">
+             <number>24</number>
+            </property>
+            <property name="topMargin">
+             <number>9</number>
+            </property>
+            <property name="rightMargin">
+             <number>24</number>
+            </property>
+            <property name="bottomMargin">
+             <number>9</number>
+            </property>
+            <item row="0" column="0">
+             <widget class="QCheckBox" name="localUsageDictionaryCheckBox">
+              <property name="text">
+               <string>Homonym dictionary</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="1">
+             <spacer name="horizontalSpacer_5">
+              <property name="orientation">
+               <enum>Qt::Orientation::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>20</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
+          </widget>
+         </item>
+         <item>
+          <widget class="QFrame" name="specialConversionsHeader">
+           <property name="frameShape">
+            <enum>QFrame::Shape::NoFrame</enum>
+           </property>
+           <layout class="QHBoxLayout" name="horizontalLayout_22">
+            <property name="leftMargin">
+             <number>9</number>
+            </property>
+            <property name="topMargin">
+             <number>9</number>
+            </property>
+            <property name="rightMargin">
+             <number>9</number>
+            </property>
+            <property name="bottomMargin">
+             <number>9</number>
+            </property>
+            <property name="spacing">
+             <number>6</number>
+            </property>
+            <item>
+             <widget class="QLabel" name="specialConversionLabel">
+              <property name="text">
+               <string>Special conversions</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="Line" name="specialConversionLine">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="orientation">
+               <enum>Qt::Orientation::Horizontal</enum>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+         </item>
+         <item>
+          <widget class="QFrame" name="specialConversionsGroup">
+           <property name="frameShape">
+            <enum>QFrame::Shape::NoFrame</enum>
+           </property>
+           <layout class="QGridLayout" name="gridLayout_3">
+            <property name="verticalSpacing">
+             <number>6</number>
+            </property>
+            <property name="horizontalSpacing">
+             <number>8</number>
+            </property>
+            <property name="leftMargin">
+             <number>24</number>
+            </property>
+            <property name="topMargin">
+             <number>9</number>
+            </property>
+            <property name="rightMargin">
+             <number>24</number>
+            </property>
+            <property name="bottomMargin">
+             <number>9</number>
+            </property>
+            <item row="0" column="0">
+             <widget class="QCheckBox" name="singleKanjiConversionCheckBox">
+              <property name="text">
+               <string>Single kanji conversion</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="0">
+             <widget class="QCheckBox" name="symbolConversionCheckBox">
+              <property name="text">
+               <string>Symbol conversion</string>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="0">
+             <widget class="QCheckBox" name="emoticonConversionCheckBox">
+              <property name="text">
+               <string>Emoticon conversion</string>
+              </property>
+             </widget>
+            </item>
+            <item row="3" column="0">
+             <widget class="QCheckBox" name="t13nConversionCheckBox">
+              <property name="text">
+               <string>Katakana to English conversion</string>
+              </property>
+             </widget>
+            </item>
+            <item row="4" column="0">
+             <widget class="QCheckBox" name="zipcodeConversionCheckBox">
+              <property name="text">
+               <string>Postal code conversion</string>
+              </property>
+             </widget>
+            </item>
+            <item row="4" column="1">
+             <widget class="QCheckBox" name="spellingCorrectionCheckBox">
+              <property name="text">
+               <string>Spelling correction</string>
+              </property>
+             </widget>
+            </item>
+            <item row="3" column="1">
+             <widget class="QCheckBox" name="calculatorCheckBox">
+              <property name="text">
+               <string>Calculator</string>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="1">
+             <widget class="QCheckBox" name="numberConversionCheckBox">
+              <property name="text">
+               <string>Special number conversion</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="1">
+             <widget class="QCheckBox" name="dateConversionCheckBox">
+              <property name="text">
+               <string>Date/time conversion</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="1">
+             <widget class="QCheckBox" name="emojiConversionCheckBox">
+              <property name="text">
+               <string>Emoji conversion</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+         </item>
+         <item>
+          <spacer name="dictionaryTabBottomSpacer">
+           <property name="orientation">
+            <enum>Qt::Orientation::Vertical</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
             <size>
-             <width>45</width>
-             <height>16777215</height>
+             <width>20</width>
+             <height>20</height>
             </size>
            </property>
-           <property name="text">
-            <string>（</string>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="4">
-          <widget class="QCheckBox" name="directCommitCloseParenthesisCheckBox">
-           <property name="maximumSize">
-            <size>
-             <width>45</width>
-             <height>16777215</height>
-            </size>
-           </property>
-           <property name="text">
-            <string>）</string>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="5">
-          <widget class="QCheckBox" name="directCommitOpenBracketCheckBox">
-           <property name="maximumSize">
-            <size>
-             <width>45</width>
-             <height>16777215</height>
-            </size>
-           </property>
-           <property name="text">
-            <string>「</string>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="6">
-          <widget class="QCheckBox" name="directCommitCloseBracketCheckBox">
-           <property name="maximumSize">
-            <size>
-             <width>45</width>
-             <height>16777215</height>
-            </size>
-           </property>
-           <property name="text">
-            <string>」</string>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="7">
-          <widget class="QCheckBox" name="directCommitMiddleDotCheckBox">
-           <property name="maximumSize">
-            <size>
-             <width>45</width>
-             <height>16777215</height>
-            </size>
-           </property>
-           <property name="text">
-            <string>・</string>
-           </property>
-          </widget>
-         </item>
-
-         <item row="3" column="0" colspan="3">
-          <widget class="QLabel" name="autoCorrectionLable_3">
-           <property name="text">
-            <string>Shift key mode switch</string>
-           </property>
-          </widget>
-         </item>
-         <item row="3" column="3" colspan="5">
-          <widget class="QComboBox" name="shiftKeyModeSwitchComboBox">
-           <property name="minimumSize">
-            <size>
-             <width>150</width>
-             <height>0</height>
-            </size>
-           </property>
-          </widget>
-         </item>
-
-         <item row="4" column="0" colspan="8">
-          <widget class="QCheckBox" name="useJapaneseLayout">
-           <property name="enabled">
-            <bool>true</bool>
-           </property>
-           <property name="text">
-            <string>Always use Japanese keyboard layout for Japanese input</string>
-           </property>
-          </widget>
-         </item>
-         <item row="5" column="0" colspan="8">
-          <widget class="QCheckBox" name="useModeIndicator">
-           <property name="enabled">
-            <bool>true</bool>
-           </property>
-           <property name="text">
-            <string>Show input mode indicator near the cursor</string>
-           </property>
-          </widget>
-         </item>
-         <item row="6" column="0" colspan="8">
-          <widget class="QCheckBox" name="useDarkModeCandidateWindow">
-           <property name="enabled">
-            <bool>true</bool>
-           </property>
-           <property name="text">
-            <string>Use dark mode for candidate and ruby windows</string>
-           </property>
-          </widget>
-         </item>
-
-         <item row="7" column="0" colspan="3">
-          <widget class="QLabel" name="candidateRubyFontLabel">
-           <property name="text">
-            <string>Candidate/ruby font</string>
-           </property>
-          </widget>
-         </item>
-
-         <item row="7" column="3" colspan="5">
-          <widget class="QComboBox" name="candidateRubyFontComboBox">
-           <property name="minimumSize">
-            <size>
-             <width>180</width>
-             <height>0</height>
-            </size>
-           </property>
-           <property name="maximumSize">
-            <size>
-             <width>280</width>
-             <height>16777215</height>
-            </size>
-           </property>
-           <property name="sizeAdjustPolicy">
-            <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
-           </property>
-           <property name="minimumContentsLength">
-            <number>18</number>
-           </property>
-          </widget>
-         </item>
-
-         <item row="16" column="0" colspan="8">
-          <widget class="QCheckBox" name="zenzLiveCorrectionCheckBox">
-           <property name="toolTip">
-            <string>ライブ変換結果に対して、ローカルの Zenz モデルで文脈補正を行います。</string>
-           </property>
-           <property name="text">
-            <string>Zenz ライブ補正を有効にする</string>
-           </property>
-          </widget>
-         </item>
-
-         <item row="17" column="0" colspan="3">
-          <widget class="QLabel" name="zenzLiveCorrectionDelayLabel">
-           <property name="toolTip">
-            <string>ライブ変換後、Zenz 補正を開始するまでの待ち時間です。</string>
-           </property>
-           <property name="text">
-            <string>Zenz 補正開始の遅延</string>
-           </property>
-          </widget>
-         </item>
-         <item row="17" column="3" colspan="5">
-          <widget class="QSpinBox" name="zenzLiveCorrectionDelaySpinBox">
-           <property name="toolTip">
-            <string>ライブ変換後、Zenz 補正を開始するまでの待ち時間です。0 ms にすると即時補正します。</string>
-           </property>
-           <property name="minimum">
-            <number>0</number>
-           </property>
-           <property name="maximum">
-            <number>5000</number>
-           </property>
-           <property name="singleStep">
-            <number>100</number>
-           </property>
-           <property name="value">
-            <number>1000</number>
-           </property>
-           <property name="suffix">
-            <string> ms</string>
-           </property>
-           <property name="specialValueText">
-            <string>即時</string>
-           </property>
-          </widget>
-         </item>
-         <item row="18" column="0" colspan="3">
-          <widget class="QLabel" name="zenzLiveCorrectionMinKeyLengthLabel">
-           <property name="toolTip">
-            <string>Zenz 補正を開始する最小文字数です。短くすると補正機会は増えますが、誤補正も増える可能性があります。</string>
-           </property>
-           <property name="text">
-            <string>Zenz 補正開始の最小文字数</string>
-           </property>
-          </widget>
-         </item>
-         <item row="18" column="3" colspan="5">
-          <widget class="QSpinBox" name="zenzLiveCorrectionMinKeyLengthSpinBox">
-           <property name="toolTip">
-            <string>Zenz 補正を開始する最小文字数です。</string>
-           </property>
-           <property name="minimum">
-            <number>2</number>
-           </property>
-           <property name="maximum">
-            <number>20</number>
-           </property>
-           <property name="singleStep">
-            <number>1</number>
-           </property>
-           <property name="value">
-            <number>2</number>
-           </property>
-           <property name="suffix">
-            <string> 文字</string>
-           </property>
-          </widget>
-         </item>
-
-
-         <item row="20" column="0" colspan="3">
-          <widget class="QLabel" name="zenzLiveCorrectionProfileLabel">
-           <property name="toolTip">
-            <string>U+EE03 profile として Zenzai v3/v3.2 のプロンプトに渡します。</string>
-           </property>
-           <property name="text">
-            <string>Zenz profile</string>
-           </property>
-          </widget>
-         </item>
-         <item row="20" column="3" colspan="5">
-          <widget class="QLineEdit" name="zenzLiveCorrectionProfileLineEdit">
-           <property name="toolTip">
-            <string>例: 技術文書を書く日本語ユーザー。空欄なら送信しません。</string>
-           </property>
-           <property name="maxLength">
-            <number>128</number>
-           </property>
-           <property name="placeholderText">
-            <string>例: 技術文書を書く日本語ユーザー</string>
-           </property>
-          </widget>
-         </item>
-
-         <item row="21" column="0" colspan="3">
-          <widget class="QLabel" name="zenzLiveCorrectionTopicLabel">
-           <property name="toolTip">
-            <string>U+EE04 topic として Zenzai v3/v3.2 のプロンプトに渡します。experimental です。</string>
-           </property>
-           <property name="text">
-            <string>Zenz topic</string>
-           </property>
-          </widget>
-         </item>
-         <item row="21" column="3" colspan="5">
-          <widget class="QLineEdit" name="zenzLiveCorrectionTopicLineEdit">
-           <property name="toolTip">
-            <string>例: Mozc、Rust、会計、法律。空欄なら送信しません。</string>
-           </property>
-           <property name="maxLength">
-            <number>128</number>
-           </property>
-           <property name="placeholderText">
-            <string>例: Mozc</string>
-           </property>
-          </widget>
-         </item>
-
-         <item row="22" column="0" colspan="3">
-          <widget class="QLabel" name="zenzLiveCorrectionStyleLabel">
-           <property name="toolTip">
-            <string>U+EE05 style として Zenzai v3/v3.2 のプロンプトに渡します。experimental です。</string>
-           </property>
-           <property name="text">
-            <string>Zenz style</string>
-           </property>
-          </widget>
-         </item>
-         <item row="22" column="3" colspan="5">
-          <widget class="QLineEdit" name="zenzLiveCorrectionStyleLineEdit">
-           <property name="toolTip">
-            <string>例: 技術文書、ビジネス、口語、常体。空欄なら送信しません。</string>
-           </property>
-           <property name="maxLength">
-            <number>128</number>
-           </property>
-           <property name="placeholderText">
-            <string>例: 技術文書</string>
-           </property>
-          </widget>
-         </item>
-
-         <item row="23" column="0" colspan="3">
-          <widget class="QLabel" name="zenzLiveCorrectionSettingsLabel">
-           <property name="toolTip">
-            <string>U+EE06 settings として Zenzai v3/v3.2 のプロンプトに渡します。experimental です。</string>
-           </property>
-           <property name="text">
-            <string>Zenz settings</string>
-           </property>
-          </widget>
-         </item>
-         <item row="23" column="3" colspan="5">
-          <widget class="QLineEdit" name="zenzLiveCorrectionSettingsLineEdit">
-           <property name="toolTip">
-            <string>例: 専門用語を優先。空欄なら送信しません。</string>
-           </property>
-           <property name="maxLength">
-            <number>128</number>
-           </property>
-           <property name="placeholderText">
-            <string>例: 専門用語を優先</string>
-           </property>
-          </widget>
-         </item>
-
-         <item row="24" column="0" colspan="8">
-          <widget class="QCheckBox" name="zenzLiveCorrectionRightContextCheckBox">
-           <property name="toolTip">
-            <string>クライアントからカーソル右側テキストが渡された場合、U+EE07 right context として Zenzai v3.2 のプロンプトに含めます。</string>
-           </property>
-           <property name="text">
-            <string>Zenz 右文脈を使用する</string>
-           </property>
-          </widget>
-         </item>
-
-         <item row="25" column="0" colspan="3">
-          <widget class="QLabel" name="zenzLiveCorrectionRightContextLengthLabel">
-           <property name="toolTip">
-            <string>Zenz 右文脈として使う最大文字数です。</string>
-           </property>
-           <property name="text">
-            <string>Zenz 右文脈長</string>
-           </property>
-          </widget>
-         </item>
-         <item row="25" column="3" colspan="5">
-          <widget class="QSpinBox" name="zenzLiveCorrectionRightContextLengthSpinBox">
-           <property name="toolTip">
-            <string>カーソル右側テキストが取得できる場合だけ使われます。0 文字なら送信しません。</string>
-           </property>
-           <property name="minimum">
-            <number>0</number>
-           </property>
-           <property name="maximum">
-            <number>128</number>
-           </property>
-           <property name="singleStep">
-            <number>1</number>
-           </property>
-           <property name="value">
-            <number>24</number>
-           </property>
-           <property name="suffix">
-            <string> 文字</string>
-           </property>
-           <property name="specialValueText">
-            <string>使わない</string>
-           </property>
-          </widget>
-         </item>
-         <item row="27" column="0" colspan="8">
-          <widget class="QCheckBox" name="zenzFeedbackLearningCheckBox">
-           <property name="toolTip">
-            <string>Zenz 補正結果の採用/却下をローカルに保存し、次回以降の補正や候補順位に反映します。確定した内容は、通常の変換履歴にも反映される場合があります。</string>
-           </property>
-           <property name="text">
-            <string>Zenz 補正結果をローカル学習する</string>
-           </property>
-          </widget>
-         </item>
-
-         <item row="28" column="0" colspan="8">
-          <widget class="QCheckBox" name="zenzFeedbackAutoBlockCheckBox">
-           <property name="toolTip">
-            <string>Zenz 補正を通常変換などで別の文字列に確定した回数が指定回数に達した場合、同じ読み・同じ文脈クラス・同じ補正結果を次回以降の Zenz 補正として表示しないようにします。通常の Mozc 候補から削除する機能ではありません。</string>
-           </property>
-           <property name="text">
-            <string>Zenz 補正と異なる結果で確定した場合、その補正を自動ブロックする</string>
-           </property>
-          </widget>
-         </item>
-
-         <item row="29" column="0" colspan="3">
-          <widget class="QLabel" name="zenzFeedbackAutoBlockRejectThresholdLabel">
-           <property name="toolTip">
-            <string>同じ Zenz 補正を何回異なる結果で確定したら自動ブロックするかを指定します。設定変更は既存の Zenz 学習データにも動的に反映されます。</string>
-           </property>
-           <property name="text">
-            <string>自動ブロックまでの拒否回数</string>
-           </property>
-          </widget>
-         </item>
-         <item row="29" column="3" colspan="5">
-          <widget class="QSpinBox" name="zenzFeedbackAutoBlockRejectThresholdSpinBox">
-           <property name="toolTip">
-            <string>同じ Zenz 補正を何回異なる結果で確定したら自動ブロックするかを指定します。</string>
-           </property>
-           <property name="minimum">
-            <number>1</number>
-           </property>
-           <property name="maximum">
-            <number>999</number>
-           </property>
-           <property name="singleStep">
-            <number>1</number>
-           </property>
-           <property name="value">
-            <number>3</number>
-           </property>
-           <property name="suffix">
-            <string> 回</string>
-           </property>
-          </widget>
-         </item>
-
-         <item row="30" column="0" colspan="3">
-          <widget class="QLabel" name="zenzFeedbackDataLabel">
-           <property name="text">
-            <string>Zenz 学習データ</string>
-           </property>
-          </widget>
-         </item>
-         <item row="30" column="3" colspan="5">
-          <widget class="QPushButton" name="editZenzFeedbackButton">
-           <property name="toolTip">
-            <string>保存された Zenz 学習データを確認、検索、インポート、エクスポート、削除します。通常の変換履歴に反映済みの学習は、この画面の削除対象には含まれません。</string>
-           </property>
-           <property name="text">
-            <string>管理...</string>
-           </property>
-          </widget>
+          </spacer>
          </item>
         </layout>
        </widget>
-       <widget class="QWidget" name="horizontalLayoutWidget_3">
-        <property name="geometry">
-         <rect>
-          <x>20</x>
-          <y>967</y>
-          <width>461</width>
-          <height>21</height>
-         </rect>
-        </property>
-        <layout class="QHBoxLayout" name="horizontalLayout_6">
+       <widget class="QWidget" name="inputsupport_tab">
+        <attribute name="title">
+         <string>Advanced</string>
+        </attribute>
+        <layout class="QVBoxLayout" name="inputSupportTabLayout">
+         <property name="spacing">
+          <number>0</number>
+         </property>
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
          <item>
-          <widget class="QLabel" name="autoCorrectionLable_2">
-           <property name="text">
-            <string>Fullwidth/Halfwidth</string>
+          <widget class="QScrollArea" name="inputSupportScrollArea">
+           <property name="frameShape">
+            <enum>QFrame::NoFrame</enum>
            </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="Line" name="halffullWidthLine">
+           <property name="horizontalScrollBarPolicy">
+            <enum>Qt::ScrollBarAsNeeded</enum>
+           </property>
+           <property name="widgetResizable">
+            <bool>true</bool>
+           </property>
            <property name="sizePolicy">
-            <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+            <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
              <horstretch>0</horstretch>
              <verstretch>0</verstretch>
             </sizepolicy>
            </property>
-           <property name="orientation">
-            <enum>Qt::Orientation::Horizontal</enum>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </widget>
-       <widget class="CharacterFormEditor" name="characterFormEditor">
-        <property name="geometry">
-         <rect>
-          <x>30</x>
-          <y>997</y>
-          <width>441</width>
-          <height>141</height>
-         </rect>
-        </property>
-       </widget>
-       <widget class="QWidget" name="preeditDisplayColorGroupBox">
-        <property name="geometry">
-         <rect>
-          <x>30</x>
-          <y>1162</y>
-          <width>441</width>
-          <height>270</height>
-         </rect>
-        </property>
-        <widget class="QWidget" name="horizontalLayoutWidget_preeditDisplayColor">
-         <property name="geometry">
-          <rect>
-           <x>0</x>
-           <y>0</y>
-           <width>441</width>
-           <height>21</height>
-          </rect>
-         </property>
-         <layout class="QHBoxLayout" name="horizontalLayout_preeditDisplayColor">
-          <item>
-           <widget class="QLabel" name="preeditDisplayColorSectionLabel">
-            <property name="text">
-             <string>未確定文字の表示色（カスタム）</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="Line" name="preeditDisplayColorSectionLine">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="orientation">
-             <enum>Qt::Orientation::Horizontal</enum>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-        <widget class="QWidget" name="preeditDisplayColorBodyWidget">
-         <property name="geometry">
-          <rect>
-           <x>10</x>
-           <y>30</y>
-           <width>421</width>
-           <height>235</height>
-          </rect>
-         </property>
-         <layout class="QGridLayout" name="preeditDisplayColorGridLayout">
-          <property name="leftMargin">
-           <number>8</number>
-          </property>
-          <property name="topMargin">
-           <number>8</number>
-          </property>
-          <property name="rightMargin">
-           <number>8</number>
-          </property>
-          <property name="bottomMargin">
-           <number>8</number>
-          </property>
-          <property name="horizontalSpacing">
-           <number>8</number>
-          </property>
-          <property name="verticalSpacing">
-           <number>3</number>
-          </property>
-          <item row="0" column="0" colspan="3">
-           <widget class="QLabel" name="inputPreeditColorLabel">
-            <property name="text">
-             <string>入力中の文字</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="0" colspan="2">
-           <widget class="QCheckBox" name="inputPreeditTextColorCheckBox">
-            <property name="text">
-             <string>文字色</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="2">
-           <widget class="QPushButton" name="inputPreeditTextColorButton">
-            <property name="minimumSize">
-             <size>
-              <width>80</width>
-              <height>0</height>
-             </size>
-            </property>
-            <property name="maximumSize">
-             <size>
-              <width>90</width>
-              <height>16777215</height>
-             </size>
-            </property>
-            <property name="text">
-             <string>#FF5000</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="0" colspan="2">
-           <widget class="QCheckBox" name="inputPreeditBackgroundColorCheckBox">
-            <property name="text">
-             <string>背景色</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="2">
-           <widget class="QPushButton" name="inputPreeditBackgroundColorButton">
-            <property name="minimumSize">
-             <size>
-              <width>80</width>
-              <height>0</height>
-             </size>
-            </property>
-            <property name="maximumSize">
-             <size>
-              <width>90</width>
-              <height>16777215</height>
-             </size>
-            </property>
-            <property name="text">
-             <string>#FFFFCC</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="0" colspan="2">
-           <widget class="QCheckBox" name="inputPreeditUnderlineColorCheckBox">
-            <property name="text">
-             <string>下線色</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="2">
-           <widget class="QPushButton" name="inputPreeditUnderlineColorButton">
-            <property name="minimumSize">
-             <size>
-              <width>80</width>
-              <height>0</height>
-             </size>
-            </property>
-            <property name="maximumSize">
-             <size>
-              <width>90</width>
-              <height>16777215</height>
-             </size>
-            </property>
-            <property name="text">
-             <string>#FF0000</string>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="0" colspan="3">
-           <spacer name="verticalSpacer_targetPreeditColor">
-            <property name="orientation">
-             <enum>Qt::Orientation::Vertical</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>20</width>
-              <height>18</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-          <item row="5" column="0" colspan="3">
-           <widget class="QLabel" name="targetPreeditColorLabel">
-            <property name="text">
-             <string>変換中の文節</string>
-            </property>
-           </widget>
-          </item>
-          <item row="6" column="0" colspan="2">
-           <widget class="QCheckBox" name="targetPreeditTextColorCheckBox">
-            <property name="text">
-             <string>文字色</string>
-            </property>
-           </widget>
-          </item>
-          <item row="6" column="2">
-           <widget class="QPushButton" name="targetPreeditTextColorButton">
-            <property name="minimumSize">
-             <size>
-              <width>80</width>
-              <height>0</height>
-             </size>
-            </property>
-            <property name="maximumSize">
-             <size>
-              <width>90</width>
-              <height>16777215</height>
-             </size>
-            </property>
-            <property name="text">
-             <string>#000000</string>
-            </property>
-           </widget>
-          </item>
-          <item row="7" column="0" colspan="2">
-           <widget class="QCheckBox" name="targetPreeditBackgroundColorCheckBox">
-            <property name="text">
-             <string>背景色</string>
-            </property>
-           </widget>
-          </item>
-          <item row="7" column="2">
-           <widget class="QPushButton" name="targetPreeditBackgroundColorButton">
-            <property name="minimumSize">
-             <size>
-              <width>80</width>
-              <height>0</height>
-             </size>
-            </property>
-            <property name="maximumSize">
-             <size>
-              <width>90</width>
-              <height>16777215</height>
-             </size>
-            </property>
-            <property name="text">
-             <string>#DDEEFF</string>
-            </property>
-           </widget>
-          </item>
-          <item row="8" column="0" colspan="2">
-           <widget class="QCheckBox" name="targetPreeditUnderlineColorCheckBox">
-            <property name="text">
-             <string>下線色</string>
-            </property>
-           </widget>
-          </item>
-          <item row="8" column="2">
-           <widget class="QPushButton" name="targetPreeditUnderlineColorButton">
-            <property name="minimumSize">
-             <size>
-              <width>80</width>
-              <height>0</height>
-             </size>
-            </property>
-            <property name="maximumSize">
-             <size>
-              <width>90</width>
-              <height>16777215</height>
-             </size>
-            </property>
-            <property name="text">
-             <string>#0066FF</string>
-            </property>
-           </widget>
-          </item>
-          <item row="9" column="0" colspan="3">
-           <widget class="QLabel" name="preeditDisplayColorNoteLabel">
-            <property name="text">
-             <string>対応アプリのみ有効。Chrome/Edge等は非対応の場合あり。</string>
-            </property>
-            <property name="toolTip">
-             <string>この設定は Windows TSF の表示属性を利用します。対応アプリでのみ有効です。Chrome や Edge など、一部のアプリでは反映されない場合があります。</string>
-            </property>
-            <property name="wordWrap">
-             <bool>false</bool>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-       </widget>
-      </widget>
-     </widget>
-    </widget>
-    <widget class="QWidget" name="suggestionsTab">
-     <attribute name="title">
-      <string>Suggest</string>
-     </attribute>
-     <widget class="QWidget" name="horizontalLayoutWidget_9">
-      <property name="geometry">
-       <rect>
-        <x>20</x>
-        <y>10</y>
-        <width>461</width>
-        <height>21</height>
-       </rect>
-      </property>
-      <layout class="QHBoxLayout" name="horizontalLayout_12">
-       <item>
-        <widget class="QLabel" name="label_3">
-         <property name="text">
-          <string>Source data</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="Line" name="line_4">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="orientation">
-          <enum>Qt::Orientation::Horizontal</enum>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </widget>
-     <widget class="QWidget" name="horizontalLayoutWidget_14">
-      <property name="geometry">
-       <rect>
-        <x>20</x>
-        <y>180</y>
-        <width>461</width>
-        <height>21</height>
-       </rect>
-      </property>
-      <layout class="QHBoxLayout" name="horizontalLayout_16">
-       <item>
-        <widget class="QLabel" name="SuggestionPreferenceLabel">
-         <property name="text">
-          <string>Other settings</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="Line" name="line_8">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="orientation">
-          <enum>Qt::Orientation::Horizontal</enum>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </widget>
-     <widget class="QWidget" name="gridLayoutWidget_10">
-      <property name="geometry">
-       <rect>
-        <x>30</x>
-        <y>200</y>
-        <width>441</width>
-        <height>31</height>
-       </rect>
-      </property>
-      <layout class="QGridLayout" name="gridLayout_11">
-       <item row="0" column="0">
-        <widget class="QLabel" name="defaultNUmberofSuggestionsLabel">
-         <property name="text">
-          <string>Maximum number of suggestions</string>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="2">
-        <widget class="QSpinBox" name="suggestionsSizeSpinBox"/>
-       </item>
-       <item row="0" column="1">
-        <spacer name="horizontalSpacer_8">
-         <property name="orientation">
-          <enum>Qt::Orientation::Horizontal</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>40</width>
-           <height>20</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-      </layout>
-     </widget>
-     <widget class="QWidget" name="gridLayoutWidget_4">
-      <property name="geometry">
-       <rect>
-        <x>30</x>
-        <y>40</y>
-        <width>441</width>
-        <height>121</height>
-       </rect>
-      </property>
-      <layout class="QGridLayout" name="gridLayout_4">
-       <item row="0" column="0" colspan="3">
-        <widget class="QCheckBox" name="historySuggestCheckBox">
-         <property name="text">
-          <string>Use input history</string>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="2">
-        <widget class="QPushButton" name="clearUserPredictionButton">
-         <property name="minimumSize">
-          <size>
-           <width>120</width>
-           <height>0</height>
-          </size>
-         </property>
-         <property name="text">
-          <string>Clear all history</string>
-         </property>
-        </widget>
-       </item>
-       <item row="3" column="0" colspan="3">
-        <widget class="QCheckBox" name="dictionarySuggestCheckBox">
-         <property name="text">
-          <string>Use system dictionary</string>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="1">
-        <widget class="QPushButton" name="clearUnusedUserPredictionButton">
-         <property name="minimumSize">
-          <size>
-           <width>120</width>
-           <height>0</height>
-          </size>
-         </property>
-         <property name="text">
-          <string>Clear unused history</string>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="0">
-        <spacer name="horizontalSpacer_6">
-         <property name="orientation">
-          <enum>Qt::Orientation::Horizontal</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>40</width>
-           <height>20</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item row="2" column="1">
-        <spacer name="verticalSpacer">
-         <property name="orientation">
-          <enum>Qt::Orientation::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item row="4" column="0" colspan="3">
-        <widget class="QCheckBox" name="realtimeConversionCheckBox">
-         <property name="text">
-          <string>Use realtime conversion</string>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </widget>
-    </widget>
-    <widget class="QWidget" name="privacyTab">
-     <attribute name="title">
-      <string>Privacy</string>
-     </attribute>
-     <widget class="QWidget" name="horizontalLayoutWidget_18">
-      <property name="geometry">
-       <rect>
-        <x>20</x>
-        <y>10</y>
-        <width>461</width>
-        <height>21</height>
-       </rect>
-      </property>
-      <layout class="QHBoxLayout" name="horizontalLayout_20">
-       <item>
-        <widget class="QLabel" name="label_10">
-         <property name="text">
-          <string>Secret mode</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="Line" name="line_11">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="orientation">
-          <enum>Qt::Orientation::Horizontal</enum>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </widget>
-     <widget class="QCheckBox" name="incognitoModeCheckBox">
-      <property name="geometry">
-       <rect>
-        <x>30</x>
-        <y>40</y>
-        <width>20</width>
-        <height>20</height>
-       </rect>
-      </property>
-      <property name="sizePolicy">
-       <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-        <horstretch>0</horstretch>
-        <verstretch>0</verstretch>
-       </sizepolicy>
-      </property>
-      <property name="text">
-       <string/>
-      </property>
-      <property name="tristate">
-       <bool>false</bool>
-      </property>
-     </widget>
-     <widget class="QLabel" name="incognitoModeMessage">
-      <property name="geometry">
-       <rect>
-        <x>50</x>
-        <y>42</y>
-        <width>421</width>
-        <height>48</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>Temporarily disable conversion personalization, history-based suggestions and user dictionary</string>
-      </property>
-      <property name="wordWrap">
-       <bool>true</bool>
-      </property>
-      <property name="alignment">
-       <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-      </property>
-     </widget>
-     <widget class="QCheckBox" name="presentationModeCheckBox">
-      <property name="geometry">
-       <rect>
-        <x>30</x>
-        <y>120</y>
-        <width>441</width>
-        <height>17</height>
-       </rect>
-      </property>
-      <property name="text">
-       <string>Temporarily disable all suggestions</string>
-      </property>
-     </widget>
-     <widget class="QWidget" name="horizontalLayoutWidget_19">
-      <property name="geometry">
-       <rect>
-        <x>20</x>
-        <y>90</y>
-        <width>461</width>
-        <height>21</height>
-       </rect>
-      </property>
-      <layout class="QHBoxLayout" name="horizontalLayout_21">
-       <item>
-        <widget class="QLabel" name="label_12">
-         <property name="text">
-          <string>Presentation mode</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="Line" name="line_12">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="orientation">
-          <enum>Qt::Orientation::Horizontal</enum>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </widget>
-    </widget>
-    <widget class="QWidget" name="miscTab">
-     <attribute name="title">
-      <string>Misc</string>
-     </attribute>
-     <widget class="QWidget" name="widgetMisc" native="true">
-      <property name="geometry">
-       <rect>
-        <x>20</x>
-        <y>10</y>
-        <width>471</width>
-        <height>331</height>
-       </rect>
-      </property>
-      <property name="sizePolicy">
-       <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-        <horstretch>0</horstretch>
-        <verstretch>0</verstretch>
-       </sizepolicy>
-      </property>
-      <layout class="QVBoxLayout" name="verticalLayout">
-       <property name="spacing">
-        <number>15</number>
-       </property>
-       <property name="leftMargin">
-        <number>0</number>
-       </property>
-       <property name="topMargin">
-        <number>2</number>
-       </property>
-       <property name="rightMargin">
-        <number>5</number>
-       </property>
-       <property name="bottomMargin">
-        <number>0</number>
-       </property>
-       <item>
-        <widget class="QWidget" name="miscDefaultIMEWidget" native="true">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <layout class="QVBoxLayout" name="verticalLayout_3">
-          <property name="spacing">
-           <number>10</number>
-          </property>
-          <property name="leftMargin">
-           <number>0</number>
-          </property>
-          <property name="topMargin">
-           <number>0</number>
-          </property>
-          <property name="rightMargin">
-           <number>5</number>
-          </property>
-          <property name="bottomMargin">
-           <number>0</number>
-          </property>
-          <item>
-           <widget class="QWidget" name="widget_3" native="true">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <layout class="QHBoxLayout" name="horizontalLayout_5">
+           <widget class="QWidget" name="inputSupportScrollAreaWidgetContents">
+            <layout class="QVBoxLayout" name="inputSupportContentLayout">
              <property name="spacing">
-              <number>6</number>
-             </property>
-             <property name="margin" stdset="0">
               <number>0</number>
              </property>
-             <item>
-              <widget class="QLabel" name="checkDefaultLabel">
-               <property name="text">
-                <string>Default IME</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="Line" name="checkDefaultLine">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="orientation">
-                <enum>Qt::Orientation::Horizontal</enum>
-               </property>
-              </widget>
-             </item>
-            </layout>
-           </widget>
-          </item>
-          <item>
-           <widget class="QWidget" name="widget_4" native="true">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <layout class="QVBoxLayout" name="verticalLayout_2">
+             <property name="leftMargin">
+              <number>9</number>
+             </property>
              <property name="topMargin">
-              <number>0</number>
+              <number>9</number>
              </property>
              <property name="rightMargin">
-              <number>0</number>
+              <number>9</number>
              </property>
              <property name="bottomMargin">
-              <number>0</number>
+              <number>9</number>
              </property>
              <item>
-              <widget class="QWidget" name="defaultImeButtonsWidget" native="true">
-               <layout class="QHBoxLayout" name="defaultImeButtonsLayout">
+              <widget class="QFrame" name="inputAssistanceHeader">
+               <property name="frameShape">
+                <enum>QFrame::Shape::NoFrame</enum>
+               </property>
+               <layout class="QHBoxLayout" name="horizontalLayout_4">
+                <property name="leftMargin">
+                 <number>9</number>
+                </property>
+                <property name="topMargin">
+                 <number>9</number>
+                </property>
+                <property name="rightMargin">
+                 <number>9</number>
+                </property>
+                <property name="bottomMargin">
+                 <number>9</number>
+                </property>
+                <property name="spacing">
+                 <number>6</number>
+                </property>
+                <item>
+                 <widget class="QLabel" name="autoCorrectionLable">
+                  <property name="text">
+                   <string>Input Assistance</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="Line" name="autoCorrectionLine_2">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="orientation">
+                   <enum>Qt::Orientation::Horizontal</enum>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
+              </widget>
+             </item>
+             <item>
+              <widget class="QFrame" name="inputAssistanceGroup">
+               <property name="frameShape">
+                <enum>QFrame::Shape::NoFrame</enum>
+               </property>
+               <layout class="QGridLayout" name="gridLayout_9">
+                <property name="verticalSpacing">
+                 <number>6</number>
+                </property>
+                <property name="horizontalSpacing">
+                 <number>8</number>
+                </property>
+                <property name="leftMargin">
+                 <number>24</number>
+                </property>
+                <property name="topMargin">
+                 <number>9</number>
+                </property>
+                <property name="rightMargin">
+                 <number>24</number>
+                </property>
+                <property name="bottomMargin">
+                 <number>9</number>
+                </property>
+                <item row="10" column="0" colspan="8">
+                 <widget class="QWidget" name="liveConversionSectionWidget">
+                  <layout class="QHBoxLayout" name="horizontalLayout_liveConversionSection">
+                   <property name="spacing">
+                    <number>6</number>
+                   </property>
+                   <property name="leftMargin">
+                    <number>0</number>
+                   </property>
+                   <property name="topMargin">
+                    <number>14</number>
+                   </property>
+                   <property name="rightMargin">
+                    <number>0</number>
+                   </property>
+                   <property name="bottomMargin">
+                    <number>6</number>
+                   </property>
+                   <item>
+                    <widget class="QLabel" name="liveConversionSectionLabel">
+                     <property name="text">
+                      <string>ライブ変換</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <widget class="Line" name="liveConversionSectionLine">
+                     <property name="sizePolicy">
+                      <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+                       <horstretch>0</horstretch>
+                       <verstretch>0</verstretch>
+                      </sizepolicy>
+                     </property>
+                     <property name="orientation">
+                      <enum>Qt::Orientation::Horizontal</enum>
+                     </property>
+                    </widget>
+                   </item>
+                  </layout>
+                 </widget>
+                </item>
+                <item row="15" column="0" colspan="8">
+                 <widget class="QWidget" name="zenzLiveCorrectionSectionWidget">
+                  <layout class="QHBoxLayout" name="horizontalLayout_zenzLiveCorrectionSection">
+                   <property name="spacing">
+                    <number>6</number>
+                   </property>
+                   <property name="leftMargin">
+                    <number>0</number>
+                   </property>
+                   <property name="topMargin">
+                    <number>14</number>
+                   </property>
+                   <property name="rightMargin">
+                    <number>0</number>
+                   </property>
+                   <property name="bottomMargin">
+                    <number>6</number>
+                   </property>
+                   <item>
+                    <widget class="QLabel" name="zenzLiveCorrectionSectionLabel">
+                     <property name="text">
+                      <string>Zenz ライブ補正</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <widget class="Line" name="zenzLiveCorrectionSectionLine">
+                     <property name="sizePolicy">
+                      <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+                       <horstretch>0</horstretch>
+                       <verstretch>0</verstretch>
+                      </sizepolicy>
+                     </property>
+                     <property name="orientation">
+                      <enum>Qt::Orientation::Horizontal</enum>
+                     </property>
+                    </widget>
+                   </item>
+                  </layout>
+                 </widget>
+                </item>
+                <item row="19" column="0" colspan="8">
+                 <widget class="QWidget" name="zenzConditionFieldsSectionWidget">
+                  <layout class="QHBoxLayout" name="horizontalLayout_zenzConditionFieldsSection">
+                   <property name="spacing">
+                    <number>6</number>
+                   </property>
+                   <property name="leftMargin">
+                    <number>0</number>
+                   </property>
+                   <property name="topMargin">
+                    <number>14</number>
+                   </property>
+                   <property name="rightMargin">
+                    <number>0</number>
+                   </property>
+                   <property name="bottomMargin">
+                    <number>6</number>
+                   </property>
+                   <item>
+                    <widget class="QLabel" name="zenzConditionFieldsSectionLabel">
+                     <property name="text">
+                      <string>Zenz 条件フィールド</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <widget class="Line" name="zenzConditionFieldsSectionLine">
+                     <property name="sizePolicy">
+                      <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+                       <horstretch>0</horstretch>
+                       <verstretch>0</verstretch>
+                      </sizepolicy>
+                     </property>
+                     <property name="orientation">
+                      <enum>Qt::Orientation::Horizontal</enum>
+                     </property>
+                    </widget>
+                   </item>
+                  </layout>
+                 </widget>
+                </item>
+                <item row="26" column="0" colspan="8">
+                 <widget class="QWidget" name="zenzFeedbackLearningSectionWidget">
+                  <layout class="QHBoxLayout" name="horizontalLayout_zenzFeedbackLearningSection">
+                   <property name="spacing">
+                    <number>6</number>
+                   </property>
+                   <property name="leftMargin">
+                    <number>0</number>
+                   </property>
+                   <property name="topMargin">
+                    <number>14</number>
+                   </property>
+                   <property name="rightMargin">
+                    <number>0</number>
+                   </property>
+                   <property name="bottomMargin">
+                    <number>6</number>
+                   </property>
+                   <item>
+                    <widget class="QLabel" name="zenzFeedbackLearningSectionLabel">
+                     <property name="text">
+                      <string>Zenz 学習</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <widget class="Line" name="zenzFeedbackLearningSectionLine">
+                     <property name="sizePolicy">
+                      <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+                       <horstretch>0</horstretch>
+                       <verstretch>0</verstretch>
+                      </sizepolicy>
+                     </property>
+                     <property name="orientation">
+                      <enum>Qt::Orientation::Horizontal</enum>
+                     </property>
+                    </widget>
+                   </item>
+                  </layout>
+                 </widget>
+                </item>
+                <item row="8" column="0" colspan="8">
+                 <widget class="QCheckBox" name="autoSwitchCompositionMode">
+                  <property name="text">
+                   <string>Automatically switch to halfwidth</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="9" column="0" colspan="8">
+                 <widget class="QCheckBox" name="showCandidateWindowOnInitialConversionCheckBox">
+                  <property name="toolTip">
+                   <string>When live conversion is off, the first conversion action opens the candidate window without advancing to the second candidate.</string>
+                  </property>
+                  <property name="text">
+                   <string>Open candidate window on first conversion action (live conversion off)</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="11" column="0" colspan="8">
+                 <widget class="QCheckBox" name="liveConversionCheckBox">
+                  <property name="toolTip">
+                   <string>入力中の未確定文字列を、文字が入力されるたびに自動で変換します。</string>
+                  </property>
+                  <property name="text">
+                   <string>ライブ変換を有効にする</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="12" column="0" colspan="3">
+                 <widget class="QLabel" name="liveConversionDelayLabel">
+                  <property name="toolTip">
+                   <string>文字入力後、ライブ変換を開始するまでの待ち時間です。0 ms にすると即時変換します。</string>
+                  </property>
+                  <property name="text">
+                   <string>ライブ変換の遅延</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="12" column="3" colspan="5">
+                 <widget class="QSpinBox" name="liveConversionDelaySpinBox">
+                  <property name="toolTip">
+                   <string>文字入力後、ライブ変換を開始するまでの待ち時間です。0 ms にすると即時変換します。</string>
+                  </property>
+                  <property name="minimum">
+                   <number>0</number>
+                  </property>
+                  <property name="maximum">
+                   <number>1000</number>
+                  </property>
+                  <property name="singleStep">
+                   <number>5</number>
+                  </property>
+                  <property name="value">
+                   <number>228</number>
+                  </property>
+                  <property name="suffix">
+                   <string> ms</string>
+                  </property>
+                  <property name="specialValueText">
+                   <string>即時</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="13" column="0" colspan="3">
+                 <widget class="QLabel" name="liveConversionMinKeyLengthLabel">
+                  <property name="toolTip">
+                   <string>ライブ変換を開始する最小文字数です。1 にすると 1 文字目からライブ変換します。</string>
+                  </property>
+                  <property name="text">
+                   <string>ライブ変換開始の最小文字数</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="13" column="3" colspan="5">
+                 <widget class="QSpinBox" name="liveConversionMinKeyLengthSpinBox">
+                  <property name="toolTip">
+                   <string>ライブ変換を開始する最小文字数です。短くすると変換開始は早くなりますが、1 文字の助詞などが漢字化されやすくなります。</string>
+                  </property>
+                  <property name="minimum">
+                   <number>1</number>
+                  </property>
+                  <property name="maximum">
+                   <number>20</number>
+                  </property>
+                  <property name="singleStep">
+                   <number>1</number>
+                  </property>
+                  <property name="value">
+                   <number>2</number>
+                  </property>
+                  <property name="suffix">
+                   <string> 文字</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="14" column="0" colspan="8">
+                 <widget class="QCheckBox" name="showLiveConversionRubyWindow">
+                  <property name="toolTip">
+                   <string>Shows the typed reading near the candidate window during live conversion.</string>
+                  </property>
+                  <property name="text">
+                   <string>Show ruby window during live conversion</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="0" column="0" colspan="3">
+                 <widget class="QCheckBox" name="useAutoConversion">
+                  <property name="text">
+                   <string>Convert at punctuations</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="0" column="3">
+                 <widget class="QCheckBox" name="kutenCheckBox">
+                  <property name="maximumSize">
+                   <size>
+                    <width>45</width>
+                    <height>16777215</height>
+                   </size>
+                  </property>
+                  <property name="text">
+                   <string>。</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="0" column="4">
+                 <widget class="QCheckBox" name="toutenCheckBox">
+                  <property name="maximumSize">
+                   <size>
+                    <width>45</width>
+                    <height>16777215</height>
+                   </size>
+                  </property>
+                  <property name="text">
+                   <string>、</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="0" column="5">
+                 <widget class="QCheckBox" name="questionMarkCheckBox">
+                  <property name="maximumSize">
+                   <size>
+                    <width>45</width>
+                    <height>16777215</height>
+                   </size>
+                  </property>
+                  <property name="text">
+                   <string>?</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="0" column="6">
+                 <widget class="QCheckBox" name="exclamationMarkCheckBox">
+                  <property name="maximumSize">
+                   <size>
+                    <width>45</width>
+                    <height>16777215</height>
+                   </size>
+                  </property>
+                  <property name="text">
+                   <string>!</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="1" column="0" colspan="3">
+                 <widget class="QCheckBox" name="useDirectCommit">
+                  <property name="text">
+                   <string>句読点・記号の単打確定を有効にする</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="1" column="3">
+                 <widget class="QCheckBox" name="directCommitKutenCheckBox">
+                  <property name="maximumSize">
+                   <size>
+                    <width>45</width>
+                    <height>16777215</height>
+                   </size>
+                  </property>
+                  <property name="text">
+                   <string>。</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="1" column="4">
+                 <widget class="QCheckBox" name="directCommitToutenCheckBox">
+                  <property name="maximumSize">
+                   <size>
+                    <width>45</width>
+                    <height>16777215</height>
+                   </size>
+                  </property>
+                  <property name="text">
+                   <string>、</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="1" column="5">
+                 <widget class="QCheckBox" name="directCommitQuestionMarkCheckBox">
+                  <property name="maximumSize">
+                   <size>
+                    <width>45</width>
+                    <height>16777215</height>
+                   </size>
+                  </property>
+                  <property name="text">
+                   <string>?</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="1" column="6">
+                 <widget class="QCheckBox" name="directCommitExclamationMarkCheckBox">
+                  <property name="maximumSize">
+                   <size>
+                    <width>45</width>
+                    <height>16777215</height>
+                   </size>
+                  </property>
+                  <property name="text">
+                   <string>!</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="2" column="0" colspan="3">
+                 <spacer name="horizontalSpacer_directCommit">
+                  <property name="orientation">
+                   <enum>Qt::Orientation::Horizontal</enum>
+                  </property>
+                  <property name="sizeHint" stdset="0">
+                   <size>
+                    <width>20</width>
+                    <height>20</height>
+                   </size>
+                  </property>
+                 </spacer>
+                </item>
+                <item row="2" column="3">
+                 <widget class="QCheckBox" name="directCommitOpenParenthesisCheckBox">
+                  <property name="maximumSize">
+                   <size>
+                    <width>45</width>
+                    <height>16777215</height>
+                   </size>
+                  </property>
+                  <property name="text">
+                   <string>（</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="2" column="4">
+                 <widget class="QCheckBox" name="directCommitCloseParenthesisCheckBox">
+                  <property name="maximumSize">
+                   <size>
+                    <width>45</width>
+                    <height>16777215</height>
+                   </size>
+                  </property>
+                  <property name="text">
+                   <string>）</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="2" column="5">
+                 <widget class="QCheckBox" name="directCommitOpenBracketCheckBox">
+                  <property name="maximumSize">
+                   <size>
+                    <width>45</width>
+                    <height>16777215</height>
+                   </size>
+                  </property>
+                  <property name="text">
+                   <string>「</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="2" column="6">
+                 <widget class="QCheckBox" name="directCommitCloseBracketCheckBox">
+                  <property name="maximumSize">
+                   <size>
+                    <width>45</width>
+                    <height>16777215</height>
+                   </size>
+                  </property>
+                  <property name="text">
+                   <string>」</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="2" column="7">
+                 <widget class="QCheckBox" name="directCommitMiddleDotCheckBox">
+                  <property name="maximumSize">
+                   <size>
+                    <width>45</width>
+                    <height>16777215</height>
+                   </size>
+                  </property>
+                  <property name="text">
+                   <string>・</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="3" column="0" colspan="3">
+                 <widget class="QLabel" name="autoCorrectionLable_3">
+                  <property name="text">
+                   <string>Shift key mode switch</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="3" column="3" colspan="5">
+                 <widget class="QComboBox" name="shiftKeyModeSwitchComboBox">
+                  <property name="minimumSize">
+                   <size>
+                    <width>150</width>
+                    <height>0</height>
+                   </size>
+                  </property>
+                 </widget>
+                </item>
+                <item row="4" column="0" colspan="8">
+                 <widget class="QCheckBox" name="useJapaneseLayout">
+                  <property name="enabled">
+                   <bool>true</bool>
+                  </property>
+                  <property name="text">
+                   <string>Always use Japanese keyboard layout for Japanese input</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="5" column="0" colspan="8">
+                 <widget class="QCheckBox" name="useModeIndicator">
+                  <property name="enabled">
+                   <bool>true</bool>
+                  </property>
+                  <property name="text">
+                   <string>Show input mode indicator near the cursor</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="6" column="0" colspan="8">
+                 <widget class="QCheckBox" name="useDarkModeCandidateWindow">
+                  <property name="enabled">
+                   <bool>true</bool>
+                  </property>
+                  <property name="text">
+                   <string>Use dark mode for candidate and ruby windows</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="7" column="0" colspan="3">
+                 <widget class="QLabel" name="candidateRubyFontLabel">
+                  <property name="text">
+                   <string>Candidate/ruby font</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="7" column="3" colspan="5">
+                 <widget class="QComboBox" name="candidateRubyFontComboBox">
+                  <property name="minimumSize">
+                   <size>
+                    <width>180</width>
+                    <height>0</height>
+                   </size>
+                  </property>
+                  <property name="maximumSize">
+                   <size>
+                    <width>280</width>
+                    <height>16777215</height>
+                   </size>
+                  </property>
+                  <property name="sizeAdjustPolicy">
+                   <enum>QComboBox::AdjustToMinimumContentsLengthWithIcon</enum>
+                  </property>
+                  <property name="minimumContentsLength">
+                   <number>18</number>
+                  </property>
+                 </widget>
+                </item>
+                <item row="16" column="0" colspan="8">
+                 <widget class="QCheckBox" name="zenzLiveCorrectionCheckBox">
+                  <property name="toolTip">
+                   <string>ライブ変換結果に対して、ローカルの Zenz モデルで文脈補正を行います。</string>
+                  </property>
+                  <property name="text">
+                   <string>Zenz ライブ補正を有効にする</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="17" column="0" colspan="3">
+                 <widget class="QLabel" name="zenzLiveCorrectionDelayLabel">
+                  <property name="toolTip">
+                   <string>ライブ変換後、Zenz 補正を開始するまでの待ち時間です。</string>
+                  </property>
+                  <property name="text">
+                   <string>Zenz 補正開始の遅延</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="17" column="3" colspan="5">
+                 <widget class="QSpinBox" name="zenzLiveCorrectionDelaySpinBox">
+                  <property name="toolTip">
+                   <string>ライブ変換後、Zenz 補正を開始するまでの待ち時間です。0 ms にすると即時補正します。</string>
+                  </property>
+                  <property name="minimum">
+                   <number>0</number>
+                  </property>
+                  <property name="maximum">
+                   <number>5000</number>
+                  </property>
+                  <property name="singleStep">
+                   <number>100</number>
+                  </property>
+                  <property name="value">
+                   <number>1000</number>
+                  </property>
+                  <property name="suffix">
+                   <string> ms</string>
+                  </property>
+                  <property name="specialValueText">
+                   <string>即時</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="18" column="0" colspan="3">
+                 <widget class="QLabel" name="zenzLiveCorrectionMinKeyLengthLabel">
+                  <property name="toolTip">
+                   <string>Zenz 補正を開始する最小文字数です。短くすると補正機会は増えますが、誤補正も増える可能性があります。</string>
+                  </property>
+                  <property name="text">
+                   <string>Zenz 補正開始の最小文字数</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="18" column="3" colspan="5">
+                 <widget class="QSpinBox" name="zenzLiveCorrectionMinKeyLengthSpinBox">
+                  <property name="toolTip">
+                   <string>Zenz 補正を開始する最小文字数です。</string>
+                  </property>
+                  <property name="minimum">
+                   <number>2</number>
+                  </property>
+                  <property name="maximum">
+                   <number>20</number>
+                  </property>
+                  <property name="singleStep">
+                   <number>1</number>
+                  </property>
+                  <property name="value">
+                   <number>2</number>
+                  </property>
+                  <property name="suffix">
+                   <string> 文字</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="20" column="0" colspan="3">
+                 <widget class="QLabel" name="zenzLiveCorrectionProfileLabel">
+                  <property name="toolTip">
+                   <string>U+EE03 profile として Zenzai v3/v3.2 のプロンプトに渡します。</string>
+                  </property>
+                  <property name="text">
+                   <string>Zenz profile</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="20" column="3" colspan="5">
+                 <widget class="QLineEdit" name="zenzLiveCorrectionProfileLineEdit">
+                  <property name="toolTip">
+                   <string>例: 技術文書を書く日本語ユーザー。空欄なら送信しません。</string>
+                  </property>
+                  <property name="maxLength">
+                   <number>128</number>
+                  </property>
+                  <property name="placeholderText">
+                   <string>例: 技術文書を書く日本語ユーザー</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="21" column="0" colspan="3">
+                 <widget class="QLabel" name="zenzLiveCorrectionTopicLabel">
+                  <property name="toolTip">
+                   <string>U+EE04 topic として Zenzai v3/v3.2 のプロンプトに渡します。experimental です。</string>
+                  </property>
+                  <property name="text">
+                   <string>Zenz topic</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="21" column="3" colspan="5">
+                 <widget class="QLineEdit" name="zenzLiveCorrectionTopicLineEdit">
+                  <property name="toolTip">
+                   <string>例: Mozc、Rust、会計、法律。空欄なら送信しません。</string>
+                  </property>
+                  <property name="maxLength">
+                   <number>128</number>
+                  </property>
+                  <property name="placeholderText">
+                   <string>例: Mozc</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="22" column="0" colspan="3">
+                 <widget class="QLabel" name="zenzLiveCorrectionStyleLabel">
+                  <property name="toolTip">
+                   <string>U+EE05 style として Zenzai v3/v3.2 のプロンプトに渡します。experimental です。</string>
+                  </property>
+                  <property name="text">
+                   <string>Zenz style</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="22" column="3" colspan="5">
+                 <widget class="QLineEdit" name="zenzLiveCorrectionStyleLineEdit">
+                  <property name="toolTip">
+                   <string>例: 技術文書、ビジネス、口語、常体。空欄なら送信しません。</string>
+                  </property>
+                  <property name="maxLength">
+                   <number>128</number>
+                  </property>
+                  <property name="placeholderText">
+                   <string>例: 技術文書</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="23" column="0" colspan="3">
+                 <widget class="QLabel" name="zenzLiveCorrectionSettingsLabel">
+                  <property name="toolTip">
+                   <string>U+EE06 settings として Zenzai v3/v3.2 のプロンプトに渡します。experimental です。</string>
+                  </property>
+                  <property name="text">
+                   <string>Zenz settings</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="23" column="3" colspan="5">
+                 <widget class="QLineEdit" name="zenzLiveCorrectionSettingsLineEdit">
+                  <property name="toolTip">
+                   <string>例: 専門用語を優先。空欄なら送信しません。</string>
+                  </property>
+                  <property name="maxLength">
+                   <number>128</number>
+                  </property>
+                  <property name="placeholderText">
+                   <string>例: 専門用語を優先</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="24" column="0" colspan="8">
+                 <widget class="QCheckBox" name="zenzLiveCorrectionRightContextCheckBox">
+                  <property name="toolTip">
+                   <string>クライアントからカーソル右側テキストが渡された場合、U+EE07 right context として Zenzai v3.2 のプロンプトに含めます。</string>
+                  </property>
+                  <property name="text">
+                   <string>Zenz 右文脈を使用する</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="25" column="0" colspan="3">
+                 <widget class="QLabel" name="zenzLiveCorrectionRightContextLengthLabel">
+                  <property name="toolTip">
+                   <string>Zenz 右文脈として使う最大文字数です。</string>
+                  </property>
+                  <property name="text">
+                   <string>Zenz 右文脈長</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="25" column="3" colspan="5">
+                 <widget class="QSpinBox" name="zenzLiveCorrectionRightContextLengthSpinBox">
+                  <property name="toolTip">
+                   <string>カーソル右側テキストが取得できる場合だけ使われます。0 文字なら送信しません。</string>
+                  </property>
+                  <property name="minimum">
+                   <number>0</number>
+                  </property>
+                  <property name="maximum">
+                   <number>128</number>
+                  </property>
+                  <property name="singleStep">
+                   <number>1</number>
+                  </property>
+                  <property name="value">
+                   <number>24</number>
+                  </property>
+                  <property name="suffix">
+                   <string> 文字</string>
+                  </property>
+                  <property name="specialValueText">
+                   <string>使わない</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="27" column="0" colspan="8">
+                 <widget class="QCheckBox" name="zenzFeedbackLearningCheckBox">
+                  <property name="toolTip">
+                   <string>Zenz 補正結果の採用/却下をローカルに保存し、次回以降の補正や候補順位に反映します。確定した内容は、通常の変換履歴にも反映される場合があります。</string>
+                  </property>
+                  <property name="text">
+                   <string>Zenz 補正結果をローカル学習する</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="28" column="0" colspan="8">
+                 <widget class="QCheckBox" name="zenzFeedbackAutoBlockCheckBox">
+                  <property name="toolTip">
+                   <string>Zenz 補正を通常変換などで別の文字列に確定した回数が指定回数に達した場合、同じ読み・同じ文脈クラス・同じ補正結果を次回以降の Zenz 補正として表示しないようにします。通常の Mozc 候補から削除する機能ではありません。</string>
+                  </property>
+                  <property name="text">
+                   <string>Zenz 補正と異なる結果で確定した場合、その補正を自動ブロックする</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="29" column="0" colspan="3">
+                 <widget class="QLabel" name="zenzFeedbackAutoBlockRejectThresholdLabel">
+                  <property name="toolTip">
+                   <string>同じ Zenz 補正を何回異なる結果で確定したら自動ブロックするかを指定します。設定変更は既存の Zenz 学習データにも動的に反映されます。</string>
+                  </property>
+                  <property name="text">
+                   <string>自動ブロックまでの拒否回数</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="29" column="3" colspan="5">
+                 <widget class="QSpinBox" name="zenzFeedbackAutoBlockRejectThresholdSpinBox">
+                  <property name="toolTip">
+                   <string>同じ Zenz 補正を何回異なる結果で確定したら自動ブロックするかを指定します。</string>
+                  </property>
+                  <property name="minimum">
+                   <number>1</number>
+                  </property>
+                  <property name="maximum">
+                   <number>999</number>
+                  </property>
+                  <property name="singleStep">
+                   <number>1</number>
+                  </property>
+                  <property name="value">
+                   <number>3</number>
+                  </property>
+                  <property name="suffix">
+                   <string> 回</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="30" column="0" colspan="3">
+                 <widget class="QLabel" name="zenzFeedbackDataLabel">
+                  <property name="text">
+                   <string>Zenz 学習データ</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="30" column="3" colspan="5">
+                 <widget class="QPushButton" name="editZenzFeedbackButton">
+                  <property name="toolTip">
+                   <string>保存された Zenz 学習データを確認、検索、インポート、エクスポート、削除します。通常の変換履歴に反映済みの学習は、この画面の削除対象には含まれません。</string>
+                  </property>
+                  <property name="text">
+                   <string>管理...</string>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
+              </widget>
+             </item>
+             <item>
+              <widget class="QFrame" name="characterFormHeader">
+               <property name="frameShape">
+                <enum>QFrame::Shape::NoFrame</enum>
+               </property>
+               <layout class="QHBoxLayout" name="horizontalLayout_6">
+                <property name="leftMargin">
+                 <number>9</number>
+                </property>
+                <property name="topMargin">
+                 <number>9</number>
+                </property>
+                <property name="rightMargin">
+                 <number>9</number>
+                </property>
+                <property name="bottomMargin">
+                 <number>9</number>
+                </property>
+                <property name="spacing">
+                 <number>6</number>
+                </property>
+                <item>
+                 <widget class="QLabel" name="autoCorrectionLable_2">
+                  <property name="text">
+                   <string>Fullwidth/Halfwidth</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="Line" name="halffullWidthLine">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="orientation">
+                   <enum>Qt::Orientation::Horizontal</enum>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
+              </widget>
+             </item>
+             <item>
+              <widget class="QFrame" name="characterFormGroup">
+               <property name="frameShape">
+                <enum>QFrame::Shape::NoFrame</enum>
+               </property>
+               <layout class="QVBoxLayout" name="characterFormGroupLayout">
+                <property name="spacing">
+                 <number>0</number>
+                </property>
+                <property name="leftMargin">
+                 <number>24</number>
+                </property>
+                <property name="topMargin">
+                 <number>9</number>
+                </property>
+                <property name="rightMargin">
+                 <number>24</number>
+                </property>
+                <property name="bottomMargin">
+                 <number>9</number>
+                </property>
+                <item>
+                 <widget class="CharacterFormEditor" name="characterFormEditor">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
+              </widget>
+             </item>
+             <item>
+              <widget class="QWidget" name="preeditDisplayColorGroupBox">
+               <layout class="QVBoxLayout" name="preeditDisplayColorLayout">
+                <property name="spacing">
+                 <number>0</number>
+                </property>
                 <property name="leftMargin">
                  <number>0</number>
                 </property>
@@ -2334,392 +1876,1337 @@
                  <number>0</number>
                 </property>
                 <item>
-                 <widget class="QPushButton" name="setDefaultImeButton">
-                  <property name="text">
-                   <string>Set as Windows default IME</string>
+                 <widget class="QFrame" name="preeditDisplayColorHeader">
+                  <property name="frameShape">
+                   <enum>QFrame::Shape::NoFrame</enum>
                   </property>
+                  <layout class="QHBoxLayout" name="horizontalLayout_preeditDisplayColor">
+                   <property name="leftMargin">
+                    <number>9</number>
+                   </property>
+                   <property name="topMargin">
+                    <number>9</number>
+                   </property>
+                   <property name="rightMargin">
+                    <number>9</number>
+                   </property>
+                   <property name="bottomMargin">
+                    <number>9</number>
+                   </property>
+                   <property name="spacing">
+                    <number>6</number>
+                   </property>
+                   <item>
+                    <widget class="QLabel" name="preeditDisplayColorSectionLabel">
+                     <property name="text">
+                      <string>未確定文字の表示色（カスタム）</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <widget class="Line" name="preeditDisplayColorSectionLine">
+                     <property name="sizePolicy">
+                      <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+                       <horstretch>0</horstretch>
+                       <verstretch>0</verstretch>
+                      </sizepolicy>
+                     </property>
+                     <property name="orientation">
+                      <enum>Qt::Orientation::Horizontal</enum>
+                     </property>
+                    </widget>
+                   </item>
+                  </layout>
                  </widget>
                 </item>
                 <item>
-                 <widget class="QPushButton" name="restoreDefaultImeButton">
-                  <property name="text">
-                   <string>Restore previous setting</string>
+                 <widget class="QFrame" name="preeditDisplayColorBody">
+                  <property name="frameShape">
+                   <enum>QFrame::Shape::NoFrame</enum>
                   </property>
+                  <layout class="QGridLayout" name="preeditDisplayColorGridLayout">
+                   <property name="verticalSpacing">
+                    <number>3</number>
+                   </property>
+                   <property name="horizontalSpacing">
+                    <number>8</number>
+                   </property>
+                   <property name="leftMargin">
+                    <number>18</number>
+                   </property>
+                   <property name="topMargin">
+                    <number>4</number>
+                   </property>
+                   <property name="rightMargin">
+                    <number>18</number>
+                   </property>
+                   <property name="bottomMargin">
+                    <number>8</number>
+                   </property>
+                   <item row="0" column="0" colspan="3">
+                    <widget class="QLabel" name="inputPreeditColorLabel">
+                     <property name="text">
+                      <string>入力中の文字</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="1" column="0" colspan="2">
+                    <widget class="QCheckBox" name="inputPreeditTextColorCheckBox">
+                     <property name="text">
+                      <string>文字色</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="1" column="2">
+                    <widget class="QPushButton" name="inputPreeditTextColorButton">
+                     <property name="minimumSize">
+                      <size>
+                       <width>80</width>
+                       <height>0</height>
+                      </size>
+                     </property>
+                     <property name="maximumSize">
+                      <size>
+                       <width>90</width>
+                       <height>16777215</height>
+                      </size>
+                     </property>
+                     <property name="text">
+                      <string>#FF5000</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="2" column="0" colspan="2">
+                    <widget class="QCheckBox" name="inputPreeditBackgroundColorCheckBox">
+                     <property name="text">
+                      <string>背景色</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="2" column="2">
+                    <widget class="QPushButton" name="inputPreeditBackgroundColorButton">
+                     <property name="minimumSize">
+                      <size>
+                       <width>80</width>
+                       <height>0</height>
+                      </size>
+                     </property>
+                     <property name="maximumSize">
+                      <size>
+                       <width>90</width>
+                       <height>16777215</height>
+                      </size>
+                     </property>
+                     <property name="text">
+                      <string>#FFFFCC</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="3" column="0" colspan="2">
+                    <widget class="QCheckBox" name="inputPreeditUnderlineColorCheckBox">
+                     <property name="text">
+                      <string>下線色</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="3" column="2">
+                    <widget class="QPushButton" name="inputPreeditUnderlineColorButton">
+                     <property name="minimumSize">
+                      <size>
+                       <width>80</width>
+                       <height>0</height>
+                      </size>
+                     </property>
+                     <property name="maximumSize">
+                      <size>
+                       <width>90</width>
+                       <height>16777215</height>
+                      </size>
+                     </property>
+                     <property name="text">
+                      <string>#FF0000</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="4" column="0" colspan="3">
+                    <spacer name="verticalSpacer_targetPreeditColor">
+                     <property name="orientation">
+                      <enum>Qt::Orientation::Vertical</enum>
+                     </property>
+                     <property name="sizeHint" stdset="0">
+                      <size>
+                       <width>20</width>
+                       <height>18</height>
+                      </size>
+                     </property>
+                    </spacer>
+                   </item>
+                   <item row="5" column="0" colspan="3">
+                    <widget class="QLabel" name="targetPreeditColorLabel">
+                     <property name="text">
+                      <string>変換中の文節</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="6" column="0" colspan="2">
+                    <widget class="QCheckBox" name="targetPreeditTextColorCheckBox">
+                     <property name="text">
+                      <string>文字色</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="6" column="2">
+                    <widget class="QPushButton" name="targetPreeditTextColorButton">
+                     <property name="minimumSize">
+                      <size>
+                       <width>80</width>
+                       <height>0</height>
+                      </size>
+                     </property>
+                     <property name="maximumSize">
+                      <size>
+                       <width>90</width>
+                       <height>16777215</height>
+                      </size>
+                     </property>
+                     <property name="text">
+                      <string>#000000</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="7" column="0" colspan="2">
+                    <widget class="QCheckBox" name="targetPreeditBackgroundColorCheckBox">
+                     <property name="text">
+                      <string>背景色</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="7" column="2">
+                    <widget class="QPushButton" name="targetPreeditBackgroundColorButton">
+                     <property name="minimumSize">
+                      <size>
+                       <width>80</width>
+                       <height>0</height>
+                      </size>
+                     </property>
+                     <property name="maximumSize">
+                      <size>
+                       <width>90</width>
+                       <height>16777215</height>
+                      </size>
+                     </property>
+                     <property name="text">
+                      <string>#DDEEFF</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="8" column="0" colspan="2">
+                    <widget class="QCheckBox" name="targetPreeditUnderlineColorCheckBox">
+                     <property name="text">
+                      <string>下線色</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="8" column="2">
+                    <widget class="QPushButton" name="targetPreeditUnderlineColorButton">
+                     <property name="minimumSize">
+                      <size>
+                       <width>80</width>
+                       <height>0</height>
+                      </size>
+                     </property>
+                     <property name="maximumSize">
+                      <size>
+                       <width>90</width>
+                       <height>16777215</height>
+                      </size>
+                     </property>
+                     <property name="text">
+                      <string>#0066FF</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="9" column="0" colspan="3">
+                    <widget class="QLabel" name="preeditDisplayColorNoteLabel">
+                     <property name="text">
+                      <string>対応アプリのみ有効。Chrome/Edge等は非対応の場合あり。</string>
+                     </property>
+                     <property name="toolTip">
+                      <string>この設定は Windows TSF の表示属性を利用します。対応アプリでのみ有効です。Chrome や Edge など、一部のアプリでは反映されない場合があります。</string>
+                     </property>
+                     <property name="wordWrap">
+                      <bool>false</bool>
+                     </property>
+                    </widget>
+                   </item>
+                  </layout>
                  </widget>
                 </item>
                </layout>
               </widget>
              </item>
              <item>
-              <widget class="QCheckBox" name="IMEHotKeyDisabledCheckBox">
-               <property name="text">
-                <string>Disable Keyboard layout hotkey (Ctrl+Shift)</string>
-               </property>
-              </widget>
-             </item>
-            </layout>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item>
-        <widget class="QWidget" name="miscAdministrationWidget" native="true">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <layout class="QVBoxLayout" name="verticalLayout_4">
-          <property name="spacing">
-           <number>10</number>
-          </property>
-          <property name="leftMargin">
-           <number>0</number>
-          </property>
-          <property name="topMargin">
-           <number>0</number>
-          </property>
-          <property name="rightMargin">
-           <number>5</number>
-          </property>
-          <property name="bottomMargin">
-           <number>0</number>
-          </property>
-          <item>
-           <widget class="QWidget" name="widget_7" native="true">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <layout class="QHBoxLayout" name="horizontalLayout_7">
-             <property name="spacing">
-              <number>6</number>
-             </property>
-             <property name="margin" stdset="0">
-              <number>0</number>
-             </property>
-             <item>
-              <widget class="QLabel" name="administrationLabel">
-               <property name="text">
-                <string>Administration</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="Line" name="administrationLine">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
+              <spacer name="inputSupportBottomSpacer">
                <property name="orientation">
-                <enum>Qt::Orientation::Horizontal</enum>
+                <enum>Qt::Orientation::Vertical</enum>
                </property>
-              </widget>
-             </item>
-            </layout>
-           </widget>
-          </item>
-          <item>
-           <widget class="QWidget" name="widget_8" native="true">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <layout class="QGridLayout" name="gridLayout_7">
-             <property name="leftMargin">
-              <number>12</number>
-             </property>
-             <property name="topMargin">
-              <number>0</number>
-             </property>
-             <property name="rightMargin">
-              <number>0</number>
-             </property>
-             <property name="bottomMargin">
-              <number>0</number>
-             </property>
-             <item row="0" column="0">
-              <widget class="QLabel" name="dictionaryPreloadingAndUACLabel">
-               <property name="text">
-                <string>Dictionary preloading and UAC settings</string>
-               </property>
-              </widget>
-             </item>
-             <item row="0" column="2">
-              <widget class="QPushButton" name="launchAdministrationDialogButton">
-               <property name="minimumSize">
-                <size>
-                 <width>120</width>
-                 <height>0</height>
-                </size>
-               </property>
-               <property name="text">
-                <string>Settings...</string>
-               </property>
-              </widget>
-             </item>
-             <item row="0" column="1">
-              <spacer name="horizontalSpacer_9">
-               <property name="orientation">
-                <enum>Qt::Orientation::Horizontal</enum>
+               <property name="sizeType">
+                <enum>QSizePolicy::Policy::Maximum</enum>
                </property>
                <property name="sizeHint" stdset="0">
                 <size>
-                 <width>40</width>
-                 <height>20</height>
+                 <width>20</width>
+                 <height>12</height>
                 </size>
                </property>
               </spacer>
              </item>
             </layout>
            </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item>
-        <widget class="QWidget" name="miscStartupWidget" native="true">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+       <widget class="QWidget" name="suggestionsTab">
+        <attribute name="title">
+         <string>Suggest</string>
+        </attribute>
+        <layout class="QVBoxLayout" name="suggestionsTabLayout">
+         <property name="spacing">
+          <number>0</number>
          </property>
-         <layout class="QVBoxLayout" name="verticalLayout_7">
-          <property name="leftMargin">
-           <number>0</number>
-          </property>
-          <property name="topMargin">
-           <number>0</number>
-          </property>
-          <property name="rightMargin">
-           <number>5</number>
-          </property>
-          <property name="bottomMargin">
-           <number>0</number>
-          </property>
-          <item>
-           <widget class="QWidget" name="widget_11" native="true">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
+         <item>
+          <widget class="QFrame" name="suggestSourceHeader">
+           <property name="frameShape">
+            <enum>QFrame::Shape::NoFrame</enum>
+           </property>
+           <layout class="QHBoxLayout" name="horizontalLayout_12">
+            <property name="leftMargin">
+             <number>9</number>
             </property>
-            <layout class="QHBoxLayout" name="horizontalLayout_19">
-             <property name="margin" stdset="0">
-              <number>0</number>
-             </property>
-             <item>
-              <widget class="QLabel" name="startupLabel">
-               <property name="text">
-                <string>Startup</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="Line" name="startupLine">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="orientation">
-                <enum>Qt::Orientation::Horizontal</enum>
-               </property>
-              </widget>
-             </item>
-            </layout>
-           </widget>
-          </item>
-          <item>
-           <widget class="QWidget" name="widget_12" native="true">
-            <layout class="QVBoxLayout" name="verticalLayout_6">
-             <property name="leftMargin">
-              <number>12</number>
-             </property>
-             <property name="topMargin">
-              <number>0</number>
-             </property>
-             <property name="rightMargin">
-              <number>0</number>
-             </property>
-             <property name="bottomMargin">
-              <number>0</number>
-             </property>
-             <item>
-              <widget class="QCheckBox" name="startupCheckBox">
-               <property name="text">
-                <string>Start conversion engine on login</string>
-               </property>
-              </widget>
-             </item>
-            </layout>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item>
-        <widget class="QWidget" name="miscLoggingWidget" native="true">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <layout class="QVBoxLayout" name="verticalLayout_5">
-          <property name="spacing">
-           <number>10</number>
-          </property>
-          <property name="leftMargin">
-           <number>0</number>
-          </property>
-          <property name="topMargin">
-           <number>0</number>
-          </property>
-          <property name="rightMargin">
-           <number>5</number>
-          </property>
-          <property name="bottomMargin">
-           <number>0</number>
-          </property>
-          <item>
-           <widget class="QWidget" name="widget_9" native="true">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
+            <property name="topMargin">
+             <number>9</number>
             </property>
-            <layout class="QHBoxLayout" name="horizontalLayout_13">
-             <property name="margin" stdset="0">
-              <number>0</number>
-             </property>
-             <item>
-              <widget class="QLabel" name="loggingLabel">
-               <property name="text">
-                <string>Logging</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="Line" name="loggingLine">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="orientation">
-                <enum>Qt::Orientation::Horizontal</enum>
-               </property>
-              </widget>
-             </item>
-            </layout>
-           </widget>
-          </item>
-          <item>
-           <widget class="QWidget" name="widget_10" native="true">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
+            <property name="rightMargin">
+             <number>9</number>
             </property>
-            <layout class="QHBoxLayout" name="horizontalLayout_15">
-             <property name="leftMargin">
-              <number>12</number>
-             </property>
-             <property name="topMargin">
-              <number>0</number>
-             </property>
-             <property name="rightMargin">
-              <number>0</number>
-             </property>
-             <property name="bottomMargin">
-              <number>0</number>
-             </property>
-             <item>
-              <widget class="QLabel" name="verboseLevelLabel">
-               <property name="text">
-                <string>Logging level (debug only)</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <spacer name="horizontalSpacer_13">
-               <property name="orientation">
-                <enum>Qt::Orientation::Horizontal</enum>
-               </property>
-               <property name="sizeHint" stdset="0">
-                <size>
-                 <width>40</width>
-                 <height>20</height>
-                </size>
-               </property>
-              </spacer>
-             </item>
-             <item>
-              <widget class="QComboBox" name="verboseLevelComboBox">
-               <property name="minimumSize">
-                <size>
-                 <width>100</width>
-                 <height>0</height>
-                </size>
-               </property>
-              </widget>
-             </item>
-            </layout>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item>
-        <spacer name="verticalSpacer_2">
-         <property name="orientation">
-          <enum>Qt::Orientation::Vertical</enum>
+            <property name="bottomMargin">
+             <number>9</number>
+            </property>
+            <property name="spacing">
+             <number>6</number>
+            </property>
+            <item>
+             <widget class="QLabel" name="label_3">
+              <property name="text">
+               <string>Source data</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="Line" name="line_4">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="orientation">
+               <enum>Qt::Orientation::Horizontal</enum>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+         </item>
+         <item>
+          <widget class="QFrame" name="suggestSourceGroup">
+           <property name="frameShape">
+            <enum>QFrame::Shape::NoFrame</enum>
+           </property>
+           <layout class="QGridLayout" name="gridLayout_4">
+            <property name="verticalSpacing">
+             <number>6</number>
+            </property>
+            <property name="horizontalSpacing">
+             <number>8</number>
+            </property>
+            <property name="leftMargin">
+             <number>24</number>
+            </property>
+            <property name="topMargin">
+             <number>9</number>
+            </property>
+            <property name="rightMargin">
+             <number>24</number>
+            </property>
+            <property name="bottomMargin">
+             <number>9</number>
+            </property>
+            <item row="0" column="0" colspan="3">
+             <widget class="QCheckBox" name="historySuggestCheckBox">
+              <property name="text">
+               <string>Use input history</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="2">
+             <widget class="QPushButton" name="clearUserPredictionButton">
+              <property name="minimumSize">
+               <size>
+                <width>120</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="text">
+               <string>Clear all history</string>
+              </property>
+             </widget>
+            </item>
+            <item row="3" column="0" colspan="3">
+             <widget class="QCheckBox" name="dictionarySuggestCheckBox">
+              <property name="text">
+               <string>Use system dictionary</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="1">
+             <widget class="QPushButton" name="clearUnusedUserPredictionButton">
+              <property name="minimumSize">
+               <size>
+                <width>120</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="text">
+               <string>Clear unused history</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="0">
+             <spacer name="horizontalSpacer_6">
+              <property name="orientation">
+               <enum>Qt::Orientation::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item row="2" column="1">
+             <spacer name="verticalSpacer">
+              <property name="orientation">
+               <enum>Qt::Orientation::Vertical</enum>
+              </property>
+              <property name="sizeType">
+               <enum>QSizePolicy::Policy::Maximum</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>20</width>
+                <height>24</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item row="4" column="0" colspan="3">
+             <widget class="QCheckBox" name="realtimeConversionCheckBox">
+              <property name="text">
+               <string>Use realtime conversion</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+         </item>
+         <item>
+          <widget class="QFrame" name="suggestOtherHeader">
+           <property name="frameShape">
+            <enum>QFrame::Shape::NoFrame</enum>
+           </property>
+           <layout class="QHBoxLayout" name="horizontalLayout_16">
+            <property name="leftMargin">
+             <number>9</number>
+            </property>
+            <property name="topMargin">
+             <number>9</number>
+            </property>
+            <property name="rightMargin">
+             <number>9</number>
+            </property>
+            <property name="bottomMargin">
+             <number>9</number>
+            </property>
+            <property name="spacing">
+             <number>6</number>
+            </property>
+            <item>
+             <widget class="QLabel" name="SuggestionPreferenceLabel">
+              <property name="text">
+               <string>Other settings</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="Line" name="line_8">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="orientation">
+               <enum>Qt::Orientation::Horizontal</enum>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+         </item>
+         <item>
+          <widget class="QFrame" name="suggestOtherGroup">
+           <property name="frameShape">
+            <enum>QFrame::Shape::NoFrame</enum>
+           </property>
+           <layout class="QGridLayout" name="gridLayout_11">
+            <property name="verticalSpacing">
+             <number>6</number>
+            </property>
+            <property name="horizontalSpacing">
+             <number>8</number>
+            </property>
+            <property name="leftMargin">
+             <number>24</number>
+            </property>
+            <property name="topMargin">
+             <number>9</number>
+            </property>
+            <property name="rightMargin">
+             <number>24</number>
+            </property>
+            <property name="bottomMargin">
+             <number>9</number>
+            </property>
+            <item row="0" column="0">
+             <widget class="QLabel" name="defaultNUmberofSuggestionsLabel">
+              <property name="text">
+               <string>Maximum number of suggestions</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="2">
+             <widget class="QSpinBox" name="suggestionsSizeSpinBox"/>
+            </item>
+            <item row="0" column="1">
+             <spacer name="horizontalSpacer_8">
+              <property name="orientation">
+               <enum>Qt::Orientation::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
+          </widget>
+         </item>
+         <item>
+          <spacer name="suggestionsTabBottomSpacer">
+           <property name="orientation">
+            <enum>Qt::Orientation::Vertical</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>20</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </widget>
+       <widget class="QWidget" name="privacyTab">
+        <attribute name="title">
+         <string>Privacy</string>
+        </attribute>
+        <layout class="QVBoxLayout" name="privacyTabLayout">
+         <property name="spacing">
+          <number>0</number>
          </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
+         <item>
+          <widget class="QFrame" name="incognitoModeHeader">
+           <property name="frameShape">
+            <enum>QFrame::Shape::NoFrame</enum>
+           </property>
+           <layout class="QHBoxLayout" name="horizontalLayout_20">
+            <property name="leftMargin">
+             <number>9</number>
+            </property>
+            <property name="topMargin">
+             <number>9</number>
+            </property>
+            <property name="rightMargin">
+             <number>9</number>
+            </property>
+            <property name="bottomMargin">
+             <number>9</number>
+            </property>
+            <property name="spacing">
+             <number>6</number>
+            </property>
+            <item>
+             <widget class="QLabel" name="label_10">
+              <property name="text">
+               <string>Secret mode</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="Line" name="line_11">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="orientation">
+               <enum>Qt::Orientation::Horizontal</enum>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+         </item>
+         <item>
+          <widget class="QFrame" name="incognitoModeGroup">
+           <property name="frameShape">
+            <enum>QFrame::Shape::NoFrame</enum>
+           </property>
+           <layout class="QHBoxLayout" name="incognitoModeLayout">
+            <property name="spacing">
+             <number>8</number>
+            </property>
+            <property name="leftMargin">
+             <number>24</number>
+            </property>
+            <property name="topMargin">
+             <number>9</number>
+            </property>
+            <property name="rightMargin">
+             <number>24</number>
+            </property>
+            <property name="bottomMargin">
+             <number>9</number>
+            </property>
+            <item alignment="Qt::AlignmentFlag::AlignTop">
+             <widget class="QCheckBox" name="incognitoModeCheckBox">
+              <property name="text">
+               <string/>
+              </property>
+              <property name="tristate">
+               <bool>false</bool>
+              </property>
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLabel" name="incognitoModeMessage">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+                <horstretch>1</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string>Temporarily disable conversion personalization, history-based suggestions and user dictionary</string>
+              </property>
+              <property name="wordWrap">
+               <bool>true</bool>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+         </item>
+         <item>
+          <widget class="QFrame" name="presentationModeHeader">
+           <property name="frameShape">
+            <enum>QFrame::Shape::NoFrame</enum>
+           </property>
+           <layout class="QHBoxLayout" name="horizontalLayout_21">
+            <property name="leftMargin">
+             <number>9</number>
+            </property>
+            <property name="topMargin">
+             <number>9</number>
+            </property>
+            <property name="rightMargin">
+             <number>9</number>
+            </property>
+            <property name="bottomMargin">
+             <number>9</number>
+            </property>
+            <property name="spacing">
+             <number>6</number>
+            </property>
+            <item>
+             <widget class="QLabel" name="label_12">
+              <property name="text">
+               <string>Presentation mode</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="Line" name="line_12">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="orientation">
+               <enum>Qt::Orientation::Horizontal</enum>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+         </item>
+         <item>
+          <widget class="QFrame" name="presentationModeGroup">
+           <property name="frameShape">
+            <enum>QFrame::Shape::NoFrame</enum>
+           </property>
+           <layout class="QVBoxLayout" name="presentationModeLayout">
+            <property name="spacing">
+             <number>6</number>
+            </property>
+            <property name="leftMargin">
+             <number>24</number>
+            </property>
+            <property name="topMargin">
+             <number>9</number>
+            </property>
+            <property name="rightMargin">
+             <number>24</number>
+            </property>
+            <property name="bottomMargin">
+             <number>9</number>
+            </property>
+            <item>
+             <widget class="QCheckBox" name="presentationModeCheckBox">
+              <property name="text">
+               <string>Temporarily disable all suggestions</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+         </item>
+         <item>
+          <spacer name="privacyTabBottomSpacer">
+           <property name="orientation">
+            <enum>Qt::Orientation::Vertical</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>20</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </widget>
+       <widget class="QWidget" name="miscTab">
+        <attribute name="title">
+         <string>Misc</string>
+        </attribute>
+        <layout class="QVBoxLayout" name="miscTabLayout">
+         <property name="spacing">
+          <number>0</number>
          </property>
-        </spacer>
-       </item>
-      </layout>
-     </widget>
-    </widget>
-   </widget>
-   <widget class="QWidget" name="horizontalLayoutWidget_12">
-    <property name="geometry">
-     <rect>
-      <x>10</x>
-      <y>400</y>
-      <width>506</width>
-      <height>35</height>
-     </rect>
-    </property>
-    <layout class="QHBoxLayout" name="horizontalLayout_2">
+         <item>
+          <widget class="QWidget" name="widgetMisc" native="true">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <layout class="QVBoxLayout" name="verticalLayout">
+            <property name="leftMargin">
+             <number>0</number>
+            </property>
+            <property name="topMargin">
+             <number>0</number>
+            </property>
+            <property name="rightMargin">
+             <number>0</number>
+            </property>
+            <property name="bottomMargin">
+             <number>0</number>
+            </property>
+            <property name="spacing">
+             <number>0</number>
+            </property>
+            <item>
+             <widget class="QWidget" name="miscDefaultIMEWidget" native="true">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <layout class="QVBoxLayout" name="verticalLayout_3">
+               <property name="leftMargin">
+                <number>0</number>
+               </property>
+               <property name="topMargin">
+                <number>0</number>
+               </property>
+               <property name="rightMargin">
+                <number>0</number>
+               </property>
+               <property name="bottomMargin">
+                <number>0</number>
+               </property>
+               <property name="spacing">
+                <number>0</number>
+               </property>
+               <item>
+                <widget class="QFrame" name="defaultImeHeader">
+                 <property name="frameShape">
+                  <enum>QFrame::Shape::NoFrame</enum>
+                 </property>
+                 <layout class="QHBoxLayout" name="horizontalLayout_5">
+                  <property name="leftMargin">
+                   <number>9</number>
+                  </property>
+                  <property name="topMargin">
+                   <number>9</number>
+                  </property>
+                  <property name="rightMargin">
+                   <number>9</number>
+                  </property>
+                  <property name="bottomMargin">
+                   <number>9</number>
+                  </property>
+                  <property name="spacing">
+                   <number>6</number>
+                  </property>
+                  <property name="margin" stdset="0">
+                   <number>0</number>
+                  </property>
+                  <item>
+                   <widget class="QLabel" name="checkDefaultLabel">
+                    <property name="text">
+                     <string>Default IME</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="Line" name="checkDefaultLine">
+                    <property name="sizePolicy">
+                     <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+                      <horstretch>0</horstretch>
+                      <verstretch>0</verstretch>
+                     </sizepolicy>
+                    </property>
+                    <property name="orientation">
+                     <enum>Qt::Orientation::Horizontal</enum>
+                    </property>
+                   </widget>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
+                <widget class="QFrame" name="defaultImeGroup">
+                 <property name="frameShape">
+                  <enum>QFrame::Shape::NoFrame</enum>
+                 </property>
+                 <layout class="QVBoxLayout" name="verticalLayout_2">
+                  <property name="spacing">
+                   <number>6</number>
+                  </property>
+                  <property name="leftMargin">
+                   <number>24</number>
+                  </property>
+                  <property name="topMargin">
+                   <number>9</number>
+                  </property>
+                  <property name="rightMargin">
+                   <number>24</number>
+                  </property>
+                  <property name="bottomMargin">
+                   <number>9</number>
+                  </property>
+                  <item>
+                   <widget class="QWidget" name="defaultImeButtonsWidget" native="true">
+                    <layout class="QHBoxLayout" name="defaultImeButtonsLayout">
+                     <property name="leftMargin">
+                      <number>0</number>
+                     </property>
+                     <property name="topMargin">
+                      <number>0</number>
+                     </property>
+                     <property name="rightMargin">
+                      <number>0</number>
+                     </property>
+                     <property name="bottomMargin">
+                      <number>0</number>
+                     </property>
+                     <item>
+                      <widget class="QPushButton" name="setDefaultImeButton">
+                       <property name="text">
+                        <string>Set as Windows default IME</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QPushButton" name="restoreDefaultImeButton">
+                       <property name="text">
+                        <string>Restore previous setting</string>
+                       </property>
+                      </widget>
+                     </item>
+                    </layout>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QCheckBox" name="IMEHotKeyDisabledCheckBox">
+                    <property name="text">
+                     <string>Disable Keyboard layout hotkey (Ctrl+Shift)</string>
+                    </property>
+                   </widget>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </item>
+            <item>
+             <widget class="QWidget" name="miscAdministrationWidget" native="true">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <layout class="QVBoxLayout" name="verticalLayout_4">
+               <property name="leftMargin">
+                <number>0</number>
+               </property>
+               <property name="topMargin">
+                <number>0</number>
+               </property>
+               <property name="rightMargin">
+                <number>0</number>
+               </property>
+               <property name="bottomMargin">
+                <number>0</number>
+               </property>
+               <property name="spacing">
+                <number>0</number>
+               </property>
+               <item>
+                <widget class="QFrame" name="administrationHeader">
+                 <property name="frameShape">
+                  <enum>QFrame::Shape::NoFrame</enum>
+                 </property>
+                 <layout class="QHBoxLayout" name="horizontalLayout_7">
+                  <property name="leftMargin">
+                   <number>9</number>
+                  </property>
+                  <property name="topMargin">
+                   <number>9</number>
+                  </property>
+                  <property name="rightMargin">
+                   <number>9</number>
+                  </property>
+                  <property name="bottomMargin">
+                   <number>9</number>
+                  </property>
+                  <property name="spacing">
+                   <number>6</number>
+                  </property>
+                  <property name="margin" stdset="0">
+                   <number>0</number>
+                  </property>
+                  <item>
+                   <widget class="QLabel" name="administrationLabel">
+                    <property name="text">
+                     <string>Administration</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="Line" name="administrationLine">
+                    <property name="sizePolicy">
+                     <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+                      <horstretch>0</horstretch>
+                      <verstretch>0</verstretch>
+                     </sizepolicy>
+                    </property>
+                    <property name="orientation">
+                     <enum>Qt::Orientation::Horizontal</enum>
+                    </property>
+                   </widget>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
+                <widget class="QFrame" name="administrationGroup">
+                 <property name="frameShape">
+                  <enum>QFrame::Shape::NoFrame</enum>
+                 </property>
+                 <layout class="QGridLayout" name="gridLayout_7">
+                  <property name="verticalSpacing">
+                   <number>6</number>
+                  </property>
+                  <property name="horizontalSpacing">
+                   <number>8</number>
+                  </property>
+                  <property name="leftMargin">
+                   <number>24</number>
+                  </property>
+                  <property name="topMargin">
+                   <number>9</number>
+                  </property>
+                  <property name="rightMargin">
+                   <number>24</number>
+                  </property>
+                  <property name="bottomMargin">
+                   <number>9</number>
+                  </property>
+                  <item row="0" column="0">
+                   <widget class="QLabel" name="dictionaryPreloadingAndUACLabel">
+                    <property name="text">
+                     <string>Dictionary preloading and UAC settings</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="0" column="2">
+                   <widget class="QPushButton" name="launchAdministrationDialogButton">
+                    <property name="minimumSize">
+                     <size>
+                      <width>120</width>
+                      <height>0</height>
+                     </size>
+                    </property>
+                    <property name="text">
+                     <string>Settings...</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="0" column="1">
+                   <spacer name="horizontalSpacer_9">
+                    <property name="orientation">
+                     <enum>Qt::Orientation::Horizontal</enum>
+                    </property>
+                    <property name="sizeHint" stdset="0">
+                     <size>
+                      <width>40</width>
+                      <height>20</height>
+                     </size>
+                    </property>
+                   </spacer>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </item>
+            <item>
+             <widget class="QWidget" name="miscStartupWidget" native="true">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <layout class="QVBoxLayout" name="verticalLayout_7">
+               <property name="leftMargin">
+                <number>0</number>
+               </property>
+               <property name="topMargin">
+                <number>0</number>
+               </property>
+               <property name="rightMargin">
+                <number>0</number>
+               </property>
+               <property name="bottomMargin">
+                <number>0</number>
+               </property>
+               <property name="spacing">
+                <number>0</number>
+               </property>
+               <item>
+                <widget class="QFrame" name="startupHeader">
+                 <property name="frameShape">
+                  <enum>QFrame::Shape::NoFrame</enum>
+                 </property>
+                 <layout class="QHBoxLayout" name="horizontalLayout_19">
+                  <property name="leftMargin">
+                   <number>9</number>
+                  </property>
+                  <property name="topMargin">
+                   <number>9</number>
+                  </property>
+                  <property name="rightMargin">
+                   <number>9</number>
+                  </property>
+                  <property name="bottomMargin">
+                   <number>9</number>
+                  </property>
+                  <property name="spacing">
+                   <number>6</number>
+                  </property>
+                  <property name="margin" stdset="0">
+                   <number>0</number>
+                  </property>
+                  <item>
+                   <widget class="QLabel" name="startupLabel">
+                    <property name="text">
+                     <string>Startup</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="Line" name="startupLine">
+                    <property name="sizePolicy">
+                     <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+                      <horstretch>0</horstretch>
+                      <verstretch>0</verstretch>
+                     </sizepolicy>
+                    </property>
+                    <property name="orientation">
+                     <enum>Qt::Orientation::Horizontal</enum>
+                    </property>
+                   </widget>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
+                <widget class="QFrame" name="startupGroup">
+                 <property name="frameShape">
+                  <enum>QFrame::Shape::NoFrame</enum>
+                 </property>
+                 <layout class="QVBoxLayout" name="verticalLayout_6">
+                  <property name="spacing">
+                   <number>6</number>
+                  </property>
+                  <property name="leftMargin">
+                   <number>24</number>
+                  </property>
+                  <property name="topMargin">
+                   <number>9</number>
+                  </property>
+                  <property name="rightMargin">
+                   <number>24</number>
+                  </property>
+                  <property name="bottomMargin">
+                   <number>9</number>
+                  </property>
+                  <item>
+                   <widget class="QCheckBox" name="startupCheckBox">
+                    <property name="text">
+                     <string>Start conversion engine on login</string>
+                    </property>
+                   </widget>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </item>
+            <item>
+             <widget class="QWidget" name="miscLoggingWidget" native="true">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <layout class="QVBoxLayout" name="verticalLayout_5">
+               <property name="leftMargin">
+                <number>0</number>
+               </property>
+               <property name="topMargin">
+                <number>0</number>
+               </property>
+               <property name="rightMargin">
+                <number>0</number>
+               </property>
+               <property name="bottomMargin">
+                <number>0</number>
+               </property>
+               <property name="spacing">
+                <number>0</number>
+               </property>
+               <item>
+                <widget class="QFrame" name="loggingHeader">
+                 <property name="frameShape">
+                  <enum>QFrame::Shape::NoFrame</enum>
+                 </property>
+                 <layout class="QHBoxLayout" name="horizontalLayout_13">
+                  <property name="leftMargin">
+                   <number>9</number>
+                  </property>
+                  <property name="topMargin">
+                   <number>9</number>
+                  </property>
+                  <property name="rightMargin">
+                   <number>9</number>
+                  </property>
+                  <property name="bottomMargin">
+                   <number>9</number>
+                  </property>
+                  <property name="spacing">
+                   <number>6</number>
+                  </property>
+                  <property name="margin" stdset="0">
+                   <number>0</number>
+                  </property>
+                  <item>
+                   <widget class="QLabel" name="loggingLabel">
+                    <property name="text">
+                     <string>Logging</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="Line" name="loggingLine">
+                    <property name="sizePolicy">
+                     <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+                      <horstretch>0</horstretch>
+                      <verstretch>0</verstretch>
+                     </sizepolicy>
+                    </property>
+                    <property name="orientation">
+                     <enum>Qt::Orientation::Horizontal</enum>
+                    </property>
+                   </widget>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
+                <widget class="QFrame" name="loggingGroup">
+                 <property name="frameShape">
+                  <enum>QFrame::Shape::NoFrame</enum>
+                 </property>
+                 <layout class="QHBoxLayout" name="horizontalLayout_15">
+                  <property name="spacing">
+                   <number>6</number>
+                  </property>
+                  <property name="leftMargin">
+                   <number>24</number>
+                  </property>
+                  <property name="topMargin">
+                   <number>9</number>
+                  </property>
+                  <property name="rightMargin">
+                   <number>24</number>
+                  </property>
+                  <property name="bottomMargin">
+                   <number>9</number>
+                  </property>
+                  <item>
+                   <widget class="QLabel" name="verboseLevelLabel">
+                    <property name="text">
+                     <string>Logging level (debug only)</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <spacer name="horizontalSpacer_13">
+                    <property name="orientation">
+                     <enum>Qt::Orientation::Horizontal</enum>
+                    </property>
+                    <property name="sizeHint" stdset="0">
+                     <size>
+                      <width>40</width>
+                      <height>20</height>
+                     </size>
+                    </property>
+                   </spacer>
+                  </item>
+                  <item>
+                   <widget class="QComboBox" name="verboseLevelComboBox">
+                    <property name="minimumSize">
+                     <size>
+                      <width>100</width>
+                      <height>0</height>
+                     </size>
+                    </property>
+                   </widget>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </item>
+            <item>
+             <spacer name="verticalSpacer_2">
+              <property name="orientation">
+               <enum>Qt::Orientation::Vertical</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>20</width>
+                <height>40</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
+          </widget>
+         </item>
+         <item>
+          <spacer name="miscTabBottomSpacer">
+           <property name="orientation">
+            <enum>Qt::Orientation::Vertical</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>20</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </widget>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="footerLayout">
      <item>
       <widget class="QPushButton" name="resetToDefaultsButton">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
        <property name="minimumSize">
         <size>
          <width>110</width>
@@ -2734,6 +3221,12 @@
        </property>
        <property name="text">
         <string>Reset to defaults</string>
+       </property>
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
        </property>
       </widget>
      </item>
@@ -2752,20 +3245,20 @@
      </item>
      <item>
       <widget class="QDialogButtonBox" name="configDialogButtonBox">
+       <property name="standardButtons">
+        <set>QDialogButtonBox::StandardButton::Apply|QDialogButtonBox::StandardButton::Cancel|QDialogButtonBox::StandardButton::Ok</set>
+       </property>
        <property name="sizePolicy">
-        <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+        <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
          <horstretch>0</horstretch>
          <verstretch>0</verstretch>
         </sizepolicy>
        </property>
-       <property name="standardButtons">
-        <set>QDialogButtonBox::StandardButton::Apply|QDialogButtonBox::StandardButton::Cancel|QDialogButtonBox::StandardButton::Ok</set>
-       </property>
       </widget>
      </item>
     </layout>
-   </widget>
-  </widget>
+   </item>
+  </layout>
  </widget>
  <customwidgets>
   <customwidget>


### PR DESCRIPTION
## 概要

設定ダイアログの固定座標ベースのレイアウトを見直し、
ウィンドウサイズに追従するレスポンシブなレイアウトへ変更します。

特に Advanced タブでは、設定項目をレイアウト管理下に移し、
ウィンドウのリサイズやスクロール時にも各セクションが自然に配置されるようにしました。

## 主な変更

- 設定ダイアログ全体をリサイズ可能なレイアウトへ変更
- Advanced タブの固定座標配置をレイアウトベースへ変更
- 候補・サジェスト・ルビ等の外観設定を既存レイアウトへ動的に挿入
- Advanced タブの最小幅を内容に応じて設定
- 狭いウィンドウ幅では必要に応じて水平スクロールを利用
- Character Form Editor の高さを内容に応じて調整
- macOS で非表示になる Windows 専用項目の後に不要な空白が残らないよう整理
- 既存のプラットフォーム固有表示・設定保存・dirty tracking の挙動を維持

## 検証

### Windows

- 開発版 ConfigDialog の各タブ・リサイズ・スクロールを確認
- Cancel / Apply / 再起動後の設定保存を確認
- dirty tracking と依存 UI を確認
- Character Form Editor を確認
- release MSI をビルド
- MSI payload とビルド成果物の一致を確認
- 旧版をクリーンアンインストール後、再起動して通常インストール
- インストール済み ConfigDialog の実動作を確認

### macOS

- 開発版 ConfigDialog の各タブ・リサイズ・スクロールを確認
- Apply / 再起動後の設定保存を確認
- Zenz runtime を含む PKG をビルド
- ConfigDialog / llama-server / GGUF の package payload を検証
- Mozc.app / ConfigDialog.app / llama-server の code signature を検証
- 通常の PKG upgrade install を実施
- インストール済み主要 payload が PKG 内のファイルと一致することを確認
- インストール済み Preferences の実動作を確認
- 実際の日本語入力・ライブ変換を確認
- mozc_zenz_scorer / llama-server / GGUF を使用した Zenz runtime の実起動を確認

macOS の今回の実機検証は Apple Silicon (arm64) で実施しています。