### PR TITLE
Feature/config dialog control usability

### DIFF
--- a/src/gui/config_dialog/config_dialog.cc
+++ b/src/gui/config_dialog/config_dialog.cc
@@ -356,7 +356,7 @@ ConfigDialog::ConfigDialog()
   suggestionsSizeSpinBox->setRange(1, 9);
 
   liveConversionDelaySpinBox->setRange(0, 1000);
-  liveConversionDelaySpinBox->setSingleStep(5);
+  liveConversionDelaySpinBox->setSingleStep(1);
   liveConversionDelaySpinBox->setSuffix(QString::fromUtf8(" ms"));
   liveConversionDelaySpinBox->setSpecialValueText(QString::fromUtf8("即時"));
 
@@ -365,7 +365,7 @@ ConfigDialog::ConfigDialog()
   liveConversionMinKeyLengthSpinBox->setSuffix(QString::fromUtf8(" 文字"));
 
   zenzLiveCorrectionDelaySpinBox->setRange(0, 5000);
-  zenzLiveCorrectionDelaySpinBox->setSingleStep(100);
+  zenzLiveCorrectionDelaySpinBox->setSingleStep(1);
   zenzLiveCorrectionDelaySpinBox->setSuffix(QString::fromUtf8(" ms"));
   zenzLiveCorrectionDelaySpinBox->setSpecialValueText(QString::fromUtf8("即時"));
 
@@ -2593,7 +2593,7 @@ void ConfigDialog::InitializeRendererAppearanceControls() {
     QSpinBox* size_spin = new QSpinBox(group);
     size_spin->setObjectName(QString::fromLatin1(size_name));
     size_spin->setRange(80, 200);
-    size_spin->setSingleStep(5);
+    size_spin->setSingleStep(1);
     size_spin->setSuffix(QStringLiteral(" %"));
     size_spin->setValue(100);
     size_spin->setMinimumHeight(24);

--- a/src/gui/config_dialog/config_dialog.cc
+++ b/src/gui/config_dialog/config_dialog.cc
@@ -31,6 +31,8 @@
 #include "gui/config_dialog/config_dialog.h"
 
 #include <QAbstractItemView>
+#include <QAbstractScrollArea>
+#include <QAbstractSpinBox>
 #include <QByteArray>
 #include <QComboBox>
 #include <QCoreApplication>
@@ -54,6 +56,7 @@
 #include <QTableWidget>
 #include <QTableWidgetItem>
 #include <QVBoxLayout>
+#include <QWheelEvent>
 #include <algorithm>
 #include <cstdint>
 #include <istream>
@@ -114,6 +117,34 @@ void Connect(const QList<T *> &objects, const char *signal,
        itr != objects.end(); ++itr) {
     QObject::connect(*itr, signal, receiver, slot);
   }
+}
+
+QAbstractScrollArea *FindAncestorScrollArea(QWidget *widget) {
+  for (QWidget *parent = widget->parentWidget(); parent != nullptr;
+       parent = parent->parentWidget()) {
+    if (QAbstractScrollArea *scroll_area =
+            qobject_cast<QAbstractScrollArea *>(parent)) {
+      return scroll_area;
+    }
+  }
+  return nullptr;
+}
+
+void ForwardWheelEventToScrollArea(QWidget *source, QWheelEvent *event) {
+  QAbstractScrollArea *scroll_area = FindAncestorScrollArea(source);
+  if (scroll_area == nullptr) {
+    return;
+  }
+
+  QWidget *viewport = scroll_area->viewport();
+  const QPointF viewport_position =
+      viewport->mapFromGlobal(event->globalPosition().toPoint());
+  QWheelEvent forwarded_event(
+      viewport_position, event->globalPosition(), event->pixelDelta(),
+      event->angleDelta(), event->buttons(), event->modifiers(), event->phase(),
+      event->inverted(), Qt::MouseEventNotSynthesized,
+      event->pointingDevice());
+  QCoreApplication::sendEvent(viewport, &forwarded_event);
 }
 
 int FindComboBoxItemByData(QComboBox *combo_box, const QString &data) {
@@ -539,6 +570,14 @@ ConfigDialog::ConfigDialog()
           SLOT(EnableApplyButton()));
   // 'Apply' button is disabled on launching.
   configDialogButtonBox->button(QDialogButtonBox::Apply)->setEnabled(false);
+
+  // Prevent mouse-wheel and trackpad scrolling from silently changing
+  // combo-box and spin-box values anywhere in this dialog.  Install the
+  // filter on the application so controls created later by item delegates are
+  // covered too.
+  if (QCoreApplication *application = QCoreApplication::instance()) {
+    application->installEventFilter(this);
+  }
 
   // When clicking these messages, CheckBoxs corresponding
   // to them should be toggled.
@@ -4300,6 +4339,22 @@ void ConfigDialog::EnableApplyButton() {
 
 // Catch MouseButtonRelease event to toggle the CheckBoxes
 bool ConfigDialog::eventFilter(QObject *obj, QEvent *event) {
+  if (event->type() == QEvent::Wheel) {
+    QWidget *widget = qobject_cast<QWidget *>(obj);
+    if (widget != nullptr && isAncestorOf(widget) &&
+        (qobject_cast<QComboBox *>(widget) != nullptr ||
+         qobject_cast<QAbstractSpinBox *>(widget) != nullptr)) {
+      // QComboBox and QAbstractSpinBox normally consume wheel gestures to
+      // change their value.  In a settings dialog this is easy to trigger
+      // accidentally while scrolling.  Keep the setting unchanged and, when
+      // the control lives in a scroll area, forward the same gesture to that
+      // scroll area instead.
+      ForwardWheelEventToScrollArea(widget,
+                                    static_cast<QWheelEvent *>(event));
+      return true;
+    }
+  }
+
   if (event->type() == QEvent::MouseButtonRelease) {
     if (obj == incognitoModeMessage) {
       incognitoModeCheckBox->toggle();

--- a/src/gui/config_dialog/config_dialog.ui
+++ b/src/gui/config_dialog/config_dialog.ui
@@ -1166,7 +1166,7 @@
                    <number>1000</number>
                   </property>
                   <property name="singleStep">
-                   <number>5</number>
+                   <number>1</number>
                   </property>
                   <property name="value">
                    <number>228</number>
@@ -1525,7 +1525,7 @@
                    <number>5000</number>
                   </property>
                   <property name="singleStep">
-                   <number>100</number>
+                   <number>1</number>
                   </property>
                   <property name="value">
                    <number>1000</number>


### PR DESCRIPTION
## 概要

設定ダイアログの ComboBox / SpinBox に対するホイール・トラックパッド操作によって、
意図せず設定値が変更される問題を改善します。

あわせて、一部の数値設定について変更刻みを細かくし、
より精密に調整できるようにします。

## 変更内容

### ホイール操作による設定値の誤変更を防止

ConfigDialog 内の以下のコントロールでは、
マウスホイールまたはトラックパッドのスクロール操作によって値を変更しないようにしました。

- `QComboBox`
- `QAbstractSpinBox` 派生コントロール

Advanced タブのようにスクロール可能な領域内にある場合は、
コントロール上で発生したホイールイベントを親のスクロール領域へ転送します。

これにより、

- ComboBox / SpinBox の値は意図せず変更されない
- コントロール上にポインタがあってもページ自体はスクロールできる

という挙動になります。

クリックによる選択、SpinBox の上下ボタン、数値の直接入力、
キーボード操作などの通常操作は従来どおり利用できます。

### 数値設定の変更刻みを細分化

以下の設定をより細かく調整できるようにしました。

- ライブ変換遅延
  - 5 ms 刻み → 1 ms 刻み
- Zenz 補正開始遅延
  - 100 ms 刻み → 1 ms 刻み
- Candidate window size
  - 5% 刻み → 1% 刻み
- Suggestion window size
  - 5% 刻み → 1% 刻み
- Ruby window size
  - 5% 刻み → 1% 刻み

`.ui` 側と C++ 側の設定値も一致させています。

## 実装

ConfigDialog にアプリケーションレベルの event filter を追加し、
ConfigDialog 配下の `QComboBox` / `QAbstractSpinBox` に対する
`QEvent::Wheel` を処理します。

スクロール可能な親 `QAbstractScrollArea` が存在する場合は、
元の wheel event の以下の情報を保持したまま viewport へ転送します。

- pixel delta
- angle delta
- mouse buttons
- modifiers
- scroll phase
- inverted state
- pointing device

そのうえで元のコントロール側の wheel event を消費することで、
値の変更のみを防止します。

動的に生成される設定コントロールも対象となります。

## 動作確認

### Windows

- ConfigDialog development build: PASS
- development ConfigDialog runtime: PASS
- マウスホイールによる ComboBox / SpinBox の誤変更防止: PASS
- Advanced タブのスクロール継続: PASS
- 1 ms / 1% 刻み: PASS
- MSI package build: PASS
- Bazel `mozc_tool_win.exe` と MSI 内 `mozc_tool.exe` の payload identity: EXACT
- clean uninstall → reboot →通常 MSI install: PASS
- TIP registration: PASS
- インストール済み `mozc_tool.exe` と監査済み MSI payload: EXACT
- インストール済み ConfigDialog runtime: PASS
- 実際の日本語入力: PASS
- Zenz runtime (`mozc_zenz_scorer` / `llama-server`): PASS

### macOS

- ConfigDialog development build: PASS
- development ConfigDialog runtime: PASS
- トラックパッドによる ComboBox / SpinBox の誤変更防止: PASS
- Advanced タブのスクロール継続: PASS
- 1 ms / 1% 刻み: PASS
- Zenz 対応 PKG build: PASS
- ConfigDialog / llama-server / GGUF payload: PASS
- payload code signature verification: PASS
- PKG 実インストール: PASS
- PKG payload とインストール済み ConfigDialog / llama-server / GGUF: EXACT
- インストール済み ConfigDialog runtime: PASS
- 実際の日本語入力: PASS
- Zenz runtime (`mozc_zenz_scorer` / `llama-server`): PASS

macOS の今回の実機・パッケージ検証は Apple Silicon (arm64) で実施しています。
Intel Mac / Universal Binary は今回の検証範囲には含めていません。
