### PR TITLE
Fix a potential infinity loop in DictionaryTool.

### DIFF
--- a/src/gui/dictionary_tool/dictionary_content_table_widget.cc
+++ b/src/gui/dictionary_tool/dictionary_content_table_widget.cc
@@ -29,7 +29,13 @@
 
 #include "gui/dictionary_tool/dictionary_content_table_widget.h"
 
+#include <QHeaderView>
+#include <QScrollBar>
 #include <QtGui>
+
+#ifdef __APPLE__
+#include <algorithm>
+#endif  // __APPLE__
 
 namespace mozc::gui {
 
@@ -44,33 +50,33 @@ void DictionaryContentTableWidget::paintEvent(QPaintEvent *event) {
     return;
   }
 
-  // TODO(taku): we don't want to use the fixed size, because
-  // the row height would change according to the users' environment
-  constexpr int kDefaultHeight = 19;
-
-  QRect rect;
-  int alternate_index = 0;
-  if (rowCount() == 0) {
-    rect.setRect(0, 0, 1, kDefaultHeight);
-    alternate_index = 1;
-  } else {
-    QTableWidgetItem *last_item = item(rowCount() - 1, 0);
-    if (last_item == nullptr) {
-      return;
-    }
-    rect = visualItemRect(last_item);
-    alternate_index = rowCount();
+  const int row_height = rowCount() > 0 ? rowHeight(0)
+                         : verticalHeader()->defaultSectionSize();
+  if (row_height <= 0) [[unlikely]] {
+    // If row_height is not available, do not paint the alternate color.
+    return;
   }
 
-  int start_offset = rect.y() + rect.height();
+  int row_y = 0;
+  if (rowCount() > 0) {
+    // rowViewportPosition() returns the Y-coordinate of the row directly on the
+    // viewport, automatically accounting for the vertical scrollbar offset.
+    const int last_row_bottom = rowViewportPosition(rowCount() - 1)
+                                + rowHeight(rowCount() - 1);
+    row_y = std::max(0, last_row_bottom);
+  }
+
+  bool is_odd = rowCount() % 2 == 1;
   QPainter painter(viewport());
-  while (start_offset < height()) {
-    if (alternate_index % 2 == 1) {
-      QRect draw_rect(0, start_offset, width(), rect.height());
-      painter.fillRect(draw_rect, QPalette().color(QPalette::AlternateBase));
+  const QColor alternate_color =
+      viewport()->palette().color(QPalette::Active, QPalette::AlternateBase);
+  while (row_y < height()) {
+    if (is_odd) {
+      QRect draw_rect(0, row_y, width(), row_height);
+      painter.fillRect(draw_rect, alternate_color);
     }
-    start_offset += rect.height();
-    ++alternate_index;
+    row_y += row_height;
+    is_odd = !is_odd;
   }
 #endif  // __APPLE__
 }


### PR DESCRIPTION
## 概要

upstream Mozc の `e7ab408ab1175bee24d0b4b19d0ba926beea3d6d` を取り込み、
macOS の DictionaryTool で alternate-row background を描画する際に
row height が 0 以下となった場合に無限ループへ入る可能性を修正します。

## 変更内容

- 固定値 `19` の row height fallback を廃止
- 実際の row height、または vertical header の default section size を使用
- row height が 0 以下の場合は alternate background の描画を中止
- `rowViewportPosition()` を使い、スクロール位置を考慮して最終行の下から描画
- alternate background の描画処理を整理

## Upstream

- google/mozc: `e7ab408ab1175bee24d0b4b19d0ba926beea3d6d`
- `Fix a potential infinity loop in DictionaryTool.`
- https://github.com/google/mozc/issues/1545

Mozkey 側の差分は upstream commit と patch-id が一致しています。

## 検証

- upstream master 上で対象 commit が現在も有効であることを確認
- 対象ファイルに後続の upstream 修正がないことを確認
- Mozkey `main` に同等 patch が未導入であることを確認
- upstream patch が Mozkey `main` に clean apply できることを確認
- patch-id identity: EXACT
- changed file set: 1 file only
- `//gui/dictionary_tool:dictionary_tool_macos`
  - `--config=oss_macos`
  - `--config=release_build`
  - build PASS
- DictionaryTool 手動スモーク
  - 起動
  - 空テーブル
  - 1行 / 複数行
  - 縦スクロール最下部
  - ウィンドウリサイズ
  - いずれも問題なし
  