### PR TITLE
Test/upstream quality regression corpus

### DIFF
--- a/src/data/dictionary_oss/evaluation.tsv
+++ b/src/data/dictionary_oss/evaluation.tsv
@@ -592,3 +592,11 @@ FAILED:	あのたなにあります	あの店にあります	Conversion Expected
 FAILED:	せいをだす	性を出す	Conversion Expected	精を出す	3.33.6239
 FAILED:	びーるはいた	ビールはいた	Conversion Expected	ビール吐いた	3.33.6239
 FAILED:	くつはいた	靴はいた	Conversion Expected	靴履いた	3.33.6239
+FAILED:	ともだちのしんちょうをはかる	友達の身長を図る	Conversion Expected	友達の身長を測る	3.34.6239
+OK:	きのうのゆうしょくはてんぷらだった	昨日の夕食は天ぷらだった	Conversion Expected	昨日の夕食は天ぷらだった	3.34.6239
+FAILED:	いえにはやくかえる	家に早く変える	Conversion Expected	家に早く帰る	3.34.6239
+FAILED:	てんきがいいからせんたくしよう	天気がいいから選択しよう	Conversion Expected	天気がいいから洗濯しよう	3.34.6239
+FAILED:	あめがふるかもしれない	雨がフルかもしれない	Conversion Expected	雨が降るかもしれない	3.34.6239
+FAILED:	きのうはどのくらいねましたか	機能はどのくらい寝ましたか	Conversion Expected	昨日はどのくらい寝ましたか	3.34.6239
+OK:	こんどのしゅじゅつはいつですか	今度の手術はいつですか	Conversion Expected	今度の手術はいつですか	3.34.6239
+FAILED:	けんかをしてしまったのであやまりたい	喧嘩をしてしまったので誤りたい	Conversion Expected	喧嘩をしてしまったので謝りたい	3.34.6239

--- a/src/data/dictionary_oss/evaluation.tsv
+++ b/src/data/dictionary_oss/evaluation.tsv
@@ -585,3 +585,10 @@ FAILED:	そうむてき	総務的	Conversion Expected	双務的	3.33.6089
 FAILED:	かこつ	過去つ	Conversion Expected	仮骨	3.33.6089
 OK:	ねんのため	念の為	Conversion Expected 3	念のため	3.33.6089
 FAILED:	えらんだかさ	選ん高さ	Conversion Expected	選んだ傘	3.33.6133
+FAILED:	そういういみなの	そういう諱の	Conversion Expected	そういう意味なの	3.33.6239
+FAILED:	おさとうとおす	お砂糖と押す	Conversion Expected	お砂糖とお酢	3.33.6239
+FAILED:	こちらいえにつきました	こちら言えにつきました	Conversion Expected	こちら家に着きました	3.33.6239
+FAILED:	あのたなにあります	あの店にあります	Conversion Expected	あの棚にあります	3.33.6239
+FAILED:	せいをだす	性を出す	Conversion Expected	精を出す	3.33.6239
+FAILED:	びーるはいた	ビールはいた	Conversion Expected	ビール吐いた	3.33.6239
+FAILED:	くつはいた	靴はいた	Conversion Expected	靴履いた	3.33.6239

--- a/src/data/test/quality_regression_test/regression.tsv
+++ b/src/data/test/quality_regression_test/regression.tsv
@@ -92,3 +92,11 @@ regression	あのたなにあります	あの棚にあります	Conversion Expec
 regression	せいをだす	精を出す	Conversion Expected
 regression	びーるはいた	ビール吐いた	Conversion Expected
 regression	くつはいた	靴履いた	Conversion Expected
+regression	ともだちのしんちょうをはかる	友達の身長を測る	Conversion Expected
+regression	きのうのゆうしょくはてんぷらだった	昨日の夕食は天ぷらだった	Conversion Expected
+regression	いえにはやくかえる	家に早く帰る	Conversion Expected
+regression	てんきがいいからせんたくしよう	天気がいいから洗濯しよう	Conversion Expected
+regression	あめがふるかもしれない	雨が降るかもしれない	Conversion Expected
+regression	きのうはどのくらいねましたか	昨日はどのくらい寝ましたか	Conversion Expected
+regression	こんどのしゅじゅつはいつですか	今度の手術はいつですか	Conversion Expected
+regression	けんかをしてしまったのであやまりたい	喧嘩をしてしまったので謝りたい	Conversion Expected

--- a/src/data/test/quality_regression_test/regression.tsv
+++ b/src/data/test/quality_regression_test/regression.tsv
@@ -85,3 +85,10 @@ regression	そうむてき	双務的	Conversion Expected
 regression	かこつ	仮骨	Conversion Expected
 regression	ねんのため	念のため	Conversion Expected 3
 regression	えらんだかさ	選んだ傘	Conversion Expected
+regression	そういういみなの	そういう意味なの	Conversion Expected
+regression	おさとうとおす	お砂糖とお酢	Conversion Expected
+regression	こちらいえにつきました	こちら家に着きました	Conversion Expected
+regression	あのたなにあります	あの棚にあります	Conversion Expected
+regression	せいをだす	精を出す	Conversion Expected
+regression	びーるはいた	ビール吐いた	Conversion Expected
+regression	くつはいた	靴履いた	Conversion Expected


### PR DESCRIPTION
## 概要

upstream Mozc の日本語変換品質向け evaluation / regression case を取り込みます。

対象 upstream commits:

- `04733c92daf891a3f3d67ba85c69fa9cc64032ba`
  - Add new regression tests for common mis-conversions.
- `d12e78ed6be257b820844f30346de642b73014f1`
  - Add new evaluation and regression test cases.

実装ロジックは変更せず、変換品質の評価・回帰検出用データのみを追加します。

## 変更内容

以下の2ファイルへ計15ケースを追加します。

- `src/data/dictionary_oss/evaluation.tsv`
- `src/data/test/quality_regression_test/regression.tsv`

主なケース:

- `そういういみなの` → `そういう意味なの`
- `おさとうとおす` → `お砂糖とお酢`
- `せいをだす` → `精を出す`
- `びーるはいた` → `ビール吐いた`
- `くつはいた` → `靴履いた`
- `ともだちのしんちょうをはかる` → `友達の身長を測る`
- `きのうのゆうしょくはてんぷらだった` → `昨日の夕食は天ぷらだった`
- `いえにはやくかえる` → `家に早く帰る`
- `あめがふるかもしれない` → `雨が降るかもしれない`
- `けんかをしてしまったのであやまりたい` → `喧嘩をしてしまったので謝りたい`

## 目的

今後の Mozkey / Zenz の変換品質改善や upstream 追従時に、
同音異義語選択、連語、述語との意味的整合性などの回帰を検出できるようにします。

このPR自体は変換アルゴリズムを変更しません。

## Upstream identity

2コミットとも upstream と patch-id が一致しています。

- commit 1 patch identity: EXACT
- commit 2 patch identity: EXACT
- Author / AuthorDate: upstream metadata を保持
- changed file set: 2 files only

## 検証

- upstream 上で2コミットの順序関係を確認
- Mozkey `main` に15ケースが未導入であることを確認
- 2コミットを順番に clean apply できることを確認
- 15ケースが `evaluation.tsv` / `regression.tsv` の両方に存在することを確認
- `//data/dictionary_oss:evaluation_diff_test`
  - T1 適用後: PASS
  - T2 適用後: PASS
  - push 前再確認: PASS
- `git diff --check`: PASS
- working tree: CLEAN