### PR TITLE
Apply entry count cost penalty to user dictionary entries.

### DIFF
--- a/src/dictionary/user_dictionary.cc
+++ b/src/dictionary/user_dictionary.cc
@@ -31,6 +31,7 @@
 
 #include <algorithm>
 #include <atomic>
+#include <cmath>
 #include <cstddef>
 #include <cstdint>
 #include <functional>
@@ -153,6 +154,7 @@ class UserDictionary::TokensIndex {
 
   bool empty() const { return user_pos_tokens_.empty(); }
   size_t size() const { return user_pos_tokens_.size(); }
+  int cost_penalty() const { return cost_penalty_; }
 
   std::vector<UserPos::Token>::const_iterator begin() const {
     return user_pos_tokens_.begin();
@@ -218,6 +220,30 @@ class UserDictionary::TokensIndex {
     std::sort(user_pos_tokens_.begin(), user_pos_tokens_.end(),
               OrderByKeyThenById());
 
+    // Adds cost penalty based on dictionary entry count N: 500 * log(N + 1).
+    //
+    // Background:
+    // User dictionary entries default to static minimum costs defined in
+    // user_pos.def. When users carelessly or unconsciously import large
+    // 3rd-party dictionaries, low-quality entries over-trigger and overpower
+    // standard system candidates.
+    //
+    // Theoretical Justification:
+    // Assuming a uniform prior probability P = 1/N across N entries, the
+    // self-information penalty in Mozc cost scaling (approx. 500 * (-ln P)) is
+    // 500 * ln(N + 1). Using N + 1 generalizes to 0 penalty when N = 0.
+    //
+    // Cost penalty examples per N:
+    // - N = 0: +0
+    // - N = 1: +346
+    // - N = 10: +1,198
+    // - N = 100: +2,307
+    // - N = 1,000: +3,454
+    // - N = 10,000: +4,605
+    // - N = 100,000: +5,756
+    cost_penalty_ = static_cast<int>(
+        500.0 * std::log(user_pos_tokens_.size() + 1));
+
     MOZC_VLOG(1) << user_pos_tokens_.size() << " user dic entries loaded";
   }
 
@@ -233,6 +259,7 @@ class UserDictionary::TokensIndex {
   const UserPos& user_pos_;
   SuppressionDictionary suppression_dictionary_;
   std::vector<UserPos::Token> user_pos_tokens_;
+  int cost_penalty_ = 0;
 };
 
 class UserDictionary::UserDictionaryReloader {
@@ -561,7 +588,8 @@ void UserDictionary::PopulateTokenFromUserPosToken(
   if (user_pos_token.has_attribute(UserPos::Token::NON_JA_LOCALE)) {
     token->cost = 10000;
   } else {
-    token->cost = UserPos::GetCostFromPosType(user_pos_token.pos_type());
+    token->cost = UserPos::GetCostFromPosType(user_pos_token.pos_type(),
+                                              GetTokens()->cost_penalty());
     DCHECK_GT(token->cost, 0);
   }
 

--- a/src/dictionary/user_dictionary_test.cc
+++ b/src/dictionary/user_dictionary_test.cc
@@ -30,6 +30,7 @@
 #include "dictionary/user_dictionary.h"
 
 #include <algorithm>
+#include <cmath>
 #include <cstdint>
 #include <cstring>
 #include <memory>
@@ -991,6 +992,37 @@ TEST_F(UserDictionaryTest, TestPopulateTokenFromUserPosToken) {
   dic->PopulateTokenFromUserPosToken(user_token, UserDictionary::PREFIX,
                                      &token);
   EXPECT_EQ(token.cost, expected_cost);
+}
+
+TEST_F(UserDictionaryTest, TestPopulateTokenFromUserPosTokenWithEntryPenalty) {
+  std::unique_ptr<UserDictionary> dic(CreateDictionaryWithMockPos());
+  user_dictionary::UserDictionaryStorage storage;
+  user_dictionary::UserDictionary* user_dic = storage.add_dictionaries();
+  for (int i = 0; i < 10; ++i) {
+    user_dictionary::UserDictionary::Entry* entry = user_dic->add_entries();
+    entry->set_key(absl::StrCat("key", i));
+    entry->set_value(absl::StrCat("value", i));
+    entry->set_pos(user_dictionary::UserDictionary::NOUN);
+  }
+  dic->Load(storage);
+
+  UserPos::Token user_token{.key = "key0", .value = "value0", .id = 10};
+  user_token.set_pos_type(user_dictionary::UserDictionary::NOUN);
+
+  Token token;
+  dic->PopulateTokenFromUserPosToken(user_token, UserDictionary::PREFIX,
+                                     &token);
+  const int base_cost = UserPos::GetCostFromPosType(user_token.pos_type());
+  const int expected_penalty =
+      static_cast<int>(500.0 * std::log(11.0));  // N = 10
+  EXPECT_EQ(token.cost, base_cost + expected_penalty);
+
+  // POS type with cost 0 in user_pos.def (e.g. WA_GROUP1_VERB) uses default
+  // cost (5000) without penalty.
+  user_token.set_pos_type(user_dictionary::UserDictionary::WA_GROUP1_VERB);
+  dic->PopulateTokenFromUserPosToken(user_token, UserDictionary::PREFIX,
+                                     &token);
+  EXPECT_EQ(token.cost, 5000);
 }
 
 TEST_F(UserDictionaryTest, AsyncImportTest) {

--- a/src/dictionary/user_pos.cc
+++ b/src/dictionary/user_pos.cc
@@ -195,13 +195,21 @@ absl::string_view UserPos::GetStringPosType(
 
 // static
 uint16_t UserPos::GetCostFromPosType(
-    user_dictionary::UserDictionary::PosType pos_type) {
+    user_dictionary::UserDictionary::PosType pos_type, int cost_penalty) {
   int cost = 0;
   if (user_dictionary::UserDictionary::PosType_IsValid(pos_type)) {
     cost = kPosTypeStringTable[pos_type].second;
   }
-  static constexpr uint16_t kDefaultCost = 5000;
-  return cost > 0 ? cost : kDefaultCost;
+  if (cost == 0) {
+    // When cost is 0 in user_pos.def (e.g. verbs/adjectives), a large default
+    // cost is used. In this case, no extra entry count penalty needs to be
+    // added.
+    static constexpr uint16_t kDefaultCost = 5000;
+    return kDefaultCost;
+  }
+  // Cost is explicitly defined in user_pos.def (> 0). Apply entry count
+  // cost_penalty.
+  return cost + cost_penalty;
 }
 
 // static

--- a/src/dictionary/user_pos.h
+++ b/src/dictionary/user_pos.h
@@ -161,10 +161,14 @@ class UserPos {
   static absl::string_view GetStringPosType(
       user_dictionary::UserDictionary::PosType pos_type);
 
-  // Returns the cost of PosType. if cost is not defined, the default cost
-  // is returned.
+  // Returns the cost of PosType. If cost is explicitly defined in user_pos.def
+  // (> 0), returns cost + cost_penalty. If cost is 0 in user_pos.def (e.g.
+  // verbs/adjectives), default cost (5000) is returned without applying
+  // cost_penalty.
+  // The default cost of 5000 is already penalized, so we don't want to add
+  // an extra penalty.
   static uint16_t GetCostFromPosType(
-      user_dictionary::UserDictionary::PosType pos_type);
+      user_dictionary::UserDictionary::PosType pos_type, int cost_penalty = 0);
 
   // Returns the string representation of PosType. INVALID if the given pos is
   // invalid.

--- a/src/dictionary/user_pos_test.cc
+++ b/src/dictionary/user_pos_test.cc
@@ -209,6 +209,20 @@ TEST_F(UserPosTest, GetStringPosType) {
             "抑制単語");
 }
 
+TEST_F(UserPosTest, GetCostFromPosTypeWithPenalty) {
+  // When cost is explicitly defined (> 0) in user_pos.def, cost + cost_penalty
+  // is returned. NOUN cost is 2500. With penalty 346: 2500 + 346 = 2846.
+  EXPECT_EQ(
+      UserPos::GetCostFromPosType(user_dictionary::UserDictionary::NOUN, 346),
+      2846);
+
+  // When cost is 0 in user_pos.def (e.g. verbs/adjectives), default cost 5000
+  // is returned without penalty.
+  EXPECT_EQ(UserPos::GetCostFromPosType(
+                user_dictionary::UserDictionary::WA_GROUP1_VERB, 346),
+            5000);
+}
+
 TEST_F(UserPosTest, PosTypeRoundTrip) {
   const std::vector<std::string> pos_list = user_pos_.GetPosList();
   for (absl::string_view pos : pos_list) {


### PR DESCRIPTION
## 概要

upstream Mozc の user dictionary entry-count penalty を取り込みます。

対象 upstream commit:

- `3f235b4eb6fcff7d14ef5f0fb8ee56de7ee4c732`
  - Apply entry count cost penalty to user dictionary entries.

大規模なサードパーティ辞書を user dictionary として取り込んだ場合に、
user dictionary 候補が system dictionary 候補を過剰に押しのける問題を緩和する変更です。

## 変更内容

user dictionary のロード時に、登録エントリ数 `N` に基づいて

`500 * log(N + 1)`

の cost penalty を一度計算し、対象となる user dictionary token の cost に加算します。

これにより、

- 小規模 user dictionary では影響を比較的小さく保つ
- 10,000件以上など大規模 user dictionary では候補優先度を自然に下げる
- lookup / Viterbi decoding 時には事前計算済み penalty を使うため O(1)

という挙動になります。

### POS cost の扱い

`user_pos.def` で明示的な cost (> 0) を持つ品詞については、

`base cost + entry-count penalty`

を使用します。

一方、動詞・形容詞系など `user_pos.def` 上の cost が 0 の品詞は、
従来どおり既定 cost `5000` を使用し、追加 penalty は適用しません。

## 変更ファイル

- `src/dictionary/user_dictionary.cc`
- `src/dictionary/user_dictionary_test.cc`
- `src/dictionary/user_pos.cc`
- `src/dictionary/user_pos.h`
- `src/dictionary/user_pos_test.cc`

計5ファイルのみです。

## Upstream identity

- upstream patch-id:
  `7328d7f1987c59602fe62672eeddb309e7573c4c`
- Mozkey imported commit patch-id: EXACT
- Author / AuthorDate: upstream metadata を保持
- changed file set: EXACT (5 files)
- upstream master 上で対象5ファイルへの後続commitなし

## 検証

事前監査:

- Mozkey `main` に target-specific implementation が未導入であることを確認
- current upstream master に target が存在することを確認
- 対象5ファイルへの後続 upstream commit が 0 件であることを確認
- exact `origin/main` 上で clean apply: PASS
- simulated patch-id: EXACT
- simulated changed file set: EXACT (5 files)

直接テスト:

- `//dictionary:user_dictionary_test`: PASS
- `//dictionary:user_pos_test`: PASS

取り込み後:

- patch identity: EXACT
- Author / AuthorDate: EXACT
- changed file set: EXACT (5 files)
- `git diff --check`: PASS
- working tree: CLEAN

## 備考

この変更は user dictionary の候補順位に影響する挙動変更です。
独自調整は加えず、upstream の実装・係数・例外条件をそのまま取り込んでいます。