### PR TITLE
Align Windows ARM64 host toolchain with upstream Mozc

### DIFF
--- a/src/.bazelrc
+++ b/src/.bazelrc
@@ -67,6 +67,11 @@ build:compiler_msvc_like --per_file_copt="external/.*@/w" --host_per_file_copt="
 common:compiler_gcc_like --announce_rc=false
 common:compiler_msvc_like --announce_rc=false
 
+# Make the following workaround for llvm/llvm-project#47432 work.
+# https://github.com/protocolbuffers/protobuf/commit/0e84323cd6fba27c7834b5596f3ef14b7e69e7b8
+build:compiler_msvc_like --per_file_copt="external/protobuf[+]/upb/wire/encode.c@/D__SEH__=1"
+build:compiler_msvc_like --host_per_file_copt="external/protobuf[+]/upb/wire/encode.c@/D__SEH__=1"
+
 ## Linux specific options
 build:linux_env --build_tag_filters=-nolinux --copt "-fPIC"
 test:linux_env   --test_tag_filters=-nolinux

--- a/src/bazel/rules_cc_BUILD.windows.tpl.patch
+++ b/src/bazel/rules_cc_BUILD.windows.tpl.patch
@@ -1,6 +1,6 @@
 --- cc/private/toolchain/BUILD.windows.tpl
 +++ cc/private/toolchain/BUILD.windows.tpl
-@@ -85,6 +85,7 @@ cc_toolchain_suite(
+@@ -85,6 +85,7 @@
          "x64_windows|mingw-gcc": ":cc-compiler-x64_windows_mingw",
          "x64_x86_windows|mingw-gcc": ":cc-compiler-x64_x86_windows_mingw",
          "x64_windows|clang-cl": ":cc-compiler-x64_windows-clang-cl",
@@ -8,11 +8,26 @@
          "x64_windows_msys": ":cc-compiler-x64_windows_msys",
          "x64_windows": ":cc-compiler-x64_windows",
          "x64_x86_windows": ":cc-compiler-x64_x86_windows",
-@@ -670,6 +671,75 @@ toolchain(
-     toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
+@@ -644,6 +645,7 @@
+         "strip": "wrapper/bin/msvc_nop.bat",
+     },
+     archiver_flags = ["/MACHINE:X64"],
++    default_compile_flags = ["--target=x86_64-pc-windows-msvc"],
+     default_link_flags = ["/MACHINE:X64"],
+     dbg_mode_debug_flag = "%{clang_cl_dbg_mode_debug_flag_x64}",
+     fastbuild_mode_debug_flag = "%{clang_cl_fastbuild_mode_debug_flag_x64}",
+@@ -658,7 +660,6 @@
+ toolchain(
+     name = "cc-toolchain-x64_windows-clang-cl",
+     exec_compatible_with = [
+-        "@platforms//cpu:x86_64",
+         "@platforms//os:windows",
+         "@rules_cc//cc/private/toolchain:clang-cl",
+     ],
+@@ -671,6 +672,74 @@
  )
  
-+cc_toolchain(
+ cc_toolchain(
 +    name = "cc-compiler-x64_x86_windows-clang-cl",
 +    toolchain_identifier = "clang_cl_x64_x86",
 +    toolchain_config = ":clang_cl_x64_x86",
@@ -59,7 +74,7 @@
 +        "strip": "wrapper/bin/msvc_nop.bat",
 +    },
 +    archiver_flags = ["/MACHINE:X86"],
-+    default_compile_flags = ["-m32"],
++    default_compile_flags = ["--target=i686-pc-windows-msvc"],
 +    default_link_flags = ["/MACHINE:X86"],
 +    dbg_mode_debug_flag = "%{clang_cl_dbg_mode_debug_flag_x86}",
 +    fastbuild_mode_debug_flag = "%{clang_cl_fastbuild_mode_debug_flag_x86}",
@@ -69,7 +84,6 @@
 +toolchain(
 +    name = "cc-toolchain-x64_x86_windows-clang-cl",
 +    exec_compatible_with = [
-+        "@platforms//cpu:x86_64",
 +        "@platforms//os:windows",
 +        "@rules_cc//cc/private/toolchain:clang-cl",
 +    ],
@@ -81,10 +95,11 @@
 +    toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
 +)
 +
- cc_toolchain(
++cc_toolchain(
      name = "cc-compiler-arm64_windows-clang-cl",
      toolchain_identifier = "clang_cl_arm64",
-@@ -719,6 +789,7 @@
+     toolchain_config = ":clang_cl_arm64",
+@@ -717,6 +786,7 @@
          "strip": "wrapper/bin/msvc_nop.bat",
      },
      archiver_flags = ["/MACHINE:ARM64"],

--- a/src/bazel/windows_sdk_repository.bzl
+++ b/src/bazel/windows_sdk_repository.bzl
@@ -115,10 +115,21 @@ def _windows_sdk_impl(repo_ctx):
         )
         return
 
-    # Hopefully "x86" and "arm64" should just work, but we need to check later.
-    arch = repo_ctx.os.arch
-    if arch == "amd64" or arch == "x86_64":
-        arch = "x64"
+    # Normalizes repo_ctx.os.arch to the Windows SDK's bin/<ver>/<arch> layout.
+    arch = {
+        "amd64": "x64",
+        "x86_64": "x64",
+        "aarch64": "arm64",
+        "arm64": "arm64",
+    }.get(repo_ctx.os.arch.lower())
+    if not arch:
+        repo_ctx.file("BUILD.bazel", "")
+        repo_ctx.template(
+            "windows_sdk_rules.bzl",
+            repo_ctx.path(Label("@//bazel:windows_sdk_rules.noop.template.bzl")),
+            executable = False,
+        )
+        return
 
     winsdk_path = repo_ctx.path(winsdk_dir)
     repo_ctx.symlink(winsdk_path.get_child("bin/" + winsdk_ver + "/" + arch), "bin")

--- a/src/build_tools/build_qt.py
+++ b/src/build_tools/build_qt.py
@@ -408,7 +408,7 @@ def make_configure_options(args: argparse.Namespace) -> list[str]:
         '-platform',
         'win32-msvc',
     ]
-    if args.target_arch in ['x64', 'amd64']:
+    if args.target_arch == 'x64':
       qt_configure_options += ['-intelcet']
 
   if args.confirm_license:
@@ -490,7 +490,10 @@ def parse_args() -> argparse.Namespace:
   )
   if is_windows():
     parser.add_argument(
-        '--target_arch', help='"x64" or "arm64"', type=str, default='x64'
+        '--target_arch',
+        help='target architecture',
+        choices=['x64', 'arm64'],
+        default=normalize_win_arch(platform.uname().machine),
     )
     parser.add_argument(
         '--vcvarsall_path', help='Path of vcvarsall.bat', type=str, default=None
@@ -729,14 +732,21 @@ def normalize_win_arch(arch: str) -> str:
   """Normalize the architecture name for Windows build environment.
 
   Args:
-    arch: a string representation of a CPU architecture to be normalized.
+    arch: 'amd64', 'x64', 'arm64', or its capitalization variants.
 
   Returns:
-    String representation of a CPU architecture (e.g. 'x64' and 'arm64')
+    Either 'x64' or 'arm64'.
+
+  Raises:
+    ValueError: When the given architecture does not match any of them.
   """
-  normalized = arch.lower()
-  if normalized == 'amd64':
-    return 'x64'
+  normalized = {
+      'amd64': 'x64',
+      'x64': 'x64',
+      'arm64': 'arm64',
+  }.get(arch.lower())
+  if not normalized:
+    raise ValueError(f'Unsupported architecture: {arch}')
   return normalized
 
 


### PR DESCRIPTION
## 概要

upstream Mozc の Windows ARM64 host build 対応の中核4変更を Mozkey に取り込みます。

対象 upstream commits:

- `96b314db8b4bbadb8e446bb66914b34843eec8dd` (#1532)
  - Let `build_qt.py` build Qt for the host arch
- `08aac93e288053e627a8ee9bdf882e09bd1e68e7` (#1533)
  - Resolve the Windows SDK tool dir on an Arm64 host
- `8f2cf1901af46e00edb5d29efe701728c4d140fe` (#1534)
  - Avoid clang crash when building protobuf for arm64
- `9d2a86d93909d0b6739e321083d98880e010f927` (#1535)
  - Make clang-cl toolchains host-agnostic

この PR では **build/toolchain substrate のみ**を変更します。

`.github/workflows/windows.yaml` は変更せず、現在の

`windows-2025 x64 host -> ARM64 cross-build -> native ARM64 installed-MSI/lifecycle audits`

という CI contract を維持します。

## 変更内容

### #1532 — Qt host architecture

Windows の `build_qt.py` で、既定 target architecture を固定 `x64` ではなく host architecture に合わせます。

これにより:

- x64 host -> default x64 Qt
- ARM64 host -> default ARM64 Qt

となります。

明示的な `--target_arch=x64` / `--target_arch=arm64` は引き続き利用できます。

### #1533 — Windows SDK architecture mapping

Windows SDK tool directory 解決時に host architecture を明示的に正規化します。

- `amd64` / `x86_64` -> `x64`
- `aarch64` / `arm64` -> `arm64`

unsupported architecture では不正な SDK path を生成しない upstream の挙動へ合わせます。

### #1534 — protobuf clang-cl crash workaround

Windows clang-cl で protobuf の

`external/protobuf+/upb/wire/encode.c`

をビルドする際の既知 crash workaround として、そのファイルだけに `/D__SEH__=1` を適用します。

ARM64 build 全体へ `__SEH__` を広く定義する変更ではありません。

Mozkey には upstream の後続 `09d84bea` 相当の compiler placeholder block がすでに存在するため、この1コミットだけは exact patch-id cherry-pick ではありません。

ただし:

- changed file: `src/.bazelrc` のみ
- 5 additions / 0 deletions
- upstream #1534 の added payload と完全一致
- final relevant `.bazelrc` block は current upstream master と一致

を確認した semantic-equivalent port です。

### #1535 — host-agnostic clang-cl toolchains

x86/x64 target に explicit target triple を設定し、x86/x64 clang-cl toolchain の x86_64 host pin を外します。

これにより host architecture と target architecture を分離し、ARM64 host 上でも x86/x64 target toolchain を正しく選択できる upstream 設計へ寄せます。

## 変更ファイル

- `src/build_tools/build_qt.py`
- `src/bazel/windows_sdk_repository.bzl`
- `src/.bazelrc`
- `src/bazel/rules_cc_BUILD.windows.tpl.patch`

計4ファイルのみです。

## Upstream identity

- #1532 patch identity: EXACT
- #1533 patch identity: EXACT
- #1534 added payload: EXACT / semantic-equivalent
- #1535 patch identity: EXACT
- upstream Author / AuthorDate を保持
- provenance を各 commit message に記録

## ローカル検証

- `build_qt.py` `py_compile`: PASS
- `bazelisk mod graph`: PASS
- `git diff --check`: PASS
- changed file set: EXACT (4 files)
- working tree: CLEAN

## CI contract

この PR では以下を変更しません。

- `.github/workflows/windows.yaml`
- `docs/build_mozc_in_windows.md`
- ARM64 current package build runner (`windows-2025`)
- W2 predecessor lifecycle baseline build
- native `windows-11-arm` installed-MSI Zenz audit
- native `windows-11-arm` installer lifecycle audit
- Zenz semantic / named-pipe / firewall / upgrade / uninstall gates

したがって、この PR の目的は

> build substrate を upstream ARM64-host対応へ寄せても、既存の Windows package/runtime contract が不変であることを確認する

ことです。

## 後続作業

native ARM64 package build (`windows-11-arm`) への切り替えは別 PR とします。

その前に、現在 `build_arm64` job 内に結合されている immutable W2 predecessor baseline build を x64 runner の別 job へ分離します。

その後の別 PR で:

- current ARM64 package build -> `windows-11-arm`
- cache key architecture 分離 (`runner.arch`)
- 必要に応じて cross-build / native-build parity audit

を行います。

この PR では CI execution host は変更しません。
