### PR TITLE
Split ARM64 lifecycle baseline build into dedicated job

### DIFF
--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -387,6 +387,118 @@ jobs:
           name: Mozc64_arm64.msi
           path: src/bazel-bin/win32/installer/Mozc64.msi
           if-no-files-found: warn
+
+  build_arm64_lifecycle_baseline:
+    needs: prepare_daily_dictionary
+    # https://github.com/actions/runner-images/blob/main/images/windows/Windows2025-Readme.md
+    runs-on: windows-2025
+    timeout-minutes: 120
+
+    # Preserve the pre-split W2 baseline semantics: prepare the environment
+    # from the current source, run the current ARM64 build once to warm the
+    # same Bazel workspace/output-base, then checkout the immutable baseline.
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          submodules: false
+          persist-credentials: false
+
+      - name: download daily dictionary
+        uses: actions/download-artifact@v6
+        with:
+          name: daily-dictionary
+          path: .
+
+      - name: Try to restore update_deps cache
+        uses: actions/cache@v5
+        with:
+          path: src/third_party_cache
+          key: update_deps-${{ runner.os }}-${{ hashFiles('src/build_tools/update_deps.py') }}
+
+      - name: Install Dependencies
+        shell: cmd
+        working-directory: .\src
+        # This command uses src/third_party_cache as the download cache.
+        run: |
+          python build_tools/update_deps.py
+
+      - name: Build Qt (arm64)
+        shell: cmd
+        working-directory: .\src
+        run: |
+          python build_tools/build_qt.py --release --confirm_license --target_arch=arm64
+
+      # This is needed only for GitHub Actions where free disk space is quite limited.
+      - name: Delete Qt src to save disk space
+        shell: cmd
+        working-directory: .\src
+        run: |
+          rmdir third_party\qt_src /s /q
+
+      - name: Prepare CRT redist directory expected by WiX
+        shell: pwsh
+        run: |
+          $expectedDir = "C:\Program Files\Microsoft Visual Studio\18\Community\VC\Redist\MSVC\14.50.35710\x64\Microsoft.VC145.CRT"
+
+          $requiredDlls = @(
+            "msvcp140.dll",
+            "msvcp140_1.dll",
+            "msvcp140_2.dll",
+            "vcruntime140.dll",
+            "vcruntime140_1.dll"
+          )
+
+          $searchRoots = @(
+            "C:\Program Files\Microsoft Visual Studio\2022",
+            "C:\Program Files\Microsoft Visual Studio\17",
+            "C:\Program Files\Microsoft Visual Studio\18",
+            "C:\Program Files (x86)\Microsoft Visual Studio\2022",
+            "C:\Program Files (x86)\Microsoft Visual Studio\17",
+            "C:\Program Files (x86)\Microsoft Visual Studio\18"
+          ) | Where-Object { Test-Path $_ }
+
+          Write-Host "Expected CRT redist dir:"
+          Write-Host $expectedDir
+
+          Write-Host "Search roots:"
+          $searchRoots | ForEach-Object { Write-Host $_ }
+
+          New-Item -ItemType Directory -Force $expectedDir | Out-Null
+
+          foreach ($dll in $requiredDlls) {
+            $source = Get-ChildItem -Path $searchRoots -Recurse -Filter $dll -ErrorAction SilentlyContinue |
+              Where-Object { $_.FullName -match "\\x64\\Microsoft\.VC[0-9]+\.CRT\\" } |
+              Sort-Object FullName -Descending |
+              Select-Object -First 1
+
+            if (-not $source) {
+              Write-Host "Available CRT directories:"
+              Get-ChildItem -Path $searchRoots -Recurse -Directory -ErrorAction SilentlyContinue |
+                Where-Object { $_.FullName -match "\\x64\\Microsoft\.VC[0-9]+\.CRT$" } |
+                Select-Object FullName
+
+              throw "Required CRT DLL was not found: $dll"
+            }
+
+            $destination = Join-Path $expectedDir $dll
+            Copy-Item $source.FullName $destination -Force
+            Write-Host "Copied $dll"
+            Write-Host "  from: $($source.FullName)"
+            Write-Host "  to:   $destination"
+          }
+
+          Write-Host "Prepared CRT redist directory:"
+          Get-ChildItem $expectedDir | Select-Object FullName
+
+      - name: build artifacts
+        shell: cmd
+        working-directory: .\src
+        env:
+          ANDROID_NDK_HOME: ""
+        run: |
+          bazelisk build package --config release_build --platforms=//:windows-arm64
+
       - name: Build W2-predecessor ARM64 lifecycle baseline
         shell: pwsh
         run: |
@@ -447,10 +559,11 @@ jobs:
           path: src/bazel-bin/win32/installer/Mozc64.msi
           if-no-files-found: error
 
-
   test_arm64_installer_lifecycle:
     name: Native ARM64 installer lifecycle audit
-    needs: build_arm64
+    needs:
+      - build_arm64
+      - build_arm64_lifecycle_baseline
     runs-on: windows-11-arm
     timeout-minutes: 30
 


### PR DESCRIPTION
## 概要

Windows ARM64 installer lifecycle audit で使用している immutable W2 predecessor baseline MSI の build を、current ARM64 package build から専用 job へ分離します。

この PR の目的は **CI dependency graph の分離だけ**です。

current ARM64 package の build host や build method は変更しません。

## 背景

変更前の `build_arm64` job は、同じ `windows-2025` runner / workspace 上で以下を順番に行っていました。

1. current source を checkout
2. daily dictionary を取得
3. dependencies を準備
4. ARM64 Qt を build
5. CRT redist を準備
6. current ARM64 MSI を build / upload
7. immutable W2 predecessor commit
   `c986db2c611c7255ba92b1d44fc6ac3fb6b098bf`
   を checkout
8. 同じ prepared environment / Bazel workspace で baseline ARM64 MSI を build
9. baseline MSI を upload

このため baseline は単純な standalone historical-source build ではなく、

> current prepared environment + current ARM64 build warm-up + exact baseline source

という semantics を持っていました。

## 変更内容

### `build_arm64`

current ARM64 package build のみにします。

- runner: `windows-2025`
- `needs: prepare_daily_dictionary`
- daily dictionary
- update_deps
- ARM64 Qt
- CRT redist
- current ARM64 Bazel package build
- `Mozc64_arm64.msi` upload

は従来どおりです。

W2 predecessor baseline build / upload だけをこの job から取り除きます。

### `build_arm64_lifecycle_baseline`

新しい dedicated job を追加します。

runner は従来と同じ `windows-2025` です。

pre-split semantics を変えないため、意図的に:

1. current source checkout
2. daily dictionary
3. update_deps
4. ARM64 Qt
5. CRT redist
6. current ARM64 package buildを1回実行して Bazel workspace/output-base を warm-up
7. exact W2 predecessor commitをfetch / detached checkout
8. baseline ARM64 package build
9. 従来と同名の baseline artifact を upload

としています。

baseline source:
`c986db2c611c7255ba92b1d44fc6ac3fb6b098bf`

baseline artifact:
`Mozc64_arm64_pre_native_lifecycle_baseline.msi`

### installer lifecycle audit

`test_arm64_installer_lifecycle` は current MSI と baseline MSI の両方を必要とするため、

```yaml
needs:
  - build_arm64
  - build_arm64_lifecycle_baseline
```

へ変更します。

### installed-MSI Zenz audit

`test_arm64_installed_msi` は current MSI のみを使用するため、

```yaml
needs: build_arm64
```

のまま変更しません。

## この PR で変更しないもの

- current ARM64 build runner (`windows-2025`)
- current ARM64 cross-build method
- `--target_arch=arm64`
- `--platforms=//:windows-arm64`
- W2 predecessor source SHA
- baseline artifact name
- native `windows-11-arm` installer lifecycle audit
- native `windows-11-arm` installed-MSI Zenz audit
- semantic / named-pipe / firewall / upgrade / uninstall contract
- Mozc / Zenz / installer / toolchain source code

変更ファイルは `.github/workflows/windows.yaml` のみです。

## なぜ current warm-up build を baseline job に残すか

これは意図的です。

pre-split baseline build は current ARM64 build 完了後の同じ runner / Bazel workspace 上で実行されていました。

この PR で baseline を「baseline source を最初から standalone build する方式」へ変更すると、job 分離と baseline build semantics の変更を同時に行うことになります。

そのためこの PR では correctness / isolation を優先し、pre-split state を可能な限り再現します。

baseline build の純化や pinned artifact 化、重複 build の削減は別の変更として扱います。

## ローカル構造監査

- changed files: `windows.yaml` only
- `build_arm64`: current-only structure PASS
- baseline current-source preparation: preserved
- baseline current ARM64 warm-up build: preserved
- exact W2 predecessor checkout: preserved
- baseline artifact name: preserved
- installer lifecycle: both producers required
- installed-MSI audit dependency: unchanged
- `windows-11-arm` audit runners: unchanged
- `git diff --check`: PASS

## 後続作業

この PR が green / merge された後、別 PR で current ARM64 package build を `windows-11-arm` native build へ切り替えます。

その PR では:

- `build_arm64` -> `windows-11-arm`
- native ARM64 Qt/build path
- cache key architecture separation (`runner.arch`)
- cross-build / native-build parity

を扱います。

W2 predecessor baseline builder は x64 `windows-2025` runner に残すため、historical baseline と current native build の host requirements を切り離せます。