### PR TITLE
Build ARM64 package on native Windows ARM runner

### DIFF
--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -66,7 +66,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: src/third_party_cache
-          key: update_deps-${{ runner.os }}-${{ hashFiles('src/build_tools/update_deps.py') }}
+          key: update_deps-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('src/build_tools/update_deps.py') }}
 
       - name: Install Dependencies
         shell: cmd
@@ -181,7 +181,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: src/third_party_cache
-          key: update_deps-${{ runner.os }}-${{ hashFiles('src/build_tools/update_deps.py') }}
+          key: update_deps-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('src/build_tools/update_deps.py') }}
 
       - name: Install Dependencies
         shell: cmd
@@ -275,8 +275,8 @@ jobs:
 
   build_arm64:
     needs: prepare_daily_dictionary
-    # https://github.com/actions/runner-images/blob/main/images/windows/Windows2025-Readme.md
-    runs-on: windows-2025
+    # https://github.com/actions/runner-images/blob/main/images/windows/Windows11-Arm64-Readme.md
+    runs-on: windows-11-arm
     timeout-minutes: 120
 
     steps:
@@ -296,7 +296,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: src/third_party_cache
-          key: update_deps-${{ runner.os }}-${{ hashFiles('src/build_tools/update_deps.py') }}
+          key: update_deps-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('src/build_tools/update_deps.py') }}
 
       - name: Install Dependencies
         shell: cmd
@@ -414,7 +414,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: src/third_party_cache
-          key: update_deps-${{ runner.os }}-${{ hashFiles('src/build_tools/update_deps.py') }}
+          key: update_deps-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('src/build_tools/update_deps.py') }}
 
       - name: Install Dependencies
         shell: cmd
@@ -1643,7 +1643,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: src/third_party_cache
-          key: update_deps-${{ runner.os }}-${{ hashFiles('src/build_tools/update_deps.py') }}
+          key: update_deps-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('src/build_tools/update_deps.py') }}
 
       - name: Install Dependencies
         shell: cmd
@@ -1679,7 +1679,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: src/third_party_cache
-          key: update_deps-${{ runner.os }}-${{ hashFiles('src/build_tools/update_deps.py') }}
+          key: update_deps-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('src/build_tools/update_deps.py') }}
 
       - name: Install Dependencies
         shell: cmd


### PR DESCRIPTION
## 概要

Windows ARM64 current package build を、x64 `windows-2025` runner 上の cross-build から `windows-11-arm` native runner 上の build へ切り替えます。

この PR では **build host の変更を主変数として切り分ける**ため、ARM64 target の explicit selector は維持します。

また、x64 / ARM64 runner 間で `update_deps` cache が衝突しないよう、Windows workflow 内の全 `update_deps` cache key に `runner.arch` を追加します。

## 背景

前段の変更で以下は完了しています。

1. upstream Mozc #1532〜#1535 の Windows ARM64 host toolchain core を統合
2. W2 predecessor lifecycle baseline build を dedicated `windows-2025` job へ分離

これにより、historical baseline builder を x64 host に固定したまま、current ARM64 package build だけを native ARM64 host へ移行できる状態になりました。

## 変更内容

### current ARM64 package build

`build_arm64`:

```text
before:
  windows-2025 x64 host
    -> explicit ARM64 target
    -> ARM64 MSI

after:
  windows-11-arm ARM64 host
    -> explicit ARM64 target
    -> ARM64 MSI
```

runner:

```yaml
runs-on: windows-2025
```

から

```yaml
runs-on: windows-11-arm
```

へ変更します。

### update_deps cache architecture separation

Windows workflow 内の6個すべての `update_deps` cache key を、

```text
update_deps-${runner.os}-${hash}
```

から、

```text
update_deps-${runner.os}-${runner.arch}-${hash}
```

へ変更します。

対象 job:

- `build_x64`
- `build_universal`
- `build_arm64`
- `build_arm64_lifecycle_baseline`
- `test`
- `cache_deps`

これにより x64 / ARM64 runner 間の dependency cache collision を避けます。

## この PR で意図的に変更しないもの

### explicit ARM64 target selector

以下は維持します。

```text
build_qt.py --target_arch=arm64
bazelisk build ... --platforms=//:windows-arm64
```

upstream #1537 では host-default へ寄せるためこれらを外していますが、この PR では外しません。

理由は、今回まず証明したいことが

> same explicit ARM64 target を、x64 host ではなく ARM64 host から正しく build できること

だからです。

host-default 化は native build が green になった後の小さな cleanup として独立して検証できます。

### CRT preparation

Mozkey 固有の

`Prepare CRT redist directory expected by WiX`

step はそのまま維持します。

ARM64 MSI の compatibility payload が必要とする x64 CRT を引き続き準備します。

native runner 上でこの step が実際に成立することはこの PR の CI で確認します。

### W2 lifecycle baseline builder

`build_arm64_lifecycle_baseline` は引き続き:

```yaml
runs-on: windows-2025
```

です。

以下も変更しません。

- exact baseline source:
  `c986db2c611c7255ba92b1d44fc6ac3fb6b098bf`
- current-source preparation
- current ARM64 warm-up build
- exact baseline checkout/build
- baseline artifact:
  `Mozc64_arm64_pre_native_lifecycle_baseline.msi`

### downstream contract

以下は変更しません。

- `Mozc64_arm64.msi` artifact name
- Native ARM64 installer lifecycle audit
- Native ARM64 installed MSI Zenz audit
- scorer / llama ARM64 PE identity
- model identity
- semantic checks
- named-pipe E2E
- loopback-only / firewall contract
- upgrade lifecycle
- legacy payload cleanup
- uninstall cleanup

## 変更ファイル

`.github/workflows/windows.yaml` のみ。

差分は 8 additions / 8 deletions です。

## ローカル構造監査

- changed files: `windows.yaml` only
- current ARM64 runner: `windows-11-arm`
- baseline builder runner: `windows-2025`
- explicit Qt ARM64 selector: preserved
- explicit Bazel ARM64 selector: preserved
- CRT preparation: preserved
- update_deps cache keys: 6
- cache keys with `runner.arch`: 6
- baseline source/artifact contract: preserved
- downstream lifecycle / installed-MSI dependencies: preserved
- `git diff --check`: PASS

## upstreamとの関係

upstream Mozc #1537:

`379723af27602d58b6af3feb858ab5904645ad48`
Use `windows-11-arm` runner to build Arm64 package

を参考にしています。

ただし Mozkey 固有の CI / lifecycle contract を維持するため、#1537 をそのまま cherry-pick するのではなく、native runner と cache architecture separation の必要部分だけを段階的に適用しています。

## 後続作業

この PR が green / merge された後に、必要なら別の小さな PR で:

- `--target_arch=arm64` の省略
- `--platforms=//:windows-arm64` の省略

を行い、upstream と同じ host-default ARM64 build path を検証します。

また ARM64 native unit-test coverage の追加も、package build host migration とは分離して検討します。
