### PR TITLE
Add ARM64 cross-native package parity gate

### DIFF
--- a/.github/scripts/windows_arm64_cross_native_parity_audit.ps1
+++ b/.github/scripts/windows_arm64_cross_native_parity_audit.ps1
@@ -1,0 +1,454 @@
+param(
+  [Parameter(Mandatory = $true)]
+  [string]$NativeArtifactDir,
+
+  [Parameter(Mandatory = $true)]
+  [string]$CrossArtifactDir,
+
+  [Parameter(Mandatory = $true)]
+  [string]$EvidenceDir
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+$ProgressPreference = "SilentlyContinue"
+
+New-Item -ItemType Directory -Force -Path $EvidenceDir | Out-Null
+$EvidenceDir = [System.IO.Path]::GetFullPath($EvidenceDir)
+
+function Resolve-SingleMsi {
+  param(
+    [Parameter(Mandatory = $true)][string]$Directory,
+    [Parameter(Mandatory = $true)][string]$Label
+  )
+
+  $items = @(
+    Get-ChildItem -Path $Directory -Recurse -File -Filter *.msi
+  )
+  if ($items.Count -ne 1) {
+    throw "${Label}: expected exactly one MSI; found $($items.Count)"
+  }
+  return $items[0].FullName
+}
+
+function Release-ComObject {
+  param([object]$Object)
+  if ($null -ne $Object -and [System.Runtime.InteropServices.Marshal]::IsComObject($Object)) {
+    [void][System.Runtime.InteropServices.Marshal]::FinalReleaseComObject($Object)
+  }
+}
+
+function Invoke-MsiQuery {
+  param(
+    [Parameter(Mandatory = $true)][string]$Path,
+    [Parameter(Mandatory = $true)][string]$Sql,
+    [Parameter(Mandatory = $true)][int]$FieldCount
+  )
+
+  $installer = $null
+  $database = $null
+  $view = $null
+  $rows = @()
+
+  try {
+    $installer = New-Object -ComObject WindowsInstaller.Installer
+    $database = $installer.GetType().InvokeMember(
+      "OpenDatabase",
+      [System.Reflection.BindingFlags]::InvokeMethod,
+      $null,
+      $installer,
+      @($Path, 0)
+    )
+    $view = $database.GetType().InvokeMember(
+      "OpenView",
+      [System.Reflection.BindingFlags]::InvokeMethod,
+      $null,
+      $database,
+      @($Sql)
+    )
+    [void]$view.GetType().InvokeMember(
+      "Execute",
+      [System.Reflection.BindingFlags]::InvokeMethod,
+      $null,
+      $view,
+      $null
+    )
+
+    while ($true) {
+      $record = $view.GetType().InvokeMember(
+        "Fetch",
+        [System.Reflection.BindingFlags]::InvokeMethod,
+        $null,
+        $view,
+        $null
+      )
+      if ($null -eq $record) {
+        break
+      }
+
+      try {
+        $fields = @()
+        for ($i = 1; $i -le $FieldCount; ++$i) {
+          $value = $record.GetType().InvokeMember(
+            "StringData",
+            [System.Reflection.BindingFlags]::GetProperty,
+            $null,
+            $record,
+            @($i)
+          )
+          $fields += [string]$value
+        }
+        $rows += [pscustomobject]@{
+          Fields = $fields
+        }
+      }
+      finally {
+        Release-ComObject $record
+      }
+    }
+  }
+  finally {
+    Release-ComObject $view
+    Release-ComObject $database
+    Release-ComObject $installer
+  }
+
+  return $rows
+}
+
+function Get-MsiProperty {
+  param(
+    [Parameter(Mandatory = $true)][string]$Path,
+    [Parameter(Mandatory = $true)][string]$Name
+  )
+
+  $sql = "SELECT ``Value`` FROM ``Property`` WHERE ``Property``='$Name'"
+  $rows = @(Invoke-MsiQuery -Path $Path -Sql $sql -FieldCount 1)
+  if ($rows.Count -eq 0) {
+    return ""
+  }
+  if ($rows.Count -ne 1) {
+    throw "MSI property '$Name' has unexpected row count: $($rows.Count)"
+  }
+  return [string]$rows[0].Fields[0]
+}
+
+function Get-MsiFileTable {
+  param([Parameter(Mandatory = $true)][string]$Path)
+
+  $rows = @(
+    Invoke-MsiQuery `
+      -Path $Path `
+      -Sql 'SELECT `File`, `Component_`, `FileName` FROM `File`' `
+      -FieldCount 3
+  )
+  return @(
+    $rows |
+      ForEach-Object {
+        "$($_.Fields[0])|$($_.Fields[1])|$($_.Fields[2])"
+      } |
+      Sort-Object
+  )
+}
+
+function Invoke-AdministrativeExtract {
+  param(
+    [Parameter(Mandatory = $true)][string]$Msi,
+    [Parameter(Mandatory = $true)][string]$TargetDir,
+    [Parameter(Mandatory = $true)][string]$Log
+  )
+
+  if (Test-Path $TargetDir) {
+    Remove-Item -Recurse -Force $TargetDir
+  }
+  New-Item -ItemType Directory -Force -Path $TargetDir | Out-Null
+
+  $process = Start-Process msiexec.exe -Wait -PassThru -ArgumentList @(
+    "/a",
+    "`"$Msi`"",
+    "/qn",
+    "TARGETDIR=`"$TargetDir`"",
+    "/l*v",
+    "`"$Log`""
+  )
+
+  Write-Host "Administrative extract exit = $($process.ExitCode)"
+  if ($process.ExitCode -notin @(0, 3010)) {
+    throw "Administrative extraction failed: $Msi (exit $($process.ExitCode))"
+  }
+}
+
+function Get-RelativeFileSet {
+  param([Parameter(Mandatory = $true)][string]$Root)
+
+  $fullRoot = [System.IO.Path]::GetFullPath($Root)
+  return @(
+    Get-ChildItem -Path $fullRoot -Recurse -File |
+      ForEach-Object {
+        [System.IO.Path]::GetRelativePath($fullRoot, $_.FullName).Replace("\", "/")
+      } |
+      Sort-Object
+  )
+}
+
+function Get-PEMachine {
+  param([Parameter(Mandatory = $true)][string]$Path)
+
+  $stream = $null
+  $reader = $null
+  try {
+    $stream = [System.IO.File]::Open(
+      $Path,
+      [System.IO.FileMode]::Open,
+      [System.IO.FileAccess]::Read,
+      [System.IO.FileShare]::ReadWrite
+    )
+    $reader = [System.IO.BinaryReader]::new($stream)
+
+    if ($stream.Length -lt 64) { return $null }
+    if ($reader.ReadUInt16() -ne 0x5A4D) { return $null }
+
+    $stream.Seek(0x3C, [System.IO.SeekOrigin]::Begin) | Out-Null
+    $offset = $reader.ReadUInt32()
+    if ($offset + 6 -gt $stream.Length) { return "INVALID_PE" }
+
+    $stream.Seek($offset, [System.IO.SeekOrigin]::Begin) | Out-Null
+    if ($reader.ReadUInt32() -ne 0x00004550) { return "INVALID_PE" }
+
+    $machine = $reader.ReadUInt16()
+    switch ($machine) {
+      0xAA64 { return "ARM64" }
+      0x8664 { return "x64" }
+      0x014c { return "x86" }
+      default { return ("0x{0:X4}" -f $machine) }
+    }
+  }
+  finally {
+    if ($reader) { $reader.Dispose() }
+    elseif ($stream) { $stream.Dispose() }
+  }
+}
+
+function Get-PEManifest {
+  param([Parameter(Mandatory = $true)][string]$Root)
+
+  $fullRoot = [System.IO.Path]::GetFullPath($Root)
+  $rows = @()
+
+  foreach ($file in Get-ChildItem -Path $fullRoot -Recurse -File) {
+    if ($file.Extension -notin @(".exe", ".dll")) {
+      continue
+    }
+
+    $machine = Get-PEMachine $file.FullName
+    if ($null -eq $machine) {
+      continue
+    }
+
+    $relative = [System.IO.Path]::GetRelativePath(
+      $fullRoot,
+      $file.FullName
+    ).Replace("\", "/")
+    $rows += "$relative|$machine"
+  }
+
+  return @($rows | Sort-Object)
+}
+
+function Get-SinglePayload {
+  param(
+    [Parameter(Mandatory = $true)][string]$Root,
+    [Parameter(Mandatory = $true)][string]$LeafName
+  )
+
+  $items = @(
+    Get-ChildItem -Path $Root -Recurse -File |
+      Where-Object { $_.Name -eq $LeafName }
+  )
+  if ($items.Count -ne 1) {
+    throw "Expected exactly one '$LeafName' in extracted payload; found $($items.Count)"
+  }
+  return $items[0].FullName
+}
+
+function Assert-TextSetEqual {
+  param(
+    [Parameter(Mandatory = $true)][string]$Name,
+    [Parameter(Mandatory = $true)][object[]]$Native,
+    [Parameter(Mandatory = $true)][object[]]$Cross,
+    [Parameter(Mandatory = $true)][string]$DiffPath
+  )
+
+  $diff = @(Compare-Object -ReferenceObject $Native -DifferenceObject $Cross)
+  if ($diff.Count -ne 0) {
+    $diff | Format-Table -AutoSize | Out-String | Set-Content -Encoding utf8 $DiffPath
+    throw "$Name differs between native and x64-host cross packages."
+  }
+  "MATCH" | Set-Content -Encoding utf8 $DiffPath
+  Write-Host "$Name = MATCH"
+}
+
+$nativeMsi = Resolve-SingleMsi -Directory $NativeArtifactDir -Label "native"
+$crossMsi = Resolve-SingleMsi -Directory $CrossArtifactDir -Label "cross"
+
+$nativeSha = (Get-FileHash $nativeMsi -Algorithm SHA256).Hash
+$crossSha = (Get-FileHash $crossMsi -Algorithm SHA256).Hash
+$nativeSize = (Get-Item $nativeMsi).Length
+$crossSize = (Get-Item $crossMsi).Length
+
+Write-Host "===== MSI CONTAINER INFO ====="
+Write-Host "Native MSI = $nativeMsi"
+Write-Host "Native SHA = $nativeSha"
+Write-Host "Native size = $nativeSize"
+Write-Host "Cross MSI = $crossMsi"
+Write-Host "Cross SHA = $crossSha"
+Write-Host "Cross size = $crossSize"
+Write-Host "Whole-MSI SHA equality is intentionally NOT required."
+
+$propertyNames = @(
+  "ProductName",
+  "ProductVersion",
+  "ProductCode",
+  "UpgradeCode",
+  "Manufacturer",
+  "ProductLanguage"
+)
+
+$nativeProps = [ordered]@{}
+$crossProps = [ordered]@{}
+foreach ($name in $propertyNames) {
+  $nativeProps[$name] = Get-MsiProperty -Path $nativeMsi -Name $name
+  $crossProps[$name] = Get-MsiProperty -Path $crossMsi -Name $name
+}
+
+$nativeProps | ConvertTo-Json | Set-Content -Encoding utf8 (Join-Path $EvidenceDir "native-msi-properties.json")
+$crossProps | ConvertTo-Json | Set-Content -Encoding utf8 (Join-Path $EvidenceDir "cross-msi-properties.json")
+
+Write-Host ""
+Write-Host "===== MSI PROPERTY PARITY ====="
+foreach ($name in @("ProductName", "ProductVersion", "UpgradeCode", "Manufacturer", "ProductLanguage")) {
+  Write-Host "$name native = $($nativeProps[$name])"
+  Write-Host "$name cross  = $($crossProps[$name])"
+  if ($nativeProps[$name] -ne $crossProps[$name]) {
+    throw "MSI property mismatch: $name"
+  }
+}
+Write-Host "Required MSI property parity = PASS"
+
+Write-Host "ProductCode native = $($nativeProps.ProductCode)"
+Write-Host "ProductCode cross  = $($crossProps.ProductCode)"
+if ($nativeProps.ProductCode -ne $crossProps.ProductCode) {
+  Write-Warning "ProductCode differs. This is recorded but not gated until determinism is separately audited."
+}
+
+Write-Host ""
+Write-Host "===== MSI FILE TABLE PARITY ====="
+$nativeFileTable = @(Get-MsiFileTable $nativeMsi)
+$crossFileTable = @(Get-MsiFileTable $crossMsi)
+$nativeFileTable | Set-Content -Encoding utf8 (Join-Path $EvidenceDir "native-file-table.txt")
+$crossFileTable | Set-Content -Encoding utf8 (Join-Path $EvidenceDir "cross-file-table.txt")
+Assert-TextSetEqual `
+  -Name "MSI File table logical rows" `
+  -Native $nativeFileTable `
+  -Cross $crossFileTable `
+  -DiffPath (Join-Path $EvidenceDir "file-table-diff.txt")
+
+Write-Host ""
+Write-Host "===== ADMINISTRATIVE EXTRACTION ====="
+$nativeExtract = Join-Path $EvidenceDir "native-extract"
+$crossExtract = Join-Path $EvidenceDir "cross-extract"
+Invoke-AdministrativeExtract `
+  -Msi $nativeMsi `
+  -TargetDir $nativeExtract `
+  -Log (Join-Path $EvidenceDir "native-admin-extract.log")
+Invoke-AdministrativeExtract `
+  -Msi $crossMsi `
+  -TargetDir $crossExtract `
+  -Log (Join-Path $EvidenceDir "cross-admin-extract.log")
+
+$nativePayload = @(Get-RelativeFileSet $nativeExtract)
+$crossPayload = @(Get-RelativeFileSet $crossExtract)
+$nativePayload | Set-Content -Encoding utf8 (Join-Path $EvidenceDir "native-payload.txt")
+$crossPayload | Set-Content -Encoding utf8 (Join-Path $EvidenceDir "cross-payload.txt")
+Assert-TextSetEqual `
+  -Name "Administrative extracted payload set" `
+  -Native $nativePayload `
+  -Cross $crossPayload `
+  -DiffPath (Join-Path $EvidenceDir "payload-diff.txt")
+
+Write-Host ""
+Write-Host "===== PE MACHINE PARITY ====="
+$nativePe = @(Get-PEManifest $nativeExtract)
+$crossPe = @(Get-PEManifest $crossExtract)
+$nativePe | Set-Content -Encoding utf8 (Join-Path $EvidenceDir "native-pe-machines.txt")
+$crossPe | Set-Content -Encoding utf8 (Join-Path $EvidenceDir "cross-pe-machines.txt")
+Assert-TextSetEqual `
+  -Name "PE relative-path / machine manifest" `
+  -Native $nativePe `
+  -Cross $crossPe `
+  -DiffPath (Join-Path $EvidenceDir "pe-machine-diff.txt")
+
+Write-Host ""
+Write-Host "===== PINNED PAYLOAD HASH PARITY ====="
+$nativeLlama = Get-SinglePayload -Root $nativeExtract -LeafName "llama-server.exe"
+$crossLlama = Get-SinglePayload -Root $crossExtract -LeafName "llama-server.exe"
+$nativeModel = Get-SinglePayload -Root $nativeExtract -LeafName "zenz-v3.2-small-Q5_K_M.gguf"
+$crossModel = Get-SinglePayload -Root $crossExtract -LeafName "zenz-v3.2-small-Q5_K_M.gguf"
+$nativeScorer = Get-SinglePayload -Root $nativeExtract -LeafName "mozc_zenz_scorer.exe"
+$crossScorer = Get-SinglePayload -Root $crossExtract -LeafName "mozc_zenz_scorer.exe"
+
+$hashRows = @(
+  [pscustomobject]@{
+    Payload = "llama-server.exe"
+    Native = (Get-FileHash $nativeLlama -Algorithm SHA256).Hash
+    Cross = (Get-FileHash $crossLlama -Algorithm SHA256).Hash
+    Gate = $true
+  },
+  [pscustomobject]@{
+    Payload = "zenz-v3.2-small-Q5_K_M.gguf"
+    Native = (Get-FileHash $nativeModel -Algorithm SHA256).Hash
+    Cross = (Get-FileHash $crossModel -Algorithm SHA256).Hash
+    Gate = $true
+  },
+  [pscustomobject]@{
+    Payload = "mozc_zenz_scorer.exe"
+    Native = (Get-FileHash $nativeScorer -Algorithm SHA256).Hash
+    Cross = (Get-FileHash $crossScorer -Algorithm SHA256).Hash
+    Gate = $false
+  }
+)
+
+$hashRows | Export-Csv -NoTypeInformation -Encoding utf8 (Join-Path $EvidenceDir "payload-hashes.csv")
+foreach ($row in $hashRows) {
+  Write-Host "$($row.Payload) native = $($row.Native)"
+  Write-Host "$($row.Payload) cross  = $($row.Cross)"
+  if ($row.Gate -and $row.Native -ne $row.Cross) {
+    throw "Pinned payload hash mismatch: $($row.Payload)"
+  }
+}
+Write-Host "Pinned llama/model hash parity = PASS"
+Write-Host "Scorer hash equality = INFORMATIONAL (PE machine parity is gated)"
+
+$summary = @(
+  "ARM64 cross/native package parity = PASS",
+  "Native host = windows-11-arm",
+  "Cross host = windows-2025",
+  "Native MSI SHA256 = $nativeSha",
+  "Cross MSI SHA256 = $crossSha",
+  "Native MSI size = $nativeSize",
+  "Cross MSI size = $crossSize",
+  "Whole-MSI SHA equality required = NO",
+  "ProductName parity = PASS",
+  "ProductVersion parity = PASS",
+  "UpgradeCode parity = PASS",
+  "Manufacturer parity = PASS",
+  "ProductLanguage parity = PASS",
+  "ProductCode equality = $($nativeProps.ProductCode -eq $crossProps.ProductCode)",
+  "MSI File table parity = PASS",
+  "Administrative payload set parity = PASS",
+  "PE machine manifest parity = PASS",
+  "llama-server hash parity = PASS",
+  "model hash parity = PASS"
+)
+$summary | Set-Content -Encoding utf8 (Join-Path $EvidenceDir "summary.txt")
+$summary | ForEach-Object { Write-Host $_ }

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -499,6 +499,33 @@ jobs:
         run: |
           bazelisk build package --config release_build --platforms=//:windows-arm64
 
+      - name: Verify x64-host current ARM64 parity MSI before baseline checkout
+        shell: pwsh
+        run: |
+          Set-StrictMode -Version Latest
+          $ErrorActionPreference = "Stop"
+
+          $head = (git rev-parse HEAD).Trim()
+          if ($head -ne "${{ github.sha }}") {
+            throw "Cross-parity warm-up source mismatch: $head"
+          }
+
+          $msi = ".\src\bazel-bin\win32\installer\Mozc64.msi"
+          if (-not (Test-Path $msi -PathType Leaf)) {
+            throw "Current-source x64-host ARM64 warm-up MSI was not produced."
+          }
+
+          Write-Host "Cross-parity source SHA = $head"
+          Write-Host "Cross-parity MSI SHA256 = $((Get-FileHash $msi -Algorithm SHA256).Hash)"
+
+      - name: upload x64-host current ARM64 parity MSI
+        uses: actions/upload-artifact@v6
+        with:
+          name: Mozc64_arm64_x64_cross_parity.msi
+          path: src/bazel-bin/win32/installer/Mozc64.msi
+          if-no-files-found: error
+          retention-days: 3
+
       - name: Build W2-predecessor ARM64 lifecycle baseline
         shell: pwsh
         run: |
@@ -558,6 +585,50 @@ jobs:
           name: Mozc64_arm64_pre_native_lifecycle_baseline.msi
           path: src/bazel-bin/win32/installer/Mozc64.msi
           if-no-files-found: error
+
+  test_arm64_cross_native_parity:
+    name: ARM64 cross/native package parity audit
+    needs:
+      - build_arm64
+      - build_arm64_lifecycle_baseline
+    runs-on: windows-11-arm
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout parity audit script
+        uses: actions/checkout@v6
+        with:
+          submodules: false
+          persist-credentials: false
+
+      - name: Download native ARM64 MSI
+        uses: actions/download-artifact@v6
+        with:
+          name: Mozc64_arm64.msi
+          path: ${{ runner.temp }}\mozkey-native-arm64-parity
+
+      - name: Download x64-host cross-built ARM64 MSI
+        uses: actions/download-artifact@v6
+        with:
+          name: Mozc64_arm64_x64_cross_parity.msi
+          path: ${{ runner.temp }}\mozkey-cross-arm64-parity
+
+      - name: Compare native and x64-host cross ARM64 package contracts
+        shell: pwsh
+        run: |
+          & ".\.github\scripts\windows_arm64_cross_native_parity_audit.ps1" `
+            -NativeArtifactDir "${{ runner.temp }}\mozkey-native-arm64-parity" `
+            -CrossArtifactDir "${{ runner.temp }}\mozkey-cross-arm64-parity" `
+            -EvidenceDir "${{ runner.temp }}\mozkey-arm64-cross-native-parity-evidence"
+
+      - name: Upload cross/native parity evidence
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: Mozc64_arm64_cross_native_parity_audit
+          path: ${{ runner.temp }}\mozkey-arm64-cross-native-parity-evidence
+          if-no-files-found: warn
+          retention-days: 7
 
   test_arm64_installer_lifecycle:
     name: Native ARM64 installer lifecycle audit


### PR DESCRIPTION
## 概要

Windows ARM64 package を native `windows-11-arm` host へ移行した後の検証として、
同じ current source から生成した

- native ARM64-host build
- x64-host ARM64 cross-build

の MSI package contract を比較する一時 parity gate を追加します。

whole-MSI byte equality ではなく、release/runtime contract に意味のある
metadata / payload / PE architecture / pinned payload identity を比較します。

## cross-build artifact の再利用

新しい cross-build job は追加しません。

既存の `build_arm64_lifecycle_baseline` は historical W2 baseline checkout 前に、
current source の ARM64 package を x64 `windows-2025` host 上で warm-up build しています。

この MSI を baseline checkout 前に:

`Mozc64_arm64_x64_cross_parity.msi`

として一時 artifact に保存します。

その後の exact W2 predecessor checkout / build / baseline artifact upload は従来どおりです。

## parity job

新しく:

`test_arm64_cross_native_parity`

を追加します。

依存関係:

```yaml
needs:
  - build_arm64
  - build_arm64_lifecycle_baseline
```

runner:

```yaml
runs-on: windows-11-arm
```

入力:

- `Mozc64_arm64.msi`
  - native ARM64 host build
- `Mozc64_arm64_x64_cross_parity.msi`
  - x64-host ARM64 cross-build

## gated comparisons

以下は一致を必須にします。

### MSI metadata

- ProductName
- ProductVersion
- UpgradeCode
- Manufacturer
- ProductLanguage

### package structure

- MSI `File` table logical rows
- administrative extraction 後の relative payload file set

### architecture

抽出された `.exe` / `.dll` について:

- relative path
- PE machine type

の manifest を比較します。

### pinned Zenz payload

以下は SHA256 equality を必須にします。

- `llama-server.exe`
- `zenz-v3.2-small-Q5_K_M.gguf`

`mozc_zenz_scorer.exe` は PE machine parity を必須にし、
binary SHA equality は informational とします。

## intentional non-gates

### whole MSI SHA256

native / cross MSI 全体の byte-for-byte SHA equality は要求しません。

container/cabinet/timestamp 等の非semantic差で false negative にしないためです。

### ProductCode

ProductCode は両方から記録し、差がある場合は warning を出しますが、
この PR では gate にしません。

同一sourceに対する ProductCode determinism は必要なら別途監査します。

## historical lifecycle baseline

以下は変更しません。

- baseline builder runner: `windows-2025`
- exact W2 predecessor:
  `c986db2c611c7255ba92b1d44fc6ac3fb6b098bf`
- current-source preparation
- current ARM64 warm-up build
- exact baseline checkout/build
- baseline artifact:
  `Mozc64_arm64_pre_native_lifecycle_baseline.msi`

parity MSI の upload は historical baseline checkout より前に行います。

## 変更しないもの

- native `build_arm64`
- `--target_arch=arm64`
- `--platforms=//:windows-arm64`
- CRT preparation
- `runner.arch` cache separation
- Native ARM64 installer lifecycle audit
- Native ARM64 installed MSI Zenz audit
- semantic / named-pipe / firewall / upgrade / uninstall contract

## 変更ファイル

- `.github/workflows/windows.yaml`
- `.github/scripts/windows_arm64_cross_native_parity_audit.ps1`

## ローカル検証

- exact base: PR #216 merge
  `60cbc7d22fbf0dd61b2e6b7747bc9756f6659c77`
- changed file set: exactly 2 files
- PowerShell parser: PASS
- MSI query row model: `PSCustomObject.Fields`
- synthetic multi-row self-test: PASS
- nested-array query return: removed
- warm-up -> parity upload -> historical baseline order: PASS
- native builder: unchanged
- historical baseline builder: preserved
- explicit ARM64 selectors: preserved
- CRT preparation: preserved
- cache architecture separation: preserved 6/6
- `git diff --check`: PASS

## 目的

native ARM64 host migration 後に、x64-host cross-build と native-host build が
package/runtime contract 上で同等であることを一度明示的に証明します。

parity が確認できた後、この temporary parity gate を残すか削除するか、
また explicit ARM64 target selector を host-default 化するかを別変更として判断します。