### PR TITLE
Use host-default targets for native ARM64 build

### DIFF
--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -305,11 +305,11 @@ jobs:
         run: |
           python build_tools/update_deps.py
 
-      - name: Build Qt (arm64)
+      - name: Build Qt
         shell: cmd
         working-directory: .\src
         run: |
-          python build_tools/build_qt.py --release --confirm_license --target_arch=arm64
+          python build_tools/build_qt.py --release --confirm_license
 
       # This is needed only for GitHub Actions where free disk space is quite limited.
       - name: Delete Qt src to save disk space
@@ -379,7 +379,7 @@ jobs:
         env:
           ANDROID_NDK_HOME: ""
         run: |
-          bazelisk build package --config release_build --platforms=//:windows-arm64
+          bazelisk build package --config release_build
 
       - name: upload Mozc64_arm64.msi
         uses: actions/upload-artifact@v6


### PR DESCRIPTION
## 概要

Windows ARM64 native package build を、explicit ARM64 target 指定から
`windows-11-arm` host architecture による host-default target へ切り替えます。

これは upstream Mozc #1537 の native ARM64 build path に合わせる最終 cleanup です。

今回変更するのは `build_arm64` job のみです。

## 変更内容

### Qt

before:

```text
Build Qt (arm64)

python build_tools/build_qt.py \
  --release \
  --confirm_license \
  --target_arch=arm64
```

after:

```text
Build Qt

python build_tools/build_qt.py \
  --release \
  --confirm_license
```

### Bazel package build

before:

```text
bazelisk build package \
  --config release_build \
  --platforms=//:windows-arm64
```

after:

```text
bazelisk build package \
  --config release_build
```

`build_arm64` runner は引き続き:

```yaml
runs-on: windows-11-arm
```

です。

## なぜ host-default にするか

upstream Mozc #1532〜#1535 で Windows ARM64 host toolchain support が整備され、
#1537 では native ARM64 runner 上で host-default architecture を使う形へ移行しています。

Mozkey でも前段で:

1. upstream Windows ARM64 host toolchain core を統合
2. historical lifecycle baseline builder を x64 host に分離
3. current package build を `windows-11-arm` native runner へ移行
4. x64-host cross build と native build の package parity gate を追加

まで完了しています。

そのため、この PR では explicit selector を外す変更だけを独立して検証できます。

## cross/native parity gate

PR #217 で追加した parity gate はそのまま残します。

この PR 後は比較が:

```text
native:
  windows-11-arm
  host-default ARM64 target

vs

cross:
  windows-2025
  explicit ARM64 target
```

になります。

parity gate は以下を比較します。

- ProductName
- ProductVersion
- UpgradeCode
- Manufacturer
- ProductLanguage
- MSI File table
- administrative extraction 後の payload file set
- PE relative-path / machine manifest
- llama-server SHA256
- model SHA256

whole-MSI SHA equality は要求しません。

ProductCode equality は記録のみです。

この parity gate が green であれば、host-default target resolution が従来の explicit ARM64 cross-build と package contract 上で同等であることを確認できます。

## 変更しないもの

以下は変更しません。

- `build_arm64` runner: `windows-11-arm`
- `build_arm64_lifecycle_baseline` runner: `windows-2025`
- cross-side `--target_arch=arm64`
- cross/historical `--platforms=//:windows-arm64`
- cross/native parity artifact
- cross/native parity job
- CRT preparation
- `runner.arch` cache separation
- exact W2 predecessor lifecycle baseline
- Native ARM64 installer lifecycle audit
- Native ARM64 installed MSI Zenz audit
- semantic / named-pipe / firewall / upgrade / uninstall contract

## 変更ファイル

`.github/workflows/windows.yaml` のみです。

差分:

```text
3 additions / 3 deletions
```

## ローカル監査

- exact base:
  `90c14527c348fecaac0ceb0230722737797298a5`
- changed files: `windows.yaml` only
- diff: 3 additions / 3 deletions
- native runner: `windows-11-arm`
- native Qt target: host default
- native Bazel target: host default
- cross/baseline Qt target: explicit ARM64
- cross/baseline Bazel target: explicit ARM64
- baseline/cross builder: unchanged
- cross/native parity job: unchanged
- installer lifecycle job: unchanged
- installed-MSI Zenz job: unchanged
- CRT preparation: preserved
- cache architecture separation: preserved 6/6
- artifact graph: preserved
- parity audit script: unchanged
- `git diff --check`: PASS

## upstreamとの関係

参考:

`379723af27602d58b6af3feb858ab5904645ad48`

`Use windows-11-arm runner to build Arm64 package (#1537)`

この upstream change のうち、Mozkey では runner migration / cache architecture separation を既に段階的に統合済みです。

この PR で native-side host-default target 化を完了します。

## CIで確認すること

特に重要なのは:

1. native `build_arm64` が host-default で成功
2. cross/native package parity audit が green
3. Native ARM64 installer lifecycle audit が green
4. Native ARM64 installed MSI Zenz audit が green

です。

これらがすべて成功すれば、Windows ARM64 current package build は
upstream-style native host-default path へ移行完了と判断できます。