### PR TITLE
Add native ARM64 Windows unit tests

### DIFF
--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -1731,6 +1731,46 @@ jobs:
         run: |
           bazelisk test ... -c dbg --build_tests_only
 
+  test_arm64:
+    needs: prepare_daily_dictionary
+    # https://github.com/actions/runner-images/blob/main/images/windows/Windows11-Arm64-Readme.md
+    runs-on: windows-11-arm
+    timeout-minutes: 120
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          submodules: false
+          persist-credentials: false
+
+      - name: download daily dictionary
+        uses: actions/download-artifact@v6
+        with:
+          name: daily-dictionary
+          path: .
+
+      - name: Try to restore update_deps cache
+        uses: actions/cache@v5
+        with:
+          path: src/third_party_cache
+          key: update_deps-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('src/build_tools/update_deps.py') }}
+
+      - name: Install Dependencies
+        shell: cmd
+        working-directory: .\src
+        # This command uses src/third_party_cache as the download cache.
+        run: |
+          python build_tools/update_deps.py
+
+      - name: runtests
+        shell: cmd
+        working-directory: .\src
+        env:
+          ANDROID_NDK_HOME: ""
+        run: |
+          bazelisk test ... -c dbg --build_tests_only
+
   # actions/cache works without this job, but having this would increase the likelihood of cache hit
   # in other jobs. Another approach would be to use "needs:".
   # https://docs.github.com/en/actions/using-jobs/using-jobs-in-a-workflow


### PR DESCRIPTION
## 概要

Windows ARM64 native runner 上で、既存の Windows unit-test suite を実行する
`test_arm64` job を追加します。

今回の変更は architecture coverage の追加だけに限定し、
現在の x64 `test` job と同じ Mozkey test contract を ARM64 上でも実行します。

## 追加する job

```yaml
test_arm64:
  needs: prepare_daily_dictionary
  runs-on: windows-11-arm
  timeout-minutes: 120
```

実行内容は既存の `test` job と同一です。

- Checkout
- daily dictionary download
- architecture-separated `update_deps` cache restore
- `python build_tools/update_deps.py`
- `bazelisk test ... -c dbg --build_tests_only`

`ANDROID_NDK_HOME` も既存 x64 test と同じく空にします。

## x64 testとの関係

既存:

```text
test
  windows-2025
```

追加:

```text
test_arm64
  windows-11-arm
```

job名 / runner image comment / runner architecture を除き、
test contract は同一です。

ローカル監査では ARM64 job を x64 job へ正規化した結果、
両者の test contract が identical であることを確認しています。

## daily dictionary

Mozkey の既存 Windows test は `prepare_daily_dictionary` に依存しているため、
ARM64 test でも同じ dependency / artifact を使用します。

これは upstream の generic test job をそのまま複製するのではなく、
Mozkey の現在の local test contract を ARM64 へ拡張するためです。

## cache

`update_deps` cache key は既に:

```text
update_deps-${runner.os}-${runner.arch}-${hash}
```

となっているため、`windows-11-arm` job は ARM64 namespace を使用します。

この PR では専用の ARM64 `cache_deps` warmer は追加しません。

cache warmer は correctness ではなく性能改善として、必要なら別途判断します。

## 意図的に追加しないもの

### ARM64-only logging

upstream Mozc #1537 の ARM64 test job には BEP / failing-test log collection がありますが、
現在の Mozkey x64 `test` job にはまだありません。

この PR では ARM64 側だけ logging を強化せず、既存 x64 test と対称な contract を維持します。

logging 改善を行う場合は x64 / ARM64 の両方へ別変更として適用します。

### test exclusions

ARM64 固有の exclusion は追加しません。

まず x64 と同じ test suite をそのまま ARM64 上で実行し、
failure が出た場合に source defect / test assumption / runner-toolchain 問題を分類します。

## 変更しないもの

以下は変更しません。

- existing x64 `test`
- native ARM64 package build
- host-default ARM64 build
- W2 lifecycle baseline builder
- cross/native package parity
- Native ARM64 installer lifecycle audit
- Native ARM64 installed MSI Zenz audit
- CRT preparation
- cache architecture separation
- package/runtime semantic contract

## 変更ファイル

`.github/workflows/windows.yaml` のみ。

差分:

```text
40 additions / 0 deletions
```

## ローカル監査

- exact base:
  `7add8ff653e1d3457e574445a0f5fc8cfe3673d8`
- existing x64 test: preserved
- new ARM64 test job: `test_arm64`
- runner: `windows-11-arm`
- daily dictionary: preserved
- update_deps cache: `runner.arch` separated
- Bazel test command:
  `bazelisk test ... -c dbg --build_tests_only`
- normalized x64 / ARM64 test contract: identical
- ARM64-only BEP/logging: not added
- ARM64 exclusions: not added
- ARM64 cache warmer: not added
- package/parity/lifecycle jobs: unchanged
- `git diff --check`: PASS

## upstreamとの関係

参考:

`379723af27602d58b6af3feb858ab5904645ad48`

`Use windows-11-arm runner to build Arm64 package (#1537)`

upstream #1537 では ARM64 native test coverage も追加されています。

Mozkey では upstream job をそのままコピーするのではなく、
現在の Mozkey x64 test contract を同型で ARM64 runner へ拡張しています。

## CIで確認すること

最重要なのは新しい:

`test_arm64`

が exclusion なしで green になることです。

これが green なら、Windows ARM64 について:

- native host-default package build
- cross/native package parity
- installed runtime semantics
- installer lifecycle
- native unit-test suite

まで CI coverage が揃います。
