### PR TITLE
Add ARM64 TIP client architecture smoke

### DIFF
--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -1691,6 +1691,367 @@ jobs:
           name: Mozc64_arm64_native_installed_msi_audit
           path: ${{ runner.temp }}\mozkey-w4-arm64-msi-evidence
           if-no-files-found: warn
+  test_arm64_tip_client_architecture:
+    name: ARM64 TIP client-architecture smoke
+    needs: build_arm64
+    runs-on: windows-11-arm
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          submodules: false
+          persist-credentials: false
+
+      - name: Try to restore update_deps cache
+        uses: actions/cache@v5
+        with:
+          path: src/third_party_cache
+          key: update_deps-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('src/build_tools/update_deps.py') }}
+
+      - name: Install Dependencies
+        shell: cmd
+        working-directory: .\src
+        run: |
+          python build_tools/update_deps.py
+
+      - name: Build native ARM64 and x64 TIP client smoke helpers
+        shell: cmd
+        working-directory: .\src
+        env:
+          ANDROID_NDK_HOME: ""
+        run: |
+          bazelisk build --config release_build //win32/tip:tip_client_smoke_arm64 //win32/tip:tip_client_smoke_x64
+
+      - name: Resolve, stage, and verify helper PE architectures
+        shell: pwsh
+        working-directory: .\src
+        run: |
+          Set-StrictMode -Version Latest
+          $ErrorActionPreference = "Stop"
+
+          function Get-PEMachine {
+            param([Parameter(Mandatory = $true)][string]$Path)
+
+            $stream = [System.IO.File]::Open(
+              $Path,
+              [System.IO.FileMode]::Open,
+              [System.IO.FileAccess]::Read,
+              [System.IO.FileShare]::Read
+            )
+            try {
+              $reader = New-Object System.IO.BinaryReader($stream)
+              if ($reader.ReadUInt16() -ne 0x5A4D) {
+                throw "Not an MZ executable: $Path"
+              }
+              $stream.Position = 0x3C
+              $peOffset = $reader.ReadUInt32()
+              $stream.Position = $peOffset
+              if ($reader.ReadUInt32() -ne 0x00004550) {
+                throw "Missing PE signature: $Path"
+              }
+              $machine = $reader.ReadUInt16()
+            } finally {
+              $stream.Dispose()
+            }
+
+            switch ($machine) {
+              0xAA64 { return "ARM64" }
+              0x8664 { return "x64" }
+              0x014C { return "x86" }
+              default { return ("0x{0:X4}" -f $machine) }
+            }
+          }
+
+          function Resolve-BazelOutput {
+            param(
+              [Parameter(Mandatory = $true)][string]$Target,
+              [Parameter(Mandatory = $true)][string]$ExpectedFileName,
+              [Parameter(Mandatory = $true)][string]$ExecutionRoot
+            )
+
+            $outputs = @(
+              & bazelisk cquery --config release_build --output=files $Target |
+                Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+            )
+            if ($LASTEXITCODE -ne 0) {
+              throw "bazelisk cquery failed for $Target with exit code $LASTEXITCODE"
+            }
+
+            Write-Host "cquery outputs for ${Target}:"
+            $outputs | ForEach-Object { Write-Host "  $_" }
+
+            $matching = @(
+              $outputs |
+                Where-Object {
+                  [System.IO.Path]::GetFileName($_) -ieq $ExpectedFileName
+                }
+            )
+            if ($matching.Count -ne 1) {
+              throw (
+                "Expected exactly one $ExpectedFileName output for $Target; " +
+                "found $($matching.Count)"
+              )
+            }
+
+            $resolved = Join-Path $ExecutionRoot $matching[0]
+            if (-not (Test-Path $resolved -PathType Leaf)) {
+              throw "Resolved Bazel output does not exist: $resolved"
+            }
+
+            return (Resolve-Path $resolved).Path
+          }
+
+          if ($env:PROCESSOR_ARCHITECTURE -ne "ARM64") {
+            throw "This job is not running on native Windows ARM64."
+          }
+
+          $executionRootOutput = @(
+            & bazelisk info --config release_build execution_root
+          )
+          if ($LASTEXITCODE -ne 0) {
+            throw "bazelisk info execution_root failed with exit code $LASTEXITCODE"
+          }
+
+          Write-Host "bazelisk info execution_root raw output:"
+          $executionRootOutput | ForEach-Object { Write-Host "  $_" }
+
+          $executionRootCandidates = @(
+            $executionRootOutput |
+              ForEach-Object { ([string]$_).Trim() } |
+              Where-Object {
+                -not [string]::IsNullOrWhiteSpace($_) -and
+                (Test-Path $_ -PathType Container)
+              }
+          )
+
+          if ($executionRootCandidates.Count -ne 1) {
+            throw (
+              "Expected exactly one existing execution_root directory; " +
+              "found $($executionRootCandidates.Count)"
+            )
+          }
+
+          $executionRoot = [string]$executionRootCandidates[0]
+          Write-Host "Bazel execution_root = $executionRoot"
+
+          $armSource = Resolve-BazelOutput `
+            -Target "//win32/tip:tip_client_smoke_arm64" `
+            -ExpectedFileName "tip_client_smoke_arm64.exe" `
+            -ExecutionRoot $executionRoot
+
+          $x64Source = Resolve-BazelOutput `
+            -Target "//win32/tip:tip_client_smoke_x64" `
+            -ExpectedFileName "tip_client_smoke_x64.exe" `
+            -ExecutionRoot $executionRoot
+
+          $stage = Join-Path $env:RUNNER_TEMP "mozkey-tip-client-smoke"
+          New-Item -ItemType Directory -Force -Path $stage | Out-Null
+
+          $armHelper = Join-Path $stage "tip_client_smoke_arm64.exe"
+          $x64Helper = Join-Path $stage "tip_client_smoke_x64.exe"
+
+          Copy-Item $armSource $armHelper -Force
+          Copy-Item $x64Source $x64Helper -Force
+
+          $armMachine = Get-PEMachine $armHelper
+          $x64Machine = Get-PEMachine $x64Helper
+
+          Write-Host "ARM64 source  = $armSource"
+          Write-Host "ARM64 staged  = $armHelper"
+          Write-Host "ARM64 machine = $armMachine"
+          Write-Host "x64 source    = $x64Source"
+          Write-Host "x64 staged    = $x64Helper"
+          Write-Host "x64 machine   = $x64Machine"
+
+          if ($armMachine -ne "ARM64") {
+            throw "Native helper is not ARM64."
+          }
+          if ($x64Machine -ne "x64") {
+            throw "Cross-built helper is not x64."
+          }
+
+      - name: Download exact ARM64 MSI from this workflow run
+        uses: actions/download-artifact@v6
+        with:
+          name: Mozc64_arm64.msi
+          path: ${{ runner.temp }}\mozkey-tip-smoke-msi
+
+      - name: Install MSI and audit TIP client architecture routing
+        shell: pwsh
+        run: |
+          Set-StrictMode -Version Latest
+          $ErrorActionPreference = "Stop"
+          $ProgressPreference = "SilentlyContinue"
+
+          $evidence = Join-Path $env:RUNNER_TEMP "mozkey-tip-client-architecture-evidence"
+          New-Item -ItemType Directory -Force -Path $evidence | Out-Null
+
+          $msiCandidates = @(
+            Get-ChildItem (Join-Path $env:RUNNER_TEMP "mozkey-tip-smoke-msi") `
+              -Recurse -File -Filter *.msi
+          )
+          if ($msiCandidates.Count -ne 1) {
+            throw "Expected exactly one ARM64 MSI artifact; found $($msiCandidates.Count)"
+          }
+          $msi = $msiCandidates[0].FullName
+
+          if ($env:PROCESSOR_ARCHITECTURE -ne "ARM64") {
+            throw "This job is not running on native Windows ARM64."
+          }
+
+          $installLog = Join-Path $evidence "install.log"
+          $install = Start-Process msiexec.exe -Wait -PassThru -ArgumentList @(
+            "/i",
+            "`"$msi`"",
+            "/qn",
+            "/norestart",
+            "/l*v",
+            "`"$installLog`""
+          )
+          Write-Host "msiexec install exit = $($install.ExitCode)"
+          if ($install.ExitCode -notin @(0, 3010)) {
+            throw "ARM64 MSI install failed: $($install.ExitCode)"
+          }
+
+          $clsid = "{10A67BC8-22FA-4A59-90DC-2546652C56BF}"
+          $subkey = "CLSID\$clsid\InProcServer32"
+
+          function Get-ComRegistration {
+            param(
+              [Parameter(Mandatory = $true)]
+              [Microsoft.Win32.RegistryView]$View
+            )
+
+            $base = [Microsoft.Win32.RegistryKey]::OpenBaseKey(
+              [Microsoft.Win32.RegistryHive]::ClassesRoot,
+              $View
+            )
+            try {
+              $key = $base.OpenSubKey($subkey, $false)
+              if ($null -eq $key) {
+                throw "COM registration not found in registry view $View`: $subkey"
+              }
+              try {
+                return [pscustomobject]@{
+                  View = [string]$View
+                  Server = [string]$key.GetValue("")
+                  ThreadingModel = [string]$key.GetValue("ThreadingModel")
+                }
+              } finally {
+                $key.Dispose()
+              }
+            } finally {
+              $base.Dispose()
+            }
+          }
+
+          $reg64 = Get-ComRegistration `
+            -View ([Microsoft.Win32.RegistryView]::Registry64)
+          $reg32 = Get-ComRegistration `
+            -View ([Microsoft.Win32.RegistryView]::Registry32)
+
+          @($reg64, $reg32) |
+            Export-Csv (Join-Path $evidence "com-registration.csv") `
+              -NoTypeInformation -Encoding utf8
+
+          Write-Host "64-bit COM server = $($reg64.Server)"
+          Write-Host "32-bit COM server = $($reg32.Server)"
+
+          if ([System.IO.Path]::GetFileName($reg64.Server) -ine "mozc_tip64x.dll") {
+            throw "64-bit ARM64 COM registration does not point to mozc_tip64x.dll."
+          }
+          if ([System.IO.Path]::GetFileName($reg32.Server) -ine "mozc_tip32.dll") {
+            throw "32-bit COM registration does not point to mozc_tip32.dll."
+          }
+          if ($reg64.ThreadingModel -ine "Apartment") {
+            throw "64-bit TIP ThreadingModel is not Apartment."
+          }
+          if ($reg32.ThreadingModel -ine "Apartment") {
+            throw "32-bit TIP ThreadingModel is not Apartment."
+          }
+
+          $stage = Join-Path $env:RUNNER_TEMP "mozkey-tip-client-smoke"
+          $armHelper = Join-Path $stage "tip_client_smoke_arm64.exe"
+          $x64Helper = Join-Path $stage "tip_client_smoke_x64.exe"
+
+          $armLog = Join-Path $evidence "arm64-helper.log"
+          & $armHelper *> $armLog
+          $armExit = $LASTEXITCODE
+          Get-Content $armLog | ForEach-Object { Write-Host $_ }
+          if ($armExit -ne 0) {
+            throw "Native ARM64 TIP client smoke failed: $armExit"
+          }
+
+          $x64Log = Join-Path $evidence "x64-helper.log"
+          & $x64Helper *> $x64Log
+          $x64Exit = $LASTEXITCODE
+          Get-Content $x64Log | ForEach-Object { Write-Host $_ }
+          if ($x64Exit -ne 0) {
+            throw "x64-emulated TIP client smoke failed: $x64Exit"
+          }
+
+          @(
+            "runner_arch=$env:PROCESSOR_ARCHITECTURE"
+            "msi=$msi"
+            "msi_sha256=$((Get-FileHash $msi -Algorithm SHA256).Hash)"
+            "registry64_server=$($reg64.Server)"
+            "registry32_server=$($reg32.Server)"
+            "arm64_helper_exit=$armExit"
+            "x64_helper_exit=$x64Exit"
+            "TIP_CLIENT_ARCHITECTURE_SMOKE=PASS"
+          ) | Set-Content (Join-Path $evidence "summary.txt") -Encoding utf8
+
+      - name: Uninstall exact ARM64 MSI
+        if: always()
+        shell: pwsh
+        run: |
+          Set-StrictMode -Version Latest
+          $ErrorActionPreference = "Continue"
+
+          $evidence = Join-Path $env:RUNNER_TEMP "mozkey-tip-client-architecture-evidence"
+          New-Item -ItemType Directory -Force -Path $evidence | Out-Null
+          $uninstallLog = Join-Path $evidence "uninstall.log"
+
+          $msiCandidates = @(
+            Get-ChildItem (Join-Path $env:RUNNER_TEMP "mozkey-tip-smoke-msi") `
+              -Recurse -File -Filter *.msi -ErrorAction SilentlyContinue
+          )
+
+          if ($msiCandidates.Count -eq 0) {
+            Write-Host "No MSI available for cleanup."
+            exit 0
+          }
+          if ($msiCandidates.Count -ne 1) {
+            Write-Error "Cleanup expected one MSI; found $($msiCandidates.Count)"
+            exit 1
+          }
+
+          $msi = $msiCandidates[0].FullName
+          $uninstall = Start-Process msiexec.exe -Wait -PassThru -ArgumentList @(
+            "/x",
+            "`"$msi`"",
+            "/qn",
+            "/norestart",
+            "/l*v",
+            "`"$uninstallLog`""
+          )
+          Write-Host "msiexec uninstall exit = $($uninstall.ExitCode)"
+
+          if ($uninstall.ExitCode -notin @(0, 1605, 3010)) {
+            Write-Error "ARM64 MSI cleanup failed: $($uninstall.ExitCode)"
+            exit 1
+          }
+
+      - name: Upload TIP client-architecture smoke evidence
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: Mozc64_arm64_tip_client_architecture_smoke
+          path: ${{ runner.temp }}\mozkey-tip-client-architecture-evidence
+          if-no-files-found: warn
+          retention-days: 7
+
   test:
     needs: prepare_daily_dictionary
     # https://github.com/actions/runner-images/blob/main/images/windows/Windows2025-Readme.md

--- a/src/win32/tip/BUILD.bazel
+++ b/src/win32/tip/BUILD.bazel
@@ -133,6 +133,40 @@ mozc_win32_cc_prod_binary(
     ],
 )
 
+mozc_win32_cc_prod_binary(
+    name = "tip_client_smoke_x64",
+    srcs = ["tip_client_smoke.cc"],
+    executable_name_map = {
+        "Mozc": "tip_client_smoke_x64.exe",
+        "GoogleJapaneseInput": "tip_client_smoke_x64.exe",
+    },
+    platform = "//:windows-x86_64",
+    static_crt = True,
+    tags = MOZC_TAGS.WIN_ONLY,
+    target_compatible_with = ["@platforms//os:windows"],
+    deps = [
+        "//base/win32:scoped_com",
+        "//win32/base:tsf_profile",
+    ],
+)
+
+mozc_win32_cc_prod_binary(
+    name = "tip_client_smoke_arm64",
+    srcs = ["tip_client_smoke.cc"],
+    executable_name_map = {
+        "Mozc": "tip_client_smoke_arm64.exe",
+        "GoogleJapaneseInput": "tip_client_smoke_arm64.exe",
+    },
+    platform = "//:windows-arm64",
+    static_crt = True,
+    tags = MOZC_TAGS.WIN_ONLY,
+    target_compatible_with = ["@platforms//os:windows"],
+    deps = [
+        "//base/win32:scoped_com",
+        "//win32/base:tsf_profile",
+    ],
+)
+
 genrule(
     name = "mozc_tip64x",
     srcs = [

--- a/src/win32/tip/tip_client_smoke.cc
+++ b/src/win32/tip/tip_client_smoke.cc
@@ -1,0 +1,137 @@
+// Copyright 2026, Mozc contributors.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include <objbase.h>
+#include <windows.h>
+
+#include <cstdio>
+#include <cwchar>
+
+#include "base/win32/scoped_com.h"
+#include "win32/base/tsf_profile.h"
+
+namespace {
+
+#ifdef GOOGLE_JAPANESE_INPUT_BUILD
+constexpr wchar_t kForwarder[] = L"GoogleIMEJaTIP64X.dll";
+constexpr wchar_t kX64Implementation[] = L"GoogleIMEJaTIP64.dll";
+constexpr wchar_t kArm64Implementation[] = L"GoogleIMEJaTIP64Arm.dll";
+#else   // GOOGLE_JAPANESE_INPUT_BUILD
+constexpr wchar_t kForwarder[] = L"mozc_tip64x.dll";
+constexpr wchar_t kX64Implementation[] = L"mozc_tip64.dll";
+constexpr wchar_t kArm64Implementation[] = L"mozc_tip64arm.dll";
+#endif  // GOOGLE_JAPANESE_INPUT_BUILD
+
+#if defined(_M_ARM64)
+constexpr wchar_t kProcessArchitecture[] = L"ARM64";
+constexpr const wchar_t *kExpectedImplementation = kArm64Implementation;
+constexpr const wchar_t *kForbiddenImplementation = kX64Implementation;
+#elif defined(_M_X64)
+constexpr wchar_t kProcessArchitecture[] = L"x64";
+constexpr const wchar_t *kExpectedImplementation = kX64Implementation;
+constexpr const wchar_t *kForbiddenImplementation = kArm64Implementation;
+#else
+#error This smoke helper supports only ARM64 and x64.
+#endif
+
+void PrintModule(const wchar_t *label, const wchar_t *name, HMODULE module) {
+  if (module == nullptr) {
+    std::wprintf(L"%ls=%ls:NOT_LOADED\n", label, name);
+    return;
+  }
+
+  wchar_t path[32768] = {};
+  const DWORD length = ::GetModuleFileNameW(module, path, _countof(path));
+  if (length == 0 || length >= _countof(path)) {
+    std::wprintf(L"%ls=%ls:LOADED:path_unavailable:error=%lu\n", label, name,
+                 ::GetLastError());
+    return;
+  }
+
+  std::wprintf(L"%ls=%ls:LOADED:path=%ls\n", label, name, path);
+}
+
+}  // namespace
+
+int main() {
+  std::wprintf(L"process_architecture=%ls\n", kProcessArchitecture);
+
+  mozc::ScopedCOMInitializer com_initializer;
+  const HRESULT init_result = com_initializer.error_code();
+  std::wprintf(L"CoInitialize=0x%08lX\n",
+               static_cast<unsigned long>(init_result));
+  if (FAILED(init_result)) {
+    return 10;
+  }
+
+  IUnknown *object = nullptr;
+  const HRESULT activation_result = ::CoCreateInstance(
+      mozc::win32::TsfProfile::GetTextServiceGuid(), nullptr,
+      CLSCTX_INPROC_SERVER, IID_IUnknown,
+      reinterpret_cast<void **>(&object));
+
+  std::wprintf(L"CoCreateInstance=0x%08lX\n",
+               static_cast<unsigned long>(activation_result));
+  if (FAILED(activation_result) || object == nullptr) {
+    if (object != nullptr) {
+      object->Release();
+    }
+    return 20;
+  }
+
+  HMODULE expected = ::GetModuleHandleW(kExpectedImplementation);
+  HMODULE forbidden = ::GetModuleHandleW(kForbiddenImplementation);
+  HMODULE forwarder = ::GetModuleHandleW(kForwarder);
+
+  PrintModule(L"expected_implementation", kExpectedImplementation, expected);
+  PrintModule(L"forbidden_implementation", kForbiddenImplementation, forbidden);
+  PrintModule(L"forwarder_informational", kForwarder, forwarder);
+
+  int result = 0;
+  if (expected == nullptr) {
+    std::wprintf(L"gate_expected_implementation=FAIL\n");
+    result = 30;
+  } else {
+    std::wprintf(L"gate_expected_implementation=PASS\n");
+  }
+
+  if (forbidden != nullptr) {
+    std::wprintf(L"gate_forbidden_implementation=FAIL\n");
+    result = 40;
+  } else {
+    std::wprintf(L"gate_forbidden_implementation=PASS\n");
+  }
+
+  object->Release();
+
+  if (result == 0) {
+    std::wprintf(L"TIP_CLIENT_ARCHITECTURE_SMOKE=PASS\n");
+  }
+  return result;
+}


### PR DESCRIPTION
## 概要

Windows on Arm 上で、インストール済み Mozkey TIP を

- native ARM64 client process
- x64 emulated client process

の双方から実際に COM activation し、ARM64X routing が意図した
architecture-specific implementation DLL へ解決されることを検証する
headless smoke test を追加します。

GUI automation は行いません。

## 背景

ARM64 MSI には以下の TIP payload が含まれます。

- `mozc_tip32.dll`
- `mozc_tip64.dll`
- `mozc_tip64arm.dll`
- `mozc_tip64x.dll`

ARM64 OS では 64-bit COM server として `mozc_tip64x.dll` を登録し、
ARM64X forwarder が process architecture に応じて:

```text
ARM64 client
  -> mozc_tip64arm.dll

x64 client
  -> mozc_tip64.dll
```

へ振り分ける設計です。

これまで build / package / installed runtime / lifecycle / native unit-test
coverage はありましたが、client process 側からこの routing を実際に
activation する CI gate はありませんでした。

## smoke helper

新しく:

`src/win32/tip/tip_client_smoke.cc`

を追加します。

helper は:

1. COM を初期化
2. `TsfProfile::GetTextServiceGuid()` を使って
   `CoCreateInstance(..., CLSCTX_INPROC_SERVER, IID_IUnknown, ...)`
3. activation 成功を確認
4. process architecture に応じた implementation DLL load を確認
5. 間違った architecture の implementation DLL が load されていないことを確認

します。

### ARM64 helper

必須:

```text
mozc_tip64arm.dll loaded
mozc_tip64.dll NOT loaded
```

### x64 helper

必須:

```text
mozc_tip64.dll loaded
mozc_tip64arm.dll NOT loaded
```

`mozc_tip64x.dll` 自体が process module list に残るかどうかは
ARM64X pure-forwarder のロード動作に依存するため informational とし、
gate にはしません。

## helper build targets

同じ source から2つの executable を作ります。

```text
tip_client_smoke_arm64
  platform   = //:windows-arm64
  static CRT = true

tip_client_smoke_x64
  platform   = //:windows-x86_64
  static CRT = true
```

static CRT を使用し、smoke helper 自体の外部 CRT dependency を避けます。

## 新しい CI job

```yaml
test_arm64_tip_client_architecture:
  name: ARM64 TIP client-architecture smoke
  needs: build_arm64
  runs-on: windows-11-arm
```

主な流れ:

```text
Checkout
-> update_deps
-> ARM64 helper build
-> x64 helper cross-build
-> helper PE machine verification
-> exact Mozc64_arm64.msi download
-> MSI install
-> explicit Registry64 / Registry32 routing audit
-> native ARM64 helper execution
-> x64 helper direct execution under WoA emulation
-> always() uninstall
-> evidence upload
```

## registry gate

Text Service CLSID:

```text
{10A67BC8-22FA-4A59-90DC-2546652C56BF}
```

64-bit registry view:

```text
HKCR\CLSID\{...}\InProcServer32
  -> mozc_tip64x.dll
```

32-bit registry view:

```text
HKCR\CLSID\{...}\InProcServer32
  -> mozc_tip32.dll
```

両方とも:

```text
ThreadingModel = Apartment
```

を必須にします。

PowerShell provider の暗黙的 registry redirection は使わず、
`Microsoft.Win32.RegistryView.Registry64` / `Registry32` を明示します。

## x64-on-ARM

x64 helper は `windows-11-arm` 上で直接実行します。

特殊な launcher は追加せず、Windows on Arm の x64 application emulation
そのものを compatibility contract の一部として検証します。

## evidence

常に以下の evidence artifact を upload します。

```text
Mozc64_arm64_tip_client_architecture_smoke
```

内容:

- MSI install log
- MSI uninstall log
- 64/32-bit COM registration CSV
- ARM64 helper output
- x64 helper output
- summary
- tested MSI SHA256

retention: 7 days

## 変更しないもの

以下は変更しません。

- `build_arm64`
- historical W2 lifecycle baseline
- cross/native package parity
- Native ARM64 installer lifecycle audit
- Native ARM64 installed MSI Zenz audit
- existing x64 unit tests
- native ARM64 unit tests
- cache warmer
- package/runtime semantic contract

## 意図的に今回含めないもの

- Notepad automation
- `SendInput`
- IME selection UI automation
- composition/conversion UI assertions
- candidate window screenshots
- Zenz UI/commit assertions
- x86 client helper
- test exclusions

interactive IME smoke は別レイヤーとして扱います。

## 変更ファイル

exact 3 files:

- `.github/workflows/windows.yaml`
- `src/win32/tip/BUILD.bazel`
- `src/win32/tip/tip_client_smoke.cc`

## ローカル監査

- exact base:
  `f662ff713f916199b296d7d16d603dd0da422bfe`
- changed file set: exact 3 files
- total diff: 461 additions / 0 deletions
- ARM64 helper target: explicit ARM64 + static CRT
- x64 helper target: explicit x64 + static CRT
- helper uses `CoCreateInstance`
- Registry64 route: `mozc_tip64x.dll`
- Registry32 route: `mozc_tip32.dll`
- ARM64 implementation gate: `mozc_tip64arm.dll`
- x64 implementation gate: `mozc_tip64.dll`
- ARM64X forwarder module presence: informational only
- x64 execution on WoA: direct
- existing package/parity/lifecycle jobs: unchanged
- no UI automation
- no x86 helper
- no test exclusions
- `git diff --check`: PASS

## CIで確認すること

この PR で特に重要なのは新しい:

`ARM64 TIP client-architecture smoke`

です。

最初の CI 実行では、次の順で failure を分類します。

1. helper cross/native build failure
2. helper PE architecture mismatch
3. MSI install / COM registry routing failure
4. native ARM64 COM activation failure
5. x64-emulated COM activation failure
6. unexpected implementation DLL routing

gate を弱める前に、必ずどの層で失敗したかを切り分けます。
