### PR TITLE
Use Go 1.25 for lint tooling

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -26,6 +26,12 @@ jobs:
           submodules: false
           persist-credentials: false
 
+      - name: Setup Go
+        uses: actions/setup-go@v7
+        with:
+          go-version: '1.25'
+          cache: false
+
       - name: Run
         working-directory: ./src
         run: |


### PR DESCRIPTION
## 概要

lint workflow で使用する Go toolchain を 1.25 に固定します。

`buildifier@latest` が現在の依存関係を解決する際に Go 1.25 以上を要求するようになり、GitHub-hosted runner の Go 1.24.13 では `go install` が失敗していました。

## 変更内容
* actions/setup-go@v7 を追加
* Go 1.25 を明示
* Go module cache は無効化
* buildifier@latest は変更しない

## 背景
今回の失敗は Mozkey の lint 違反ではなく、buildifier のインストール段階で発生していました。

upstream Mozc と同様に buildifier@latest を維持しつつ、現在の lint tooling が要求する Go version に合わせます。

## 確認
* lint CI: PASS
* 変更ファイル: .github/workflows/lint.yaml のみ
