### PR TITLE
Sync Windows ARM64 build docs with upstream

### DIFF
--- a/docs/build_mozc_in_windows.md
+++ b/docs/build_mozc_in_windows.md
@@ -15,7 +15,7 @@ cd mozc\src
 
 python build_tools/update_deps.py
 python build_tools/build_qt.py --release --confirm_license
-bazelisk build --config release_build package
+bazelisk build package --config release_build
 
 python build_tools/open.py bazel-bin/win32/installer/Mozc64.msi
 ```
@@ -29,9 +29,6 @@ python build_tools/open.py bazel-bin/win32/installer/Mozc64.msi
 
 64-bit Windows 10 or later.
 
-> [!IMPORTANT] Building Mozc on a Windows ARM64 environment is not yet supported
-> ([#1296](https://github.com/google/mozc/issues/1296)).
-
 ### Software Requirements
 
 Building Mozc on Windows requires the following software.
@@ -40,17 +37,23 @@ Building Mozc on Windows requires the following software.
     with the following components.
     *   Windows 11 SDK
     *   MSVC v143 - VS 2022 C++ x64/x86 build tools (Latest)
+    *   MSVC v143 - VS 2022 C++ ARM64/ARM64EC build tools (Latest)
     *   C++ ATL for latest v143 build tools (x86 & x64)
+    *   C++ ATL for latest v143 build tools (ARM64/ARM64EC)
 *   Python 3.12 or later.
 *   `.NET 6` or later (for `dotnet` command).
 *   [Bazelisk](https://github.com/bazelbuild/bazelisk)
 
-> [!TIP]
-> Visual Studio 2026 Community Edition is also supported to build Mozc. When
-> both VS 2022 and 2026 are installed, VS 2022 will be used.
+> [!TIP] The following Visual Studio components can be skipped if you do not
+> build Mozc for ARM64.
+>
+>  *   MSVC v143 - VS 2022 C++ ARM64/ARM64EC build tools (Latest)
+>  *   C++ ATL for latest v143 build tools (ARM64/ARM64EC)
 
-> [!NOTE]
-> Bazelisk is a wrapper of [Bazel](https://bazel.build) that allows you
+> [!TIP] Visual Studio 2026 Community Edition is also supported to build Mozc.
+> When both VS 2022 and 2026 are installed, VS 2022 will be used.
+
+> [!NOTE] Bazelisk is a wrapper of [Bazel](https://bazel.build) that allows you
 > to use a specific version of Bazel.
 
 ### Download the repository from GitHub
@@ -93,7 +96,7 @@ Assuming `bazelisk` is in your `%PATH%`, run the following command to build Mozc
 for Windows.
 
 ```
-bazelisk build --config oss_windows --config release_build package
+bazelisk build package --config release_build
 ```
 
 #### Install Mozc
@@ -107,8 +110,7 @@ python build_tools/open.py bazel-bin/win32/installer/Mozc64.msi
 #### Uninstall Mozc
 
 To Uninstall Mozc, press <kbd>Win</kbd>+<kbd>R</kbd> to open the Run dialog and
-type and type `ms-settings:appsfeatures-app`, run the following command in the
-terminal:
+type `ms-settings:appsfeatures-app`, run the following command in the terminal:
 
 ```
 start ms-settings:appsfeatures-app
@@ -116,36 +118,31 @@ start ms-settings:appsfeatures-app
 
 Then, uninstall `Mozc` from the list of installed applications.
 
-### Build `Mozc64.msi` for ARM64
+### Cross compilation
 
-To compile executables for ARM64, the following Visual Studio components also
-need to be installed:
+By default, `Mozc64.msi` is built for the host CPU architecture. To explicitly
+specify the target CPU architecture, specify build options as follows:
 
-*   MSVC v143 - VS 2022 C++ ARM64/ARM64EC build tools (Latest)
-*   C++ ATL for latest v143 build tools (ARM64/ARM64EC)
+#### To build x64 installer
 
-To build `Mozc64.msi` for ARM64, run the following commands:
+```
+python build_tools/build_qt.py --release --confirm_license --target_arch=x64
+bazelisk build package --config release_build --platforms=//:windows-x86_64
+```
+
+#### To build ARM64 installer
 
 ```
 python build_tools/build_qt.py --release --confirm_license --target_arch=arm64
-bazelisk build --config oss_windows --config release_build package --platforms=//:windows-arm64
+bazelisk build package --config release_build --platforms=//:windows-arm64
 ```
 
-### Build `Mozc64.msi` for both X64 and ARM64
-
-To built a X64 installer that is also compatible with ARM64 machines, run the
-following commands:
+#### To build a universal installer for both X64 and ARM64
 
 ```
-python build_tools/build_qt.py --release --confirm_license
-bazelisk build --config oss_windows --config release_build --config win_universal_installer package
+python build_tools/build_qt.py --release --confirm_license --target_arch=x64
+bazelisk build package --config release_build --platforms=//:windows-x86_64 --config win_universal_installer
 ```
-
-To build the above installer, the following Visual Studio components also need
-to be installed:
-
-*   MSVC v143 - VS 2022 C++ ARM64/ARM64EC build tools (Latest)
-*   C++ ATL for latest v143 build tools (ARM64/ARM64EC)
 
 ## Bazel command examples
 
@@ -158,7 +155,7 @@ to be installed:
 ### Run all tests
 
 ```
-bazelisk test ... --config oss_windows --build_tests_only -c dbg
+bazelisk test ... --build_tests_only -c dbg
 ```
 
 > [!NOTE] `...` means all targets under the current and subdirectories.


### PR DESCRIPTION
## 概要

Windows build documentation を upstream Mozc の Windows ARM64 native build 対応後の内容へ同期します。

この変更は documentation のみで、workflow や製品コードには変更を加えません。

## 変更内容

upstream Mozc の以下の変更に含まれる
`docs/build_mozc_in_windows.md` の差分を同期します。

- `379723af27602d58b6af3feb858ab5904645ad48`
  - `Use windows-11-arm runner to build Arm64 package (#1537)`
- `75839d929ac2301513121e77817caaedc3e9e493`
  - `Fix a typo and apply a formatter.`

主な変更は以下です。

- Windows ARM64 environment が未対応であるという古い警告を削除
- ARM64 / ARM64EC build tools を通常の Software Requirements に統合
- ARM64 build が不要な場合に該当 Visual Studio components を省略できることを明記
- 通常の `Mozc64.msi` build が host CPU architecture を対象とすることを明記
- ARM64専用build節を `Cross compilation` 節へ再編
- x64 installer の明示的な cross-build 手順を追加
- ARM64 installer の cross-build 手順を整理
- x64 / ARM64 universal installer の手順を整理
- build / test examples から不要になった `--config oss_windows` の明示を削除
- uninstall 手順の `type and type` typo を修正
- NOTE / TIP の Markdown formatting を upstream に合わせて整理

## Upstream provenance

変更前の Mozkey の

`docs/build_mozc_in_windows.md`

は、upstream の

`8be758dcc2330011d052a670b39cf8ffbaa1c253`

時点の同ファイルと byte-for-byte で一致していることを確認しています。

変更後のファイルは、

`75839d929ac2301513121e77817caaedc3e9e493`

時点の upstream の同ファイルと byte-for-byte で一致しています。

また、Mozkey の今回の差分が

`8be758dcc2330011d052a670b39cf8ffbaa1c253..75839d929ac2301513121e77817caaedc3e9e493`

における upstream の `docs/build_mozc_in_windows.md` の差分と完全一致することも確認しています。

## 変更範囲

- `docs/build_mozc_in_windows.md` のみ
- 29 additions / 32 deletions
- workflow変更なし
- 製品コード変更なし

## 検証

- pre-change docs: upstream parent と BYTE-EXACT
- post-change docs: upstream `75839d9` と BYTE-EXACT
- combined docs diff: upstream と EXACT
- `git diff --check`: PASS
- working tree: CLEAN