### PR TITLE
Fix macOS installer branding and architecture metadata

### DIFF
--- a/src/mac/installer/distribution.xml
+++ b/src/mac/installer/distribution.xml
@@ -31,14 +31,13 @@
 -->
 
 <installer-gui-script minSpecVersion="1">
-    <title>Mozc</title>
+    <title>Mozkey</title>
     <allowed-os-versions>
         <os-version min="12.0"/>
     </allowed-os-versions>
     <pkg-ref id="org.mozc.pkg.JapaneseInput"/>
     <domains enable_localSystem="true"/>
-    <options rootVolumeOnly="true"/>
-    <options customize="never" require-scripts="false"/>
+    <options rootVolumeOnly="true" customize="never" require-scripts="false" hostArchitectures="arm64,x86_64"/>
     <choices-outline>
         <line choice="default">
             <line choice="org.mozc.pkg.JapaneseInput"/>

--- a/src/mac/installer/zenz_runtime/verify_release_package.zsh
+++ b/src/mac/installer/zenz_runtime/verify_release_package.zsh
@@ -230,19 +230,41 @@ mins = [
 if "12.0" not in mins:
     raise SystemExit(f"minimum macOS 12.0 not found: {mins}")
 
+titles = [
+    (node.text or "").strip()
+    for node in root.findall("./title")
+]
+
+if titles != ["Mozkey"]:
+    raise SystemExit(f"unexpected installer title: {titles}")
+
 host_architectures = [
     node.attrib["hostArchitectures"]
     for node in root.findall(".//options")
     if "hostArchitectures" in node.attrib
 ]
 
-if host_architectures:
+if len(host_architectures) != 1:
     raise SystemExit(
-        f"unexpected hostArchitectures restriction: {host_architectures}"
+        "expected exactly one hostArchitectures declaration: "
+        f"{host_architectures}"
+    )
+
+architectures = [
+    value.strip()
+    for value in host_architectures[0].split(",")
+    if value.strip()
+]
+
+if len(architectures) != 2 or set(architectures) != {"arm64", "x86_64"}:
+    raise SystemExit(
+        "unexpected hostArchitectures declaration: "
+        f"{host_architectures[0]!r}"
     )
 
 print("Minimum macOS     = 12.0")
-print("hostArchitectures = UNRESTRICTED")
+print("Installer title   = Mozkey")
+print("hostArchitectures = arm64,x86_64")
 PY
 
 echo


### PR DESCRIPTION
## 概要

macOS 版 Mozkey の Installer 表示と Apple Silicon 向けアーキテクチャ情報を修正します。

主な変更は以下です。

- Installer の表示名を `Mozc` から `Mozkey` に変更
- Distribution に `hostArchitectures="arm64,x86_64"` を追加
- 既存の2つの `<options>` 要素を1つに統合
- formal macOS package verifier を新しい Installer 契約に対応
  - Installer title が `Mozkey` であることを検証
  - `hostArchitectures` がちょうど1つ存在することを検証
  - `arm64` と `x86_64` の両方だけが宣言されていることを検証

## 背景

これまで macOS 版 Mozkey の PKG を開くと、Installer 上では `Mozc` と表示されていました。

原因を調査したところ、生成される Distribution に

```xml
<title>Mozc</title>
```

が残っていたことを確認しました。

また、Apple Silicon Mac で PKG を開いた際に、以下の Rosetta に関する案内が表示されていました。

> Rosetta により、Intel プロセッサを前提とした機能を Apple シリコン搭載の Mac で実行できます。

PKG の内容を展開して全 Mach-O payload を監査したところ、x86_64-only のバイナリは存在しませんでした。

Zenz runtime を含む確認用 PKG では以下を確認しています。

* Mozc 本体: arm64
* `mozc_zenz_scorer`: x86_64 + arm64
* `llama-server`: x86_64 + arm64
* その他の Mach-O もすべて arm64 を含む
* x86_64-only payload: 0

一方、Distribution には対応 host architecture の宣言がありませんでした。

そこで、

```xml
hostArchitectures="arm64,x86_64"
```

を明示したテスト PKG を作成し、Apple Silicon 実機で A/B テストを行いました。

結果は以下のとおりです。

### 修正前

* Installer の表示: `Mozc`
* Rosetta の案内: 表示される

### 修正後

* Installer の表示: `Mozkey`
* Rosetta の案内: 表示されない

このため、実バイナリのアーキテクチャではなく、Distribution の Installer metadata が原因であることを確認しました。

## formal package verifier の更新

既存の `verify_release_package.zsh` には、

`hostArchitectures` が存在した場合に失敗する旧契約がありました。

今回、dual-native macOS package の Distribution が

```xml
hostArchitectures="arm64,x86_64"
```

を明示することになったため、verifier も同じ契約へ更新しています。

新しい verifier は以下の場合に失敗します。

* Installer title が `Mozkey` ではない
* `hostArchitectures` が存在しない
* `hostArchitectures` が複数存在する
* `arm64` のみ
* `x86_64` のみ
* `arm64` / `x86_64` 以外の architecture を含む

`arm64,x86_64` および `x86_64,arm64` の順序違いは許容します。

## 検証

ローカルでは以下を確認しました。

* `//mac:package` のビルド成功
* `MOZC_QT_PATH` を使用して既存の生成済み Qt を参照
* 生成された Installer title: `Mozkey`
* 生成された Distribution:
  `hostArchitectures="arm64,x86_64"`
* 通常 PKG の Mach-O payload 22本すべてが arm64 を含む
* x86_64-only payload: 0
* `git diff --check`: PASS
* verifier の `zsh -n`: PASS
* 正常系・異常系の Distribution contract テスト: PASS

Apple Silicon 実機でも以下を確認しました。

* 修正前 PKG:

  * `Mozc` と表示
  * Rosetta の案内あり
* 修正後 PKG:

  * `Mozkey` と表示
  * Rosetta の案内なし

さらに、formal macOS package を含む macOS 系 CI がすべて PASS することを確認しました。

## スコープ

この変更では、内部の bundle identifier やインストールパスは変更しません。

たとえば以下は現状のままです。

* `org.mozc.*`
* `/Library/Input Methods/Mozc.app`
* `org.mozc.pkg.JapaneseInput`

これらは既存環境の upgrade / uninstall / LaunchServices 等との互換性に関係するため、必要であれば別途 migration として設計します。

また、PKG の Developer ID Installer 署名および notarization についても、この PR の対象外です。
