### PR TITLE
Align cell background height and vertical position with the row in Ca…

### DIFF
--- a/src/renderer/mac/CandidateView.mm
+++ b/src/renderer/mac/CandidateView.mm
@@ -372,9 +372,12 @@ using mozc::renderer::mac::MacViewUtil;
     [NSBezierPath strokeRect:focusedRect];
   } else {
     // Draw normal background
+    const mozc::Rect rowRect = tableLayout_.GetRowRect(row);
     auto drawBackground = [&](ColumnType type,
-                              const mozc::renderer::RendererStyle::TextStyle& text_style) {
-      const mozc::Rect cellRect = tableLayout_.GetCellRect(row, type);
+                              const mozc::renderer::RendererStyle::TextStyle &text_style) {
+      mozc::Rect cellRect = tableLayout_.GetCellRect(row, type);
+      cellRect.origin.y = rowRect.origin.y;
+      cellRect.size.height = rowRect.size.height;
       if (cellRect.size.width > 0 && cellRect.size.height > 0 &&
           text_style.has_background_color()) {
         [MacViewUtil::ToNSColor(text_style.background_color()) set];


### PR DESCRIPTION
## 概要

upstream Mozc の `CandidateView` 描画修正を Mozkey に取り込みます。

対象 upstream commit:

- `ab0c249aadf5f6fafa297d6cc489bd82af35d73d`
- `Align cell background height and vertical position with the row in CandidateView.`

## 変更内容

macOS の `CandidateView` で通常候補行の背景を描画する際、これまでは各セルの矩形をそのまま背景描画に使用していました。

今回の修正では、背景色を持つセルについて、

- Y 座標を行全体の Y 座標に合わせる
- 高さを行全体の高さに合わせる

ようにします。

これにより、セルごとの高さ差や位置差によって候補行背景に隙間・境界が見える問題を防ぎます。

## upstream 追従方針

この修正は upstream commit を `-x` 付きで cherry-pick しています。

同時期の upstream commit `751df904` (`Use RendererStyle for colors in Qt and Windows renderers`) は、Mozkey 側ですでに独自に拡張された RendererStyle / theme 実装と大きく競合するため、丸ごとの cherry-pick は行っていません。

今回の PR は、独立性が高く、現在の Mozkey にそのまま適用できる `CandidateView` の行背景修正だけに限定しています。

## 検証

- 変更ファイル: `src/renderer/mac/CandidateView.mm` のみ
- upstream provenance (`-x`): 保持
- CandidateView の row-background semantics: PASS
- macOS renderer build: PASS
- `//renderer:table_layout_test`: PASS
- macOS package smoke build: PASS
- `git diff --check`: PASS
- working tree: CLEAN

## スコープ

この PR は macOS `CandidateView` の通常行背景描画の修正だけを対象とします。

macOS 縦書き対応そのもの、および `751df904` の Qt / shared RendererStyle 部分の追従は含みません。
