### PR TITLE
Linux対応

### DIFF
--- a/src/session/BUILD.bazel
+++ b/src/session/BUILD.bazel
@@ -199,6 +199,11 @@ mozc_cc_library(
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/time",
     ] + mozc_select(
+        linux = [
+            "//base:file_util",
+            "//base:process",
+            "//base:system_util",
+        ],
         macos = [
             "//base:file_util",
             "//base:process",

--- a/src/session/zenz_client_factory.cc
+++ b/src/session/zenz_client_factory.cc
@@ -69,6 +69,9 @@ std::unique_ptr<ZenzClient> CreateZenzClient() {
 #if defined(__APPLE__) && TARGET_OS_OSX
   return std::make_unique<ZenzUnixSocketClient>(
       ::mozc::zenz::GetZenzUnixSocketPath(), &LaunchMacZenzScorer);
+#elif defined(__linux__)
+  return std::make_unique<ZenzUnixSocketClient>(
+      ::mozc::zenz::GetZenzUnixSocketPath());
 #else
   return std::make_unique<ZenzNamedPipeClient>();
 #endif  // __APPLE__ && TARGET_OS_OSX

--- a/src/session/zenz_client_factory.cc
+++ b/src/session/zenz_client_factory.cc
@@ -7,13 +7,15 @@
 
 #if defined(__APPLE__)
 #include <TargetConditionals.h>
-#if TARGET_OS_OSX
+#endif  // __APPLE__
+
+#if (defined(__APPLE__) && TARGET_OS_OSX) || \
+    (defined(__linux__) && !defined(__ANDROID__))
 #include "absl/log/log.h"
 #include "base/file_util.h"
 #include "base/process.h"
 #include "base/system_util.h"
-#endif  // TARGET_OS_OSX
-#endif  // __APPLE__
+#endif
 
 #include "session/zenz_live_corrector.h"
 #include "session/zenz_named_pipe_client.h"
@@ -24,13 +26,14 @@ namespace mozc {
 namespace session {
 namespace {
 
-#if defined(__APPLE__) && TARGET_OS_OSX
+#if (defined(__APPLE__) && TARGET_OS_OSX) || \
+    (defined(__linux__) && !defined(__ANDROID__))
 
 constexpr char kZenzRuntimeDirectory[] = "ZenzRuntime";
 constexpr char kZenzScorerExecutable[] = "mozc_zenz_scorer";
 constexpr auto kScorerLaunchThrottle = std::chrono::seconds(2);
 
-bool LaunchMacZenzScorer() {
+bool LaunchUnixZenzScorer() {
   // MozcConverter is normally a singleton, but several Zenz worker requests
   // can observe the same cold start. Serialize the short spawn operation and
   // treat a recent successful launch as one already in progress.
@@ -61,20 +64,18 @@ bool LaunchMacZenzScorer() {
   return true;
 }
 
-#endif  // __APPLE__ && TARGET_OS_OSX
+#endif
 
 }  // namespace
 
 std::unique_ptr<ZenzClient> CreateZenzClient() {
-#if defined(__APPLE__) && TARGET_OS_OSX
+#if (defined(__APPLE__) && TARGET_OS_OSX) || \
+    (defined(__linux__) && !defined(__ANDROID__))
   return std::make_unique<ZenzUnixSocketClient>(
-      ::mozc::zenz::GetZenzUnixSocketPath(), &LaunchMacZenzScorer);
-#elif defined(__linux__)
-  return std::make_unique<ZenzUnixSocketClient>(
-      ::mozc::zenz::GetZenzUnixSocketPath());
+      ::mozc::zenz::GetZenzUnixSocketPath(), &LaunchUnixZenzScorer);
 #else
   return std::make_unique<ZenzNamedPipeClient>();
-#endif  // __APPLE__ && TARGET_OS_OSX
+#endif
 }
 
 }  // namespace session

--- a/src/session/zenz_client_factory.h
+++ b/src/session/zenz_client_factory.h
@@ -11,9 +11,10 @@ class ZenzClient;
 // Creates the platform transport used by ZenzLiveCorrector.
 //
 // This factory keeps Session independent from concrete IPC transports.  The
-// Windows uses the existing named-pipe client. macOS uses a local Unix-domain
-// socket client. Other platforms retain the unavailable named-pipe fallback
-// until a platform transport is explicitly implemented.
+// Windows uses the existing named-pipe client. macOS and desktop Linux use a
+// local Unix-domain socket client and launch the scorer on demand. Other
+// platforms retain the unavailable named-pipe fallback until a platform
+// transport is explicitly implemented.
 std::unique_ptr<ZenzClient> CreateZenzClient();
 
 }  // namespace session

--- a/src/session/zenz_client_factory_test.cc
+++ b/src/session/zenz_client_factory_test.cc
@@ -17,7 +17,8 @@ TEST(ZenzClientFactoryTest, CreatesCurrentPlatformClient) {
   std::unique_ptr<ZenzClient> client = CreateZenzClient();
   ASSERT_NE(client, nullptr);
 
-#if defined(_WIN32) || (defined(__APPLE__) && TARGET_OS_OSX)
+#if defined(_WIN32) || (defined(__APPLE__) && TARGET_OS_OSX) || \
+    (defined(__linux__) && !defined(__ANDROID__))
   EXPECT_TRUE(client->IsAvailable());
 #else
   EXPECT_FALSE(client->IsAvailable());

--- a/src/zenz_scorer/llama_server_process.cc
+++ b/src/zenz_scorer/llama_server_process.cc
@@ -18,7 +18,6 @@
 #include <vector>
 
 #include <arpa/inet.h>
-#include <crt_externs.h>
 #include <fcntl.h>
 #include <netinet/in.h>
 #include <signal.h>
@@ -29,6 +28,19 @@
 #include <unistd.h>
 
 #include "zenz_scorer/llama_http_client.h"
+
+// See base/process.cc for the platform-specific environ handling.
+#ifdef __APPLE__
+#include <crt_externs.h>
+
+// We do not use the global environ variable because it is unavailable
+// in Mac Framework/dynamic libraries. Instead call _NSGetEnviron().
+static char** environ = *_NSGetEnviron();
+#elif !defined(_WIN32)
+// Defined by libc. posix_spawn must inherit the desktop session environment
+// so the Nix runtime can resolve its normal execution environment.
+extern char** environ;
+#endif  // !__APPLE__ && !_WIN32
 
 namespace mozc {
 namespace zenz_scorer {
@@ -467,7 +479,7 @@ bool LlamaServerProcess::Spawn(std::string* error) {
 
   pid_t child_pid = -1;
   result = ::posix_spawn(&child_pid, options_.executable_path.c_str(), &actions,
-                         &attributes, argv.data(), *_NSGetEnviron());
+                         &attributes, argv.data(), environ);
 
   ::posix_spawnattr_destroy(&attributes);
   ::posix_spawn_file_actions_destroy(&actions);

--- a/src/zenz_scorer/main_posix.cc
+++ b/src/zenz_scorer/main_posix.cc
@@ -7,7 +7,10 @@
 #include <vector>
 
 #include <limits.h>
+#if defined(__APPLE__)
 #include <mach-o/dyld.h>
+#endif
+#include <unistd.h>
 
 #include "zenz/zenz_unix_socket_path.h"
 #include "zenz_scorer/posix_runtime.h"
@@ -34,6 +37,7 @@ std::string JoinPath(std::string_view directory, std::string_view name) {
 }
 
 std::string GetExecutablePath() {
+#if defined(__APPLE__)
   uint32_t size = PATH_MAX;
   std::vector<char> buffer(size, '\0');
   if (_NSGetExecutablePath(buffer.data(), &size) != 0) {
@@ -42,6 +46,23 @@ std::string GetExecutablePath() {
       return "";
     }
   }
+#elif defined(__linux__)
+  std::vector<char> buffer(PATH_MAX, '\0');
+  while (true) {
+    const ssize_t read_size =
+        ::readlink("/proc/self/exe", buffer.data(), buffer.size());
+    if (read_size <= 0) {
+      return "";
+    }
+    if (static_cast<size_t>(read_size) < buffer.size()) {
+      buffer[static_cast<size_t>(read_size)] = '\0';
+      break;
+    }
+    buffer.resize(buffer.size() * 2);
+  }
+#else
+  return "";
+#endif
 
   char resolved[PATH_MAX] = {};
   if (::realpath(buffer.data(), resolved) != nullptr) {


### PR DESCRIPTION
## 概要

mozkey本体のLinux対応の一部です。未対応部分の詳細は検討事項をご確認ください。

## 変更内容

- `_NSGetEnviron`と`_NSGetExecutablePath`を使用している箇所について、Linux版実装を追加
- `CreateMacZenzClient`を`CreateUnixZenzClient`に改名しlinuxでも使用するように変更

## 検討事項

- fcitx5対応のために https://github.com/fcitx/mozc のsrc/unix/fcitx5/を導入する必要があります。
- codexに調査させたところ、fcitx5とibusの両者ともに、zenzによる補正を使用するためには追加の変更が必要とのことでした。この点については、本当に必要かどうか含め調査しようと考えています。

## 検証

上記検討事項に対応したfcitx5版を別途ビルドし、NixOS 26.05上で動作することを確認しました。